### PR TITLE
Making find- and stat-zones stripes interleave always by changing DrawStripedRect

### DIFF
--- a/server/TracyImGui.hpp
+++ b/server/TracyImGui.hpp
@@ -184,9 +184,9 @@ namespace tracy
         const auto rw = x1 - x0;
         const auto rh = y1 - y0;
         const auto cnt = int( ( rh + rw + sw*2 ) / ( sw*2 ) );
-        auto v0 = ImVec2( x0, y0 - rw);
+        auto v0 = ImVec2( x0, y0 - rw );
 
-        if (fix_stripes_in_screen_space)
+        if ( fix_stripes_in_screen_space )
         {
             const auto window_width = double( ImGui::GetWindowHeight() );
             const auto flipped_v0y = window_width - v0.y; //we transform into a y-is-up coordinate space to achieve upper-left to lower-right stripes. If we didn't, we would calculate values for lower-left to upper-right

--- a/server/TracyImGui.hpp
+++ b/server/TracyImGui.hpp
@@ -188,16 +188,16 @@ namespace tracy
 
         if (fix_stripes_in_screen_space)
         {
-            const auto window_width = double(ImGui::GetWindowHeight());
+            const auto window_width = double( ImGui::GetWindowHeight() );
             const auto flipped_v0y = window_width - v0.y; //we transform into a y-is-up coordinate space to achieve upper-left to lower-right stripes. If we didn't, we would calculate values for lower-left to upper-right
 
             const auto manhatten_distance = x0 + flipped_v0y;
-            const auto in_multiples_of_2_times_sw = int(manhatten_distance / (sw * 2));
+            const auto in_multiples_of_2_times_sw = int( manhatten_distance / ( sw*2 ) );
         
-            const auto floored_manhatten_distance = double(in_multiples_of_2_times_sw * sw * 2); //floor in terms of 2 * stripe width
+            const auto floored_manhatten_distance = double( in_multiples_of_2_times_sw*sw*2 ); //floor in terms of 2 * stripe width
 
-            const auto corrected_flipped_v0y = (floored_manhatten_distance - x0); //we transform back into y-is-down imgui space
-            v0.y = window_width - corrected_flipped_v0y - double(inverted * sw);
+            const auto corrected_flipped_v0y = ( floored_manhatten_distance - x0 ); //the corrected (floored) y respects the position of the stripes
+            v0.y = window_width - corrected_flipped_v0y - double( inverted*sw ); //transform back into y-is-down imgui space
         }
 
         for( int i=0; i<cnt; i++ )

--- a/server/TracyImGui.hpp
+++ b/server/TracyImGui.hpp
@@ -188,8 +188,8 @@ namespace tracy
 
         if ( fix_stripes_in_screen_space )
         {
-            const auto window_width = double( ImGui::GetWindowHeight() );
-            const auto flipped_v0y = window_width - v0.y; //we transform into a y-is-up coordinate space to achieve upper-left to lower-right stripes. If we didn't, we would calculate values for lower-left to upper-right
+            const auto window_height = double( ImGui::GetWindowHeight() );
+            const auto flipped_v0y = window_height - v0.y; //we transform into a y-is-up coordinate space to achieve upper-left to lower-right stripes. If we didn't, we would calculate values for lower-left to upper-right
 
             const auto manhatten_distance = x0 + flipped_v0y;
             const auto in_multiples_of_2_times_sw = int( manhatten_distance / ( sw*2 ) );
@@ -197,7 +197,7 @@ namespace tracy
             const auto floored_manhatten_distance = double( in_multiples_of_2_times_sw*sw*2 ); //floor in terms of 2 * stripe width
 
             const auto corrected_flipped_v0y = ( floored_manhatten_distance - x0 ); //the corrected (floored) y respects the position of the stripes
-            v0.y = window_width - corrected_flipped_v0y - double( inverted*sw ); //transform back into y-is-down imgui space
+            v0.y = window_height - corrected_flipped_v0y - double( inverted*sw ); //transform back into y-is-down imgui space
         }
 
         for( int i=0; i<cnt; i++ )

--- a/server/TracyImGui.hpp
+++ b/server/TracyImGui.hpp
@@ -183,7 +183,7 @@ namespace tracy
 
         const auto rw = x1 - x0;
         const auto rh = y1 - y0;
-        const auto cnt = int( (rh + rw + sw * 2) / (sw * 2) );
+        const auto cnt = int( ( rh + rw + sw*2 ) / ( sw*2 ) );
         auto v0 = ImVec2( x0, y0 - rw);
 
         if (fix_stripes_in_screen_space)

--- a/server/TracyImGui.hpp
+++ b/server/TracyImGui.hpp
@@ -183,7 +183,7 @@ namespace tracy
 
         const auto rw = x1 - x0;
         const auto rh = y1 - y0;
-        const auto cnt = int((rh + rw + sw * 2) / (sw * 2));
+        const auto cnt = int( (rh + rw + sw * 2) / (sw * 2) );
         auto v0 = ImVec2( x0, y0 - rw);
 
         if (fix_stripes_in_screen_space)

--- a/server/TracyImGui.hpp
+++ b/server/TracyImGui.hpp
@@ -183,6 +183,7 @@ namespace tracy
 
         const auto rw = x1 - x0;
         const auto rh = y1 - y0;
+        const auto cnt = int((rh + rw + sw * 2) / (sw * 2));
         auto v0 = ImVec2( x0, y0 - rw);
 
         if (fix_stripes_in_screen_space)
@@ -199,7 +200,6 @@ namespace tracy
             v0.y = window_width - corrected_flipped_v0y - double(inverted * sw);
         }
 
