### PR TITLE
Warning fixes

### DIFF
--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -173,6 +173,7 @@ struct ThreadHandleWrapper
 #if defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64
 static inline void CpuId( uint32_t* regs, uint32_t leaf )
 {
+    memset(regs, 0, sizeof(uint32_t) * 4);
 #if defined _WIN32 || defined __CYGWIN__
     __cpuidex( (int*)regs, leaf, 0 );
 #else

--- a/client/TracySysTime.cpp
+++ b/client/TracySysTime.cpp
@@ -47,9 +47,12 @@ void SysTime::ReadTimes()
     FILE* f = fopen( "/proc/stat", "r" );
     if( f )
     {
-        fscanf( f, "cpu %" PRIu64 " %" PRIu64 " %" PRIu64" %" PRIu64, &user, &nice, &system, &idle );
+        int read = fscanf( f, "cpu %" PRIu64 " %" PRIu64 " %" PRIu64" %" PRIu64, &user, &nice, &system, &idle );
         fclose( f );
-        used = user + nice + system;
+        if (read == 4)
+        {
+            used = user + nice + system;
+        }
     }
 }
 


### PR DESCRIPTION
Just a couple warning fixes -- a use-before-init warning on regs during cpuid and an ignored-result warning on fscanf in SysTime.