### PR TITLE
ImGui Multiviewport fixes

### DIFF
--- a/profiler/src/main.cpp
+++ b/profiler/src/main.cpp
@@ -281,6 +281,9 @@ int main( int argc, char** argv )
     std::string iniFileName = tracy::GetSavePath( "imgui.ini" );
     io.IniFilename = iniFileName.c_str();
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_DockingEnable;
+    io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;  // Enable Multi-Viewport / Platform Windows
+    //io.ConfigWindowsMoveFromTitleBarOnly = true;
+    //io.ConfigDockingWithShift = false;
 
     ImGui_ImplGlfw_InitForOpenGL( window, true );
     ImGui_ImplOpenGL3_Init( "#version 150" );
@@ -908,12 +911,21 @@ static void DrawContents()
 
     // Rendering
     ImGui::Render();
-    glfwMakeContextCurrent(s_glfwWindow);
     glViewport(0, 0, display_w, display_h);
     glClearColor(clear_color.x, clear_color.y, clear_color.z, clear_color.w);
     glClear(GL_COLOR_BUFFER_BIT);
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
-    glfwMakeContextCurrent(s_glfwWindow);
+    // Update and Render additional Platform Windows
+    // (Platform functions may change the current OpenGL context, so we save/restore it to make it easier to paste this code elsewhere.
+    //  For this specific demo app we could also call glfwMakeContextCurrent(window) directly)
+    if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+    {
+        GLFWwindow* backup_current_context = glfwGetCurrentContext();
+        ImGui::UpdatePlatformWindows();
+        ImGui::RenderPlatformWindowsDefault();
+        glfwMakeContextCurrent(backup_current_context);
+    }
+
     glfwSwapBuffers(s_glfwWindow);
 }

--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -489,8 +489,10 @@ bool View::DrawImpl()
         style.WindowPadding = ImVec2( 4.f, 4.f );
         style.Colors[ImGuiCol_WindowBg] = ImVec4( 0.129f, 0.137f, 0.11f, 1.f );
 
-        ImGui::SetNextWindowPos( ImVec2( 0, 0 ) );
+        ImGuiViewport* viewport = ImGui::GetMainViewport();
+        ImGui::SetNextWindowPos(viewport->Pos);
         ImGui::SetNextWindowSize( ImVec2( m_rootWidth, m_rootHeight ) );
+        ImGui::SetNextWindowViewport(viewport->ID);
         ImGui::Begin( "Timeline view###Profiler", nullptr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoDocking );
 
         style.WindowRounding = wrPrev;


### PR DESCRIPTION
- set ImGuiConfigFlags_ViewportsEnable
- correct render loop logic with viewport api calls, `SetNextWindowViewport(), UpdatePlatformWindows(), RenderPlatformWindowsDefault()`
- Fix: coords in abs space now, `SetNextWindowPos()`

NOTE:
- I have viewports turned on by default so you can easy test (comment out `io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable`; and you get old behavior)
- Jankiness with multiviewports isn't bc perf hit; it's bc profiler reduces it's tick rate when it's not in focus. So, that bit of logic needs to be updated if you really care
- I haven't encountered any issues over past week but discount that by 50% since i'm new to tracy. No promises some UI wasn't regresssed
- Key things to watch out for is enabling viewports turns ImGui into using absolute monitor coords instead of window coords (ie SetPosition(0,0) => monitor top left, not window top/left