### PR TITLE
Misc fixes

### DIFF
--- a/client/TracyCallstack.cpp
+++ b/client/TracyCallstack.cpp
@@ -133,7 +133,7 @@ void InitCallstack()
 #endif
 }
 
-TRACY_API tracy_force_inline uintptr_t* CallTrace( int depth )
+TRACY_API uintptr_t* CallTrace( int depth )
 {
     auto trace = (uintptr_t*)tracy_malloc( ( 1 + depth ) * sizeof( uintptr_t ) );
     const auto num = RtlWalkFrameChain( (void**)( trace + 1 ), depth, 0 );

--- a/common/TracyApi.h
+++ b/common/TracyApi.h
@@ -2,10 +2,12 @@
 #define __TRACYAPI_H__
 
 #if defined _WIN32 || defined __CYGWIN__
-#  if defined TRACY_IMPORTS
+#  if defined TRACY_EXPORTS
+#    define TRACY_API __declspec(dllexport)
+#  elif defined TRACY_IMPORTS
 #    define TRACY_API __declspec(dllimport)
 #  else
-#    define TRACY_API __declspec(dllexport)
+#    define TRACY_API
 #  endif
 #else
 #  define TRACY_API __attribute__((visibility("default")))

--- a/library/win32/TracyProfiler.vcxproj
+++ b/library/win32/TracyProfiler.vcxproj
@@ -124,7 +124,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;TRACYPROFILER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;TRACY_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -139,7 +139,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;TRACYPROFILER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;TRACY_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -156,7 +156,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;TRACYPROFILER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;TRACY_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -175,7 +175,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;TRACYPROFILER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;TRACY_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -194,7 +194,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>TRACY_ENABLE;NDEBUG;TRACYPROFILER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TRACY_ENABLE;NDEBUG;TRACY_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
@@ -212,7 +212,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>TRACY_ON_DEMAND;TRACY_ENABLE;NDEBUG;TRACYPROFILER_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>TRACY_ON_DEMAND;TRACY_ENABLE;NDEBUG;TRACY_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -382,7 +382,7 @@ In projects that consist of multiple DLLs/shared objects things are a bit differ
 
 For that you need a \emph{profiler DLL} to which your executable and the other DLLs link. If that doesn't exist you have to create one explicitly for Tracy\footnote{You may also look at the \texttt{library} directory in the profiler source tree.}. This library should contain the \texttt{tracy/TracyClient.cpp} source file. Link the executable and all DLLs which you want to profile to this DLL.
 
-If you are targeting Windows with Microsoft Visual Studio, add the \texttt{TRACY\_IMPORTS} define to your application. While this is an optional step, it enables more efficient code.
+If you are targeting Windows with Microsoft Visual Studio or MinGW, add the \texttt{TRACY\_IMPORTS} define to your application.
 
 \subsubsection{Problematic platforms}
 

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -11,6 +11,10 @@
 #include <cctype>
 #include <chrono>
 #include <string.h>
+
+#ifdef __MINGW32__
+#  define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>
 
 #include <capstone/capstone.h>


### PR DESCRIPTION
Some of stuff has accumulated in my fork. I hope it is OK to put it all into single PR, because majority of changes are so tiny. Spamming 4 PRs felt wrong somehow. If there are unacceptable changes - i will remove them and force-push.

Most important change is to how `TRACY_API` is declared. While it wasnt obviously broken - using `dllexport` for static libs was not correct. We can actually dllexport API from a static library by marking API as `dllexport` in that lib. This was not intended however. Now static builds use empty `TRACY_API` define. I also fixed header to use `TRACYPROFILER_EXPORTS` that vcxproj are already defining. And now users must define `TRACYPROFILER_IMPORTS` if they consume tracy as a dll. Manual updated for that.

I bumped into `CallTrace` in this build: https://dev.azure.com/rbfx/rbfx/_build/results?buildId=1130&view=logs&j=a01c7fc3-6c29-531e-b3bc-0c716d965c9b&t=b76a1989-fa8b-5cbf-2cc5-71f36f527501
Removing `tracy_force_inline` solves the issue. It is not clear to me why it happened. I should point out that it does not happen due to `dllexport` in static builds, because i had this part solved in my project long ago.

And fixed MinGW build, our good old friend `__STDC_FORMAT_MACROS` was forgotten again.