-        const auto cnt = int( ( rh + rw + 2*sw*2 ) / ( sw*2 ) );
         for( int i=0; i<cnt; i++ )
         {
             draw->PathLineTo( v0 + ImVec2( 0, i*sw*2 ) );

--- a/server/TracyImGui.hpp
+++ b/server/TracyImGui.hpp
@@ -164,7 +164,7 @@ namespace tracy
         return res;
     }
 
-    static void DrawStripedRect( ImDrawList* draw, double x0, double y0, double x1, double y1, double sw, uint32_t color )
+    static void DrawStripedRect( ImDrawList* draw, double x0, double y0, double x1, double y1, double sw, uint32_t color, bool fix_stripes_in_screen_space, bool inverted )
     {
         assert( x1 >= x0 );
         assert( y1 >= y0 );
@@ -183,8 +183,23 @@ namespace tracy
 
         const auto rw = x1 - x0;
         const auto rh = y1 - y0;
-        const auto v0 = ImVec2( x0, y0 - rw );
-        const auto cnt = int( ( rh + rw + sw*2 ) / ( sw*2 ) );
+        auto v0 = ImVec2( x0, y0 - rw);
+
+        if (fix_stripes_in_screen_space)
+        {
+            const auto window_width = double(ImGui::GetWindowHeight());
+            const auto flipped_v0y = window_width - v0.y; //we transform into a y-is-up coordinate space to achieve upper-left to lower-right stripes. If we didn't, we would calculate values for lower-left to upper-right
+
+            const auto manhatten_distance = x0 + flipped_v0y;
+            const auto in_multiples_of_2_times_sw = int(manhatten_distance / (sw * 2));
+        
+            const auto floored_manhatten_distance = double(in_multiples_of_2_times_sw * sw * 2); //floor in terms of 2 * stripe width
+
+            const auto corrected_flipped_v0y = (floored_manhatten_distance - x0); //we transform back into y-is-down imgui space
+            v0.y = window_width - corrected_flipped_v0y - double(inverted * sw);
+        }
+
+        const auto cnt = int( ( rh + rw + 2*sw*2 ) / ( sw*2 ) );
         for( int i=0; i<cnt; i++ )
         {
             draw->PathLineTo( v0 + ImVec2( 0, i*sw*2 ) );

--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -3227,7 +3227,7 @@ void View::DrawZones()
     {
         const auto px0 = ( m_findZone.range.min - m_vd.zvStart ) * pxns;
         const auto px1 = std::max( px0 + std::max( 1.0, pxns * 0.5 ), ( m_findZone.range.max - m_vd.zvStart ) * pxns );
-        DrawStripedRect( draw, wpos.x + px0, linepos.y, wpos.x + px1, linepos.y + lineh, 10 * ImGui::GetTextLineHeight() / 15.f, 0x2288DD88 );
+        DrawStripedRect( draw, wpos.x + px0, linepos.y, wpos.x + px1, linepos.y + lineh, 10 * ImGui::GetTextLineHeight() / 15.f, 0x2288DD88, true, true );
         draw->AddLine( ImVec2( wpos.x + px0, linepos.y ), ImVec2( wpos.x + px0, linepos.y + lineh ), m_findZone.range.hiMin ? 0x9988DD88 : 0x3388DD88, m_findZone.range.hiMin ? 2 : 1 );
         draw->AddLine( ImVec2( wpos.x + px1, linepos.y ), ImVec2( wpos.x + px1, linepos.y + lineh ), m_findZone.range.hiMax ? 0x9988DD88 : 0x3388DD88, m_findZone.range.hiMax ? 2 : 1 );
     }
@@ -3236,7 +3236,7 @@ void View::DrawZones()
     {
         const auto px0 = ( m_statRange.min - m_vd.zvStart ) * pxns;
         const auto px1 = std::max( px0 + std::max( 1.0, pxns * 0.5 ), ( m_statRange.max - m_vd.zvStart ) * pxns );
-        DrawStripedRect( draw, wpos.x + px0, linepos.y, wpos.x + px1, linepos.y + lineh, 10 * ImGui::GetTextLineHeight() / 15.f, 0x228888EE );
+        DrawStripedRect( draw, wpos.x + px0, linepos.y, wpos.x + px1, linepos.y + lineh, 10 * ImGui::GetTextLineHeight() / 15.f, 0x228888EE, true, false );
         draw->AddLine( ImVec2( wpos.x + px0, linepos.y ), ImVec2( wpos.x + px0, linepos.y + lineh ), m_statRange.hiMin ? 0x998888EE : 0x338888EE, m_statRange.hiMin ? 2 : 1 );
         draw->AddLine( ImVec2( wpos.x + px1, linepos.y ), ImVec2( wpos.x + px1, linepos.y + lineh ), m_statRange.hiMax ? 0x998888EE : 0x338888EE, m_statRange.hiMax ? 2 : 1 );
     }
@@ -3245,7 +3245,7 @@ void View::DrawZones()
     {
         const auto s = std::min( m_setRangePopup.min, m_setRangePopup.max );
         const auto e = std::max( m_setRangePopup.min, m_setRangePopup.max );
-        DrawStripedRect( draw, wpos.x + ( s - m_vd.zvStart ) * pxns, linepos.y, wpos.x + ( e - m_vd.zvStart ) * pxns, linepos.y + lineh, 5 * ImGui::GetTextLineHeight() / 15.f, 0x55DD8888 );
+        DrawStripedRect( draw, wpos.x + ( s - m_vd.zvStart ) * pxns, linepos.y, wpos.x + ( e - m_vd.zvStart ) * pxns, linepos.y + lineh, 5 * ImGui::GetTextLineHeight() / 15.f, 0x55DD8888, true, false );
         draw->AddRect( ImVec2( wpos.x + ( s - m_vd.zvStart ) * pxns, linepos.y ), ImVec2( wpos.x + ( e - m_vd.zvStart ) * pxns, linepos.y + lineh ), 0x77DD8888 );
     }
 


### PR DESCRIPTION
Two `bool` parameters are added to DrawStripedRect:

`fix_stripes_in_screen_space `will align the stripes of the rect in screen space. This means that any stripe rects' stripes will always exactly "line up", no matter how they are positioned to each other. When it is false, the behaviour remains unchanged.
`inverted `will flip the empty and filled aread of a striped rectangle.

When drawing the striped zones in TracyView.hpp, one zone uses inverted and one doesn't. This leads to them interleaving, which I think looks way nicer than the random partial overlaps, that happen currently.

This is what it looks like now:
![grafik](https://user-images.githubusercontent.com/10748498/89628005-ee6ef100-d89b-11ea-967b-680578ab387e.png)

I tried to match the code style, but chose more verbose names and added some comments to make it understandable. Feel free to delete the comments and pick shorter names to get it in line with the rest of the codebase.
