### PR TITLE
Add TRACY_ONLY_LOCALHOST macro to avoid listening on all interfaces.

### DIFF
--- a/common/TracySocket.cpp
+++ b/common/TracySocket.cpp
@@ -393,7 +393,9 @@ bool ListenSocket::Listen( int port, int backlog )
     memset( &hints, 0, sizeof( hints ) );
     hints.ai_family = AF_INET6;
     hints.ai_socktype = SOCK_STREAM;
+#ifndef TRACY_ONLY_LOCALHOST
     hints.ai_flags = AI_PASSIVE;
+#endif
 
     char portbuf[32];
     sprintf( portbuf, "%i", port );

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -406,6 +406,10 @@ The client with on-demand profiling enabled needs to perform additional bookkeep
 
 By default Tracy client will announce its presence to the local network\footnote{Additional configuration may be required to achieve full functionality, depending on your network layout. Read about UDP broadcasts for more information.}. If you want to disable this feature, define the \texttt{TRACY\_NO\_BROADCAST} macro.
 
+\subsubsection{Client network interface}
+
+By default Tracy client will listen on all network interfaces. If you want to restrict it to only listening on the localhost interface, define the \texttt{TRACY\_ONLY\_LOCALHOST} macro.
+
 \subsubsection{Setup for multi-DLL projects}
 
 In projects that consist of multiple DLLs/shared objects things are a bit different. Compiling \texttt{TracyClient.cpp} into every DLL is not an option because this would result in several instances of Tracy objects lying around in the process. We rather need to pass the instances of them to the different DLLs to be reused there.


### PR DESCRIPTION
Another minor change: this lets us build in a mode where the client will only listen on localhost, which operations policy can then control access to independently using typical methods like SSH or VPN tunneling.