### PR TITLE
Add GTK3 in the list of build requirements on Unix

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install linux libraries
       if: ${{ matrix.os == 'ubuntu-20.04' }}
-      run: sudo apt-get update && sudo apt-get -y install libglfw3-dev libgtk2.0-dev libcapstone-dev libtbb-dev
+      run: sudo apt-get update && sudo apt-get -y install libglfw3-dev libgtk-3-dev libcapstone-dev libtbb-dev
     - name: Install macos libraries
       if: ${{ matrix.os == 'macOS-latest' }}
       run: brew install capstone tbb pkg-config glfw

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -660,7 +660,7 @@ vcpkg install --triplet x64-windows-static freetype glfw3 capstone[arm,arm64,x86
 
 \paragraph{Unix}
 
-On Unix systems you will need to install the \texttt{pkg-config} utility and the following libraries: \texttt{glfw}, \texttt{freetype}, \texttt{capstone}, \texttt{gtk2.0}. Some Linux distributions will require you to add a \texttt{lib} prefix and a \texttt{-dev}, or \texttt{-devel} postfix to library names. You may also need to add a seemingly random number to the library name (for example: \texttt{freetype2}, or \texttt{freetype6}). The GTK library could be installed as \texttt{libgtk2.0-dev} on some systems. How fun!
+On Unix systems you will need to install the \texttt{pkg-config} utility and the following libraries: \texttt{glfw}, \texttt{freetype}, \texttt{capstone}, \texttt{GTK3}. Some Linux distributions will require you to add a \texttt{lib} prefix and a \texttt{-dev}, or \texttt{-devel} postfix to library names. You may also need to add a seemingly random number to the library name (for example: \texttt{freetype2}, or \texttt{freetype6}). The GTK library could be installed as \texttt{libgtk-3-dev} on some systems. How fun!
 
 Installation of the libraries on OSX can be facilitated using the \texttt{brew} package manager.
 

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -660,7 +660,7 @@ vcpkg install --triplet x64-windows-static freetype glfw3 capstone[arm,arm64,x86
 
 \paragraph{Unix}
 
-On Unix systems you will need to install the \texttt{pkg-config} utility and the following libraries: \texttt{glfw}, \texttt{freetype}, \texttt{capstone}. Some Linux distributions will require you to add a \texttt{lib} prefix and a \texttt{-dev}, or \texttt{-devel} postfix to library names. You may also need to add a seemingly random number to the library name (for example: \texttt{freetype2}, or \texttt{freetype6}). How fun!
+On Unix systems you will need to install the \texttt{pkg-config} utility and the following libraries: \texttt{glfw}, \texttt{freetype}, \texttt{capstone}, \texttt{gtk2.0}. Some Linux distributions will require you to add a \texttt{lib} prefix and a \texttt{-dev}, or \texttt{-devel} postfix to library names. You may also need to add a seemingly random number to the library name (for example: \texttt{freetype2}, or \texttt{freetype6}). The GTK library could be installed as \texttt{libgtk2.0-dev} on some systems. How fun!
 
 Installation of the libraries on OSX can be facilitated using the \texttt{brew} package manager.
 

--- a/profiler/build/unix/build.mk
+++ b/profiler/build/unix/build.mk
@@ -15,8 +15,8 @@ ifeq ($(UNAME),Darwin)
 	LIBS +=  -framework CoreFoundation -framework AppKit
 else
 	SRC2 += ../../../nfd/nfd_gtk.c
-	INCLUDES += $(shell pkg-config --cflags gtk+-2.0)
-	LIBS += $(shell pkg-config --libs gtk+-2.0) -lGL
+	INCLUDES += $(shell pkg-config --cflags gtk+-3.0)
+	LIBS += $(shell pkg-config --libs gtk+-3.0) -lGL
 endif
 
 include ../../../common/unix.mk


### PR DESCRIPTION
When I tried building Tracy on another machine other than my laptop I found that GTK2.0 is needed, however, there is no mention of this dependency in the manual.

This PR adds this reference.