### PR TITLE
Capture Vulkan timestamps at BOTTOM_OF_PIPE instead of TOP_OF_PIPE

### DIFF
--- a/TracyVulkan.hpp
+++ b/TracyVulkan.hpp
@@ -210,7 +210,7 @@ public:
         m_ctx = ctx;
 
         const auto queryId = ctx->NextQueryId();
-        vkCmdWriteTimestamp( cmdbuf, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, ctx->m_query, queryId );
+        vkCmdWriteTimestamp( cmdbuf, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, ctx->m_query, queryId );
 
         auto item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
@@ -234,7 +234,7 @@ public:
         m_ctx = ctx;
 
         const auto queryId = ctx->NextQueryId();
-        vkCmdWriteTimestamp( cmdbuf, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, ctx->m_query, queryId );
+        vkCmdWriteTimestamp( cmdbuf, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, ctx->m_query, queryId );
 
         auto item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::GpuZoneBeginCallstackSerial );
@@ -253,7 +253,7 @@ public:
         if( !m_active ) return;
 
         const auto queryId = m_ctx->NextQueryId();
-        vkCmdWriteTimestamp( m_cmdbuf, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, m_ctx->m_query, queryId );
+        vkCmdWriteTimestamp( m_cmdbuf, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, m_ctx->m_query, queryId );
 
         auto item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::GpuZoneEndSerial );


### PR DESCRIPTION
This is so that the GPU will wait for all previous commands to finish (hit bottom of pipe) before taking the enter timestamp and then whatever was recorded within the scope to finish (hit bottom of pipe) before taking the leave timestamp. TOP_OF_PIPE (particularly at the scope exit) was just recording the time of when the recorded work within the VkCtxScope was starting (hit top of the pipe) and not waiting for it to complete.

Before:
![image](https://user-images.githubusercontent.com/75337/83926028-89810880-a73d-11ea-8a40-15dd44ddb9ea.png)

After:
![image](https://user-images.githubusercontent.com/75337/83926037-8e45bc80-a73d-11ea-9ae5-62802a29ecc7.png)
