### PR TITLE
Fix crash when running Tracy from DLLs

### DIFF
--- a/client/tracy_rpmalloc.cpp
+++ b/client/tracy_rpmalloc.cpp
@@ -1468,6 +1468,7 @@ _memory_deallocate_large(span_t* span) {
 	//Investigate if it is better to defer large spans as well through span_cache_deferred,
 	//possibly with some heuristics to pick either scheme at runtime per deallocation
 	heap_t* heap = get_thread_heap();
+	if (!heap) return;
 #if ENABLE_ADAPTIVE_THREAD_CACHE || ENABLE_STATISTICS
 	size_t idx = span->span_count - 1;
 	atomic_decr32(&span->heap->span_use[idx].current);


### PR DESCRIPTION
Instantiating Tracy from within a DLL will tie its internal threads life-time to the DLL. Windows does not guarantee that threads will be alive after the main function. This has implications in the Profiler dtor since will try to perform some deallocations, however, _memory_deallocate_large will try to get the heap of the current thread which can be invalid at the point of shutdown causing a crash. Checking the pointer here will won't make TRACE_NO_EXIT work, but it will prevent the Profiler from crashing.