### PR TITLE
Remove extra semicolons at the end of namespaces

### DIFF
--- a/client/TracyLock.hpp
+++ b/client/TracyLock.hpp
@@ -544,6 +544,6 @@ private:
 };
 
 
-};
+}
 
 #endif

--- a/client/TracyProfiler.hpp
+++ b/client/TracyProfiler.hpp
@@ -674,6 +674,6 @@ private:
     ParameterCallback m_paramCallback;
 };
 
-};
+}
 
 #endif

--- a/common/TracyQueue.hpp
+++ b/common/TracyQueue.hpp
@@ -551,6 +551,6 @@ static_assert( sizeof( QueueDataSize ) / sizeof( size_t ) == (uint8_t)QueueType:
 static_assert( sizeof( void* ) <= sizeof( uint64_t ), "Pointer size > 8 bytes" );
 static_assert( sizeof( void* ) == sizeof( uintptr_t ), "Pointer size != uintptr_t" );
 
-};
+}
 
 #endif


### PR DESCRIPTION
GCC with -pedantic will complain about it.