### PR TITLE
Fix timestamp calculation in chrome tracing importer

### DIFF
--- a/import-chrome/src/import-chrome.cpp
+++ b/import-chrome/src/import-chrome.cpp
@@ -105,7 +105,7 @@ int main( int argc, char** argv )
         {
             const auto tid = v["tid"].get<uint64_t>();
             const auto ts0 = uint64_t( v["ts"].get<double>() * 1000. );
-            const auto ts1 = v["dur"].is_object() ? ts0 + uint64_t( v["dur"].get<double>() * 1000. ) : ts0;
+            const auto ts1 = ts0 + uint64_t( v["dur"].get<double>() * 1000. );
             const auto name = v["name"].get<std::string>();
             timeline.emplace_back( tracy::Worker::ImportEventTimeline { tid, ts0, name, std::move(zoneText), false } );
             timeline.emplace_back( tracy::Worker::ImportEventTimeline { tid, ts1, "", "", true } );


### PR DESCRIPTION
The current Chrome Tracing importer incorrectly checks if the "dur" field is an object when calculating the end timestamp. The "dur" field is specified to be microseconds, not an object. This results in correctly formatted chrome traces resulting in Tracy files where each zone is zero duration.

See Chrome Tracing "spec" here: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.lpfof2aylapb
