### PR TITLE
Factor out Unix build logic into shared files.

### DIFF
--- a/capture/build/unix/build.mk
+++ b/capture/build/unix/build.mk
@@ -1,5 +1,3 @@
-include ../../../common/unix.mk
-
 CFLAGS +=
 CXXFLAGS := $(CFLAGS) -std=gnu++17
 DEFINES += -DTRACY_NO_STATISTICS
@@ -9,49 +7,6 @@ PROJECT := capture
 IMAGE := $(PROJECT)-$(BUILD)
 
 FILTER :=
+include ../../../common/src-from-vcxproj.mk
 
-BASE := $(shell egrep 'ClCompile.*cpp"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
-BASE2 := $(shell egrep 'ClCompile.*c"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
-
-SRC := $(filter-out $(FILTER),$(BASE))
-SRC2 := $(filter-out $(FILTER),$(BASE2))
-
-OBJDIRBASE := obj/$(BUILD)
-OBJDIR := $(OBJDIRBASE)/o/o/o
-
-OBJ := $(addprefix $(OBJDIR)/,$(SRC:%.cpp=%.o))
-OBJ2 := $(addprefix $(OBJDIR)/,$(SRC2:%.c=%.o))
-
-all: $(IMAGE)
-
-$(OBJDIR)/%.o: %.cpp
-	$(CXX) -c $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.cpp
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CXX) -MM $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.cpp=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(OBJDIR)/%.o: %.c
-	$(CC) -c $(INCLUDES) $(CFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.c
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CC) -MM $(INCLUDES) $(CFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.c=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(IMAGE): $(OBJ) $(OBJ2)
-	$(CXX) $(CXXFLAGS) $(DEFINES) $(OBJ) $(OBJ2) $(LIBS) -o $@
-
-ifneq "$(MAKECMDGOALS)" "clean"
--include $(addprefix $(OBJDIR)/,$(SRC:.cpp=.d)) $(addprefix $(OBJDIR)/,$(SRC2:.c=.d))
-endif
-
-clean:
-	rm -rf $(OBJDIRBASE) $(IMAGE)*
-
-.PHONY: clean all
+include ../../../common/unix.mk

--- a/common/src-from-vcxproj.mk
+++ b/common/src-from-vcxproj.mk
@@ -1,0 +1,18 @@
+# Extract the actual list of source files from a sibling Visual Studio project.
+
+# Ensure these are simply-substituted variables, without changing their values.
+SRC := $(SRC)
+SRC2 := $(SRC2)
+SRC3 := $(SRC3)
+
+# Paths here are relative to the directory in which make was invoked, not to
+# this file, so ../win32/$(PROJECT).vcxproj refers to the Visual Studio project
+# of whichever tool is including this makefile fragment.
+
+BASE := $(shell egrep 'ClCompile.*cpp"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
+BASE2 := $(shell egrep 'ClCompile.*c"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
+
+# The tool-specific makefile may request that certain files be omitted.
+SRC += $(filter-out $(FILTER),$(BASE))
+SRC2 += $(filter-out $(FILTER),$(BASE2))
+SRC3 += $(filter-out $(FILTER),$(BASE3))

--- a/common/unix.mk
+++ b/common/unix.mk
@@ -1,6 +1,6 @@
 # Common code needed by most Tracy Unix Makefiles.
 
-# Ensure LIBS is a simply-substituted variable, without changing its value.
+# Ensure these are simply-substituted variables, without changing their values.
 LIBS := $(LIBS)
 
 # Tracy does not use TBB directly, but the implementation of parallel algorithms
@@ -14,3 +14,58 @@ else ifeq (0,$(shell ld -ltbb -o /dev/null 2>/dev/null; echo $$?))
 	LIBS += -ltbb
 endif
 
+OBJDIRBASE := obj/$(BUILD)
+OBJDIR := $(OBJDIRBASE)/o/o/o
+
+OBJ := $(addprefix $(OBJDIR)/,$(SRC:%.cpp=%.o))
+OBJ2 := $(addprefix $(OBJDIR)/,$(SRC2:%.c=%.o))
+OBJ3 := $(addprefix $(OBJDIR)/,$(SRC3:%.m=%.o))
+
+all: $(IMAGE)
+
+$(OBJDIR)/%.o: %.cpp
+	$(CXX) -c $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< -o $@
+
+$(OBJDIR)/%.d : %.cpp
+	@echo Resolving dependencies of $<
+	@mkdir -p $(@D)
+	@$(CXX) -MM $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< > $@.$$$$; \
+	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.cpp=.o) $@ : ,g' < $@.$$$$ > $@; \
+	rm -f $@.$$$$
+
+$(OBJDIR)/%.o: %.c
+	$(CC) -c $(INCLUDES) $(CFLAGS) $(DEFINES) $< -o $@
+
+$(OBJDIR)/%.d : %.c
+	@echo Resolving dependencies of $<
+	@mkdir -p $(@D)
+	@$(CC) -MM $(INCLUDES) $(CFLAGS) $(DEFINES) $< > $@.$$$$; \
+	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.c=.o) $@ : ,g' < $@.$$$$ > $@; \
+	rm -f $@.$$$$
+
+$(OBJDIR)/%.o: %.m
+	$(CC) -c $(INCLUDES) $(CFLAGS) $(DEFINES) $< -o $@
+
+$(OBJDIR)/%.d : %.m
+	@echo Resolving dependencies of $<
+	@mkdir -p $(@D)
+	@$(CC) -MM $(INCLUDES) $(CFLAGS) $(DEFINES) $< > $@.$$$$; \
+	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.m=.o) $@ : ,g' < $@.$$$$ > $@; \
+	rm -f $@.$$$$
+
+ifeq (yes,$(SHARED_LIBRARY))
+$(IMAGE): $(OBJ) $(OBJ2)
+	$(CXX) $(CXXFLAGS) $(DEFINES) $(OBJ) $(OBJ2) $(LIBS) -shared -o $@
+else
+$(IMAGE): $(OBJ) $(OBJ2) $(OBJ3)
+	$(CXX) $(CXXFLAGS) $(DEFINES) $(OBJ) $(OBJ2) $(OBJ3) $(LIBS) -o $@
+endif
+
+ifneq "$(MAKECMDGOALS)" "clean"
+-include $(addprefix $(OBJDIR)/,$(SRC:.cpp=.d)) $(addprefix $(OBJDIR)/,$(SRC2:.c=.d)) $(addprefix $(OBJDIR)/,$(SRC3:.m=.d))
+endif
+
+clean:
+	rm -rf $(OBJDIRBASE) $(IMAGE)*
+
+.PHONY: clean all

--- a/csvexport/build/unix/build.mk
+++ b/csvexport/build/unix/build.mk
@@ -1,57 +1,12 @@
-include ../../../common/unix.mk
-
 CFLAGS +=
 CXXFLAGS := $(CFLAGS) -std=gnu++17
 # DEFINES += -DTRACY_NO_STATISTICS
 INCLUDES := $(shell pkg-config --cflags capstone)
-LIBS += $(shell pkg-config --libs capstone) -lpthread
+LIBS := $(shell pkg-config --libs capstone) -lpthread
 PROJECT := csvexport
 IMAGE := $(PROJECT)-$(BUILD)
 
 FILTER :=
+include ../../../common/src-from-vcxproj.mk
 
-BASE := $(shell egrep 'ClCompile.*cpp"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
-BASE2 := $(shell egrep 'ClCompile.*c"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
-
-SRC := $(filter-out $(FILTER),$(BASE))
-SRC2 := $(filter-out $(FILTER),$(BASE2))
-
-OBJDIRBASE := obj/$(BUILD)
-OBJDIR := $(OBJDIRBASE)/o/o/o
-
-OBJ := $(addprefix $(OBJDIR)/,$(SRC:%.cpp=%.o))
-OBJ2 := $(addprefix $(OBJDIR)/,$(SRC2:%.c=%.o))
-
-all: $(IMAGE)
-
-$(OBJDIR)/%.o: %.cpp
-	$(CXX) -c $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.cpp
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CXX) -MM $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.cpp=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(OBJDIR)/%.o: %.c
-	$(CC) -c $(INCLUDES) $(CFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.c
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CC) -MM $(INCLUDES) $(CFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.c=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(IMAGE): $(OBJ) $(OBJ2)
-	$(CXX) $(CXXFLAGS) $(DEFINES) $(OBJ) $(OBJ2) $(LIBS) -o $@
-
-ifneq "$(MAKECMDGOALS)" "clean"
--include $(addprefix $(OBJDIR)/,$(SRC:.cpp=.d)) $(addprefix $(OBJDIR)/,$(SRC2:.c=.d))
-endif
-
-clean:
-	rm -rf $(OBJDIRBASE) $(IMAGE)*
-
-.PHONY: clean all
+include ../../../common/unix.mk

--- a/import-chrome/build/unix/build.mk
+++ b/import-chrome/build/unix/build.mk
@@ -1,5 +1,3 @@
-include ../../../common/unix.mk
-
 CFLAGS +=
 CXXFLAGS := $(CFLAGS) -std=gnu++17
 DEFINES += -DTRACY_NO_STATISTICS
@@ -9,49 +7,6 @@ PROJECT := import-chrome
 IMAGE := $(PROJECT)-$(BUILD)
 
 FILTER :=
+include ../../../common/src-from-vcxproj.mk
 
-BASE := $(shell egrep 'ClCompile.*cpp"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
-BASE2 := $(shell egrep 'ClCompile.*c"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
-
-SRC := $(filter-out $(FILTER),$(BASE))
-SRC2 := $(filter-out $(FILTER),$(BASE2))
-
-OBJDIRBASE := obj/$(BUILD)
-OBJDIR := $(OBJDIRBASE)/o/o/o
-
-OBJ := $(addprefix $(OBJDIR)/,$(SRC:%.cpp=%.o))
-OBJ2 := $(addprefix $(OBJDIR)/,$(SRC2:%.c=%.o))
-
-all: $(IMAGE)
-
-$(OBJDIR)/%.o: %.cpp
-	$(CXX) -c $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.cpp
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CXX) -MM $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.cpp=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(OBJDIR)/%.o: %.c
-	$(CC) -c $(INCLUDES) $(CFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.c
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CC) -MM $(INCLUDES) $(CFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.c=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(IMAGE): $(OBJ) $(OBJ2)
-	$(CXX) $(CXXFLAGS) $(DEFINES) $(OBJ) $(OBJ2) $(LIBS) -o $@
-
-ifneq "$(MAKECMDGOALS)" "clean"
--include $(addprefix $(OBJDIR)/,$(SRC:.cpp=.d)) $(addprefix $(OBJDIR)/,$(SRC2:.c=.d))
-endif
-
-clean:
-	rm -rf $(OBJDIRBASE) $(IMAGE)*
-
-.PHONY: clean all
+include ../../../common/unix.mk

--- a/library/unix/build.mk
+++ b/library/unix/build.mk
@@ -5,44 +5,8 @@ INCLUDES :=
 LIBS := -lpthread -ldl
 PROJECT := libtracy
 IMAGE := $(PROJECT)-$(BUILD).so
+SHARED_LIBRARY := yes
 
 SRC := ../../TracyClient.cpp
 
-OBJDIRBASE := obj/$(BUILD)
-OBJDIR := $(OBJDIRBASE)/o/o/o
-
-OBJ := $(addprefix $(OBJDIR)/,$(SRC:%.cpp=%.o))
-
-all: $(IMAGE)
-
-$(OBJDIR)/%.o: %.cpp
-	$(CXX) -c $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.cpp
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CXX) -MM $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.cpp=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(OBJDIR)/%.o: %.c
-	$(CC) -c $(INCLUDES) $(CFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.c
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CC) -MM $(INCLUDES) $(CFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.c=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(IMAGE): $(OBJ)
-	$(CXX) $(CXXFLAGS) $(DEFINES) $(OBJ) $(LIBS) -shared -o $@
-
-ifneq "$(MAKECMDGOALS)" "clean"
--include $(addprefix $(OBJDIR)/,$(SRC:.cpp=.d))
-endif
-
-clean:
-	rm -rf $(OBJDIRBASE) $(PROJECT)*.so
-
-.PHONY: clean all
+include ../../common/unix.mk

--- a/profiler/build/unix/build.mk
+++ b/profiler/build/unix/build.mk
@@ -1,21 +1,13 @@
-include ../../../common/unix.mk
-
 CFLAGS +=
 CXXFLAGS := $(CFLAGS) -std=c++17
 DEFINES += -DIMGUI_IMPL_OPENGL_LOADER_GL3W
 INCLUDES := $(shell pkg-config --cflags glfw3 freetype2 capstone) -I../../../imgui -I../../libs/gl3w
-LIBS += $(shell pkg-config --libs glfw3 freetype2 capstone) -lpthread -ldl
+LIBS := $(shell pkg-config --libs glfw3 freetype2 capstone) -lpthread -ldl
 PROJECT := Tracy
 IMAGE := $(PROJECT)-$(BUILD)
 
 FILTER := ../../../nfd/nfd_win.cpp
-
-BASE := $(shell egrep 'ClCompile.*cpp"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
-BASE2 := $(shell egrep 'ClCompile.*c"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
-
-SRC := $(filter-out $(FILTER),$(BASE))
-SRC2 := $(filter-out $(FILTER),$(BASE2))
-SRC3 :=
+include ../../../common/src-from-vcxproj.mk
 
 UNAME := $(shell uname -s)
 ifeq ($(UNAME),Darwin)
@@ -27,53 +19,4 @@ else
 	LIBS += $(shell pkg-config --libs gtk+-2.0) -lGL
 endif
 
-OBJDIRBASE := obj/$(BUILD)
-OBJDIR := $(OBJDIRBASE)/o/o/o
-
-OBJ := $(addprefix $(OBJDIR)/,$(SRC:%.cpp=%.o))
-OBJ2 := $(addprefix $(OBJDIR)/,$(SRC2:%.c=%.o))
-OBJ3 := $(addprefix $(OBJDIR)/,$(SRC3:%.m=%.o))
-
-all: $(IMAGE)
-
-$(OBJDIR)/%.o: %.cpp
-	$(CXX) -c $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.cpp
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CXX) -MM $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.cpp=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(OBJDIR)/%.o: %.c
-	$(CC) -c $(INCLUDES) $(CFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.c
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CC) -MM $(INCLUDES) $(CFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.c=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(OBJDIR)/%.o: %.m
-	$(CC) -c $(INCLUDES) $(CFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.m
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CC) -MM $(INCLUDES) $(CFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.m=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(IMAGE): $(OBJ) $(OBJ2) $(OBJ3)
-	$(CXX) $(CXXFLAGS) $(DEFINES) $(OBJ) $(OBJ2) $(OBJ3) $(LIBS) -o $@
-
-ifneq "$(MAKECMDGOALS)" "clean"
--include $(addprefix $(OBJDIR)/,$(SRC:.cpp=.d)) $(addprefix $(OBJDIR)/,$(SRC2:.c=.d)) $(addprefix $(OBJDIR)/,$(SRC3:.m=.d))
-endif
-
-clean:
-	rm -rf $(OBJDIRBASE) $(IMAGE)*
-
-.PHONY: clean all
+include ../../../common/unix.mk

--- a/update/build/unix/build.mk
+++ b/update/build/unix/build.mk
@@ -1,57 +1,12 @@
-include ../../../common/unix.mk
-
 CFLAGS +=
 CXXFLAGS := $(CFLAGS) -std=gnu++17
 DEFINES += -DTRACY_NO_STATISTICS
 INCLUDES := $(shell pkg-config --cflags capstone)
-LIBS += $(shell pkg-config --libs capstone) -lpthread
+LIBS := $(shell pkg-config --libs capstone) -lpthread
 PROJECT := update
 IMAGE := $(PROJECT)-$(BUILD)
 
 FILTER :=
+include ../../../common/src-from-vcxproj.mk
 
-BASE := $(shell egrep 'ClCompile.*cpp"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
-BASE2 := $(shell egrep 'ClCompile.*c"' ../win32/$(PROJECT).vcxproj | sed -e 's/.*\"\(.*\)\".*/\1/' | sed -e 's@\\@/@g')
-
-SRC := $(filter-out $(FILTER),$(BASE))
-SRC2 := $(filter-out $(FILTER),$(BASE2))
-
-OBJDIRBASE := obj/$(BUILD)
-OBJDIR := $(OBJDIRBASE)/o/o/o
-
-OBJ := $(addprefix $(OBJDIR)/,$(SRC:%.cpp=%.o))
-OBJ2 := $(addprefix $(OBJDIR)/,$(SRC2:%.c=%.o))
-
-all: $(IMAGE)
-
-$(OBJDIR)/%.o: %.cpp
-	$(CXX) -c $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.cpp
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CXX) -MM $(INCLUDES) $(CXXFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.cpp=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(OBJDIR)/%.o: %.c
-	$(CC) -c $(INCLUDES) $(CFLAGS) $(DEFINES) $< -o $@
-
-$(OBJDIR)/%.d : %.c
-	@echo Resolving dependencies of $<
-	@mkdir -p $(@D)
-	@$(CC) -MM $(INCLUDES) $(CFLAGS) $(DEFINES) $< > $@.$$$$; \
-	sed 's,.*\.o[ :]*,$(OBJDIR)/$(<:.c=.o) $@ : ,g' < $@.$$$$ > $@; \
-	rm -f $@.$$$$
-
-$(IMAGE): $(OBJ) $(OBJ2)
-	$(CXX) $(CXXFLAGS) $(DEFINES) $(OBJ) $(OBJ2) $(LIBS) -o $@
-
-ifneq "$(MAKECMDGOALS)" "clean"
--include $(addprefix $(OBJDIR)/,$(SRC:.cpp=.d)) $(addprefix $(OBJDIR)/,$(SRC2:.c=.d))
-endif
-
-clean:
-	rm -rf $(OBJDIRBASE) $(IMAGE)*
-
-.PHONY: clean all
+include ../../../common/unix.mk


### PR DESCRIPTION
This pulls out most of the repeated code from the various tools' build.mk files into two shared files, `common/unix.mk` and `common/src-from-vcxproj.mk`.