### PR TITLE
Fit & Finish: Build sanitization & Static analysis warning fixes

### DIFF
--- a/client/TracySysTrace.cpp
+++ b/client/TracySysTrace.cpp
@@ -350,10 +350,10 @@ void SysTraceSendExternalName( uint64_t thread )
                             {
                                 if( (uint64_t)ptr >= (uint64_t)info.lpBaseOfDll && (uint64_t)ptr <= (uint64_t)info.lpBaseOfDll + (uint64_t)info.SizeOfImage )
                                 {
-                                    char buf[1024];
-                                    if( _GetModuleBaseNameA( phnd, modules[i], buf, 1024 ) != 0 )
+                                    char buf2[1024];
+                                    if( _GetModuleBaseNameA( phnd, modules[i], buf2, 1024 ) != 0 )
                                     {
-                                        GetProfiler().SendString( thread, buf, QueueType::ExternalThreadName );
+                                        GetProfiler().SendString( thread, buf2, QueueType::ExternalThreadName );
                                         threadSent = true;
                                     }
                                 }
@@ -389,13 +389,13 @@ void SysTraceSendExternalName( uint64_t thread )
                 const auto phnd = OpenProcess( PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid );
                 if( phnd != INVALID_HANDLE_VALUE )
                 {
-                    char buf[1024];
-                    const auto sz = GetProcessImageFileNameA( phnd, buf, 1024 );
+                    char buf2[1024];
+                    const auto sz = GetProcessImageFileNameA( phnd, buf2, 1024 );
                     CloseHandle( phnd );
                     if( sz != 0 )
                     {
-                        auto ptr = buf + sz - 1;
-                        while( ptr > buf && *ptr != '\\' ) ptr--;
+                        auto ptr = buf2 + sz - 1;
+                        while( ptr > buf2 && *ptr != '\\' ) ptr--;
                         if( *ptr == '\\' ) ptr++;
                         GetProfiler().SendString( thread, ptr, QueueType::ExternalName );
                         return;

--- a/client/tracy_rpmalloc.cpp
+++ b/client/tracy_rpmalloc.cpp
@@ -110,13 +110,17 @@
 #define _Static_assert static_assert
 
 /// Platform and arch specifics
-#if defined(_MSC_VER) && !defined(__clang__)
-#  define FORCEINLINE inline __forceinline
-#else
-#  define FORCEINLINE inline __attribute__((__always_inline__))
+#ifndef FORCEINLINE
+#  if defined(_MSC_VER) && !defined(__clang__)
+#    define FORCEINLINE inline __forceinline
+#  else
+#    define FORCEINLINE inline __attribute__((__always_inline__))
+#  endif
 #endif
 #if PLATFORM_WINDOWS
-#  define WIN32_LEAN_AND_MEAN
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
 #  include <windows.h>
 #  if ENABLE_VALIDATE_ARGS
 #    include <Intsafe.h>

--- a/vcpkg/install_vcpkg_dependencies.bat
+++ b/vcpkg/install_vcpkg_dependencies.bat
@@ -4,7 +4,7 @@ REM get vcpkg distribution
 if not exist vcpkg git clone https://github.com/Microsoft/vcpkg.git
 
 REM build vcpkg
-if not exist vcpkg\vcpkg.exe call vcpkg\bootstrap-vcpkg.bat
+if not exist vcpkg\vcpkg.exe call vcpkg\bootstrap-vcpkg.bat -disableMetrics
 
 REM install required packages
 vcpkg\vcpkg.exe install --triplet x64-windows-static freetype glfw3 capstone[arm,arm64,x86]


### PR DESCRIPTION
- Wrapping `FORCEINLINE `& `WIN32_LEAN_AND_MEAN` definess with ifndef bc other libraries may define it and trigger redefinition warning
- Possibly contentious given tone in the manual (:P) but removing variable shadowing in TracySysTrace.cpp
  - **Alternate Solution:** Add `#define TRACY_FORCE_SILENT_WARNINGS` toggle-able flag. If flag is enabled, push/pop warning disables that have to be included in client code
- Add `-disableMetrics` to vcpkg script

P.S. I couldn't find a contributor readme/wiki page/template/style guides etc. Happy to reformulate if there is one