### PR TITLE
Added continuous scrolling.

### DIFF
--- a/server/TracyView.hpp
+++ b/server/TracyView.hpp
@@ -155,6 +155,7 @@ private:
     int DrawCpuData( int offset, double pxns, const ImVec2& wpos, bool hover, float yMin, float yMax );
     void DrawOptions();
     void DrawMessages();
+    void ContinuousScrolling();
     void DrawFindZone();
     void DrawStatistics();
     void DrawMemory();
@@ -347,6 +348,8 @@ private:
     bool m_showMessages = false;
     bool m_showStatistics = false;
     bool m_showInfo = false;
+    bool m_continuousScrolling = true;
+    bool m_continuousScrollingFirstFrame = true;
     bool m_showPlayback = false;
     bool m_showCpuDataWindow = false;
     bool m_showAnnotationList = false;


### PR DESCRIPTION
Added a feature I thought would be useful which is to be able to continuously scroll the view automatically so you always see the latest events. As soon as the user starts interacting with the view, the continuous scroll turns off and can be toggled on again by pressing the button. You can check out the vid below to see what I mean more clearly. 
https://drive.google.com/file/d/1UFwSTbA4FCKE18jUKeUnoj0WWvx9LByJ/view?usp=sharing