### PR TITLE
 `___tracy_alloc_*` take pointer-size pairs

### DIFF
--- a/TracyC.h
+++ b/TracyC.h
@@ -82,8 +82,8 @@ struct ___tracy_c_zone_context
 typedef /*const*/ struct ___tracy_c_zone_context TracyCZoneCtx;
 
 TRACY_API void ___tracy_init_thread(void);
-TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, const char* function );
-TRACY_API uint64_t ___tracy_alloc_srcloc_name( uint32_t line, const char* source, const char* function, const char* name, size_t nameSz );
+TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz );
+TRACY_API uint64_t ___tracy_alloc_srcloc_name( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz );
 
 TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int active );
 TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int depth, int active );

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -3065,8 +3065,14 @@ TRACY_API void ___tracy_emit_messageL( const char* txt, int callstack ) { tracy:
 TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int callstack ) { tracy::Profiler::MessageColor( txt, size, color, callstack ); }
 TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int callstack ) { tracy::Profiler::MessageColor( txt, color, callstack ); }
 TRACY_API void ___tracy_emit_message_appinfo( const char* txt, size_t size ) { tracy::Profiler::MessageAppInfo( txt, size ); }
-TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, const char* function ) { return tracy::Profiler::AllocSourceLocation( line, source, function ); }
-TRACY_API uint64_t ___tracy_alloc_srcloc_name( uint32_t line, const char* source, const char* function, const char* name, size_t nameSz ) { return tracy::Profiler::AllocSourceLocation( line, source, function, name, nameSz ); }
+
+TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz ) {
+    return tracy::Profiler::AllocSourceLocation( line, source, sourceSz, function, functionSz );
+}
+
+TRACY_API uint64_t ___tracy_alloc_srcloc_name( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz ) {
+    return tracy::Profiler::AllocSourceLocation( line, source, sourceSz, function, functionSz, name, nameSz );
+}
 
 // thread_locals are not initialized on thread creation. At least on GNU/Linux. Instead they are
 // initialized on their first ODR-use. This means that the allocator is not automagically

--- a/client/TracyProfiler.hpp
+++ b/client/TracyProfiler.hpp
@@ -483,30 +483,34 @@ public:
 
     static tracy_force_inline uint64_t AllocSourceLocation( uint32_t line, const char* source, const char* function )
     {
-        const auto fsz = strlen( function );
-        const auto ssz = strlen( source );
-        const uint32_t sz = uint32_t( 4 + 4 + 4 + fsz + 1 + ssz + 1 );
-        auto ptr = (char*)tracy_malloc( sz );
-        memcpy( ptr, &sz, 4 );
-        memset( ptr + 4, 0, 4 );
-        memcpy( ptr + 8, &line, 4 );
-        memcpy( ptr + 12, function, fsz+1 );
-        memcpy( ptr + 12 + fsz + 1, source, ssz + 1 );
-        return uint64_t( ptr );
+        return AllocSourceLocation( line, source, function, nullptr, 0 );
     }
 
     static tracy_force_inline uint64_t AllocSourceLocation( uint32_t line, const char* source, const char* function, const char* name, size_t nameSz )
     {
-        const auto fsz = strlen( function );
-        const auto ssz = strlen( source );
-        const uint32_t sz = uint32_t( 4 + 4 + 4 + fsz + 1 + ssz + 1 + nameSz );
+        return AllocSourceLocation( line, source, strlen(source), function, strlen(function), name, nameSz );
+    }
+
+    static tracy_force_inline uint64_t AllocSourceLocation( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz )
+    {
+        return AllocSourceLocation( line, source, sourceSz, function, functionSz, nullptr, 0 );
+    }
+
+    static tracy_force_inline uint64_t AllocSourceLocation( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz )
+    {
+        const uint32_t sz = uint32_t( 4 + 4 + 4 + functionSz + 1 + sourceSz + 1 + nameSz );
         auto ptr = (char*)tracy_malloc( sz );
         memcpy( ptr, &sz, 4 );
         memset( ptr + 4, 0, 4 );
         memcpy( ptr + 8, &line, 4 );
-        memcpy( ptr + 12, function, fsz+1 );
-        memcpy( ptr + 12 + fsz + 1, source, ssz + 1 );
-        memcpy( ptr + 12 + fsz + 1 + ssz + 1, name, nameSz );
+        memcpy( ptr + 12, function, functionSz );
+        ptr[12 + functionSz] = '\0';
+        memcpy( ptr + 12 + functionSz + 1, source, sourceSz );
+        ptr[12 + functionSz + 1 + sourceSz] = '\0';
+        if( nameSz != 0 )
+        {
+            memcpy( ptr + 12 + functionSz + 1 + sourceSz + 1, name, nameSz );
+        }
         return uint64_t( ptr );
     }
 

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -1504,14 +1504,14 @@ these functions.
 
 \begin{itemize}
 \item \texttt{\_\_\_tracy\_init\_thread(void)}
-\item \texttt{\_\_\_tracy\_alloc\_srcloc(uint32\_t line, const char* source, const char* function)}
-\item \texttt{\_\_\_tracy\_alloc\_srcloc\_name(uint32\_t line, const char* source, const char* function, const char* name, size\_t nameSz)}
+\item \texttt{\_\_\_tracy\_alloc\_srcloc(uint32\_t line, const char* source, size\_t sourceSz, const char* function, size\_t functionSz)}
+\item \texttt{\_\_\_tracy\_alloc\_srcloc\_name(uint32\_t line, const char* source, size\_t sourceSz, const char* function, size\_t functionSz, const char* name, size\_t nameSz)}
 \end{itemize}
 
 Here \texttt{line} is line number in the \texttt{source} source file and \texttt{function} is the
-name of a function in which the zone is created. Both \texttt{source} and \texttt{function} must be
-null-terminated strings. You may additionally specify an optional zone name, by providing it in the
-\texttt{name} variable, and specifying its size in \texttt{nameSz}.
+name of a function in which the zone is created. \texttt{sourceSz} and \texttt{functionSz} are the
+size of the corresponding string arguments in bytes. You may additionally specify an optional zone
+name, by providing it in the \texttt{name} variable, and specifying its size in \texttt{nameSz}.
 
 The \texttt{\_\_\_tracy\_alloc\_srcloc} and \texttt{\_\_\_tracy\_alloc\_srcloc\_name} functions
 return an \texttt{uint64\_t} source location identifier corresponding to an \emph{allocated source


### PR DESCRIPTION
This enables better bindings in languages that do not have 0-terminated
strings for source/function name. It does not introduce any additional
overhead in languages that do use 0-terminated strings, either, but it
_is_ a breaking API change.

Fixes #53

Note: this is based on top #52 as this PR builds on top of the manual changes made there. will rebase once/if that is merged.