### PR TITLE
Check for null FILE handles in ReportTopology

### DIFF
--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -2692,12 +2692,15 @@ void Profiler::ReportTopology()
         sprintf( path, "%s%i/topology/physical_package_id", basePath, i );
         char buf[1024];
         FILE* f = fopen( path, "rb" );
+        if( f == nullptr ) {
+            tracy_free(cpuData);
+            return;
+        }
         auto read = fread( buf, 1, 1024, f );
         buf[read] = '\0';
         fclose( f );
         cpuData[i].package = uint32_t( atoi( buf ) );
         cpuData[i].thread = i;
-
         sprintf( path, "%s%i/topology/core_id", basePath, i );
         f = fopen( path, "rb" );
         read = fread( buf, 1, 1024, f );


### PR DESCRIPTION
On Linux `/sys` is not guaranteed to exist. When it doesn't, tracy
would crash with a SIGSEGV due to a nullptr dereference. Not actually
sure how well tracy clients will handle the case where this information
is missing, though...