### PR TITLE
Make TracySourceView.cpp build with somewhat old clang

### DIFF
--- a/server/TracySourceView.cpp
+++ b/server/TracySourceView.cpp
@@ -1637,7 +1637,7 @@ uint64_t SourceView::RenderSymbolAsmView( uint32_t iptotal, unordered_flat_map<u
                 {
                     symName = worker.GetString( sym->name );
                 }
-                fprintf( f, "; Tracy Profiler disassembly of symbol %s [%s]\n\n", symName, worker.GetCaptureProgram() );
+                fprintf( f, "; Tracy Profiler disassembly of symbol %s [%s]\n\n", symName, worker.GetCaptureProgram().c_str() );
                 if( !m_atnt ) fprintf( f, ".intel_syntax\n\n" );
 
                 for( auto& v : m_asm )


### PR DESCRIPTION
This was the only issue preventing build on macOS High Sierra with whatever version of clang it has.