### PR TITLE
Import chrome metrics

### DIFF
--- a/import-chrome/src/import-chrome.cpp
+++ b/import-chrome/src/import-chrome.cpp
@@ -171,11 +171,16 @@ int main( int argc, char** argv )
     {
         if( mts > messages[0].timestamp ) mts = messages[0].timestamp;
     }
+    for( auto& plot : plots )
+    {
+        if( mts > plot.data[0].first ) mts = plot.data[0].first;
+    }
     for( auto& v : timeline ) v.timestamp -= mts;
     for( auto& v : messages ) v.timestamp -= mts;
     for( auto& plot : plots )
-      for( auto& v : plot.data )
-        v.first -= mts;
+    {
+      for( auto& v : plot.data ) v.first -= mts;
+    }
 
     printf( "\33[2KProcessing...\r" );
     fflush( stdout );

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -400,8 +400,8 @@ Worker::Worker( const std::string& program, const std::vector<ImportEventTimelin
         plot->type = PlotType::User;
         plot->format = v.format;
 
-        double min = v.data.begin()->first;
-        double max = v.data.begin()->first;
+        double min = v.data.begin()->second;
+        double max = v.data.begin()->second;
         plot->data.reserve_exact( v.data.size(), m_slab );
         size_t idx = 0;
         for( auto& p : v.data )


### PR DESCRIPTION
Fixes https://github.com/wolfpld/tracy/issues/54

So I can see that data is imported but is not visible in a chart. I think I need to somehow convert timestamps for plot data, because ultimately these are stored in `PlotItem.time` which is `Int48`. Are those nanoseconds from the beginning of the file? Nanoseconds since Epoch don't fit.

The metric values, at least the min and max of those are displayed correctly in the tooltip.

![Screen Shot 2020-06-21 at 11 33 38 AM](https://user-images.githubusercontent.com/222467/85222694-9a787d80-b3bd-11ea-83c9-1844597d8d51.png)
