### PR TITLE
Add support for TRACY_ONLY_IPV4 macro to exclude listening on IPv6

### DIFF
--- a/common/TracySocket.cpp
+++ b/common/TracySocket.cpp
@@ -393,7 +393,11 @@ static int addrinfo_and_socket_for_family(int port, int ai_family, struct addrin
     hints.ai_family = ai_family;
     hints.ai_socktype = SOCK_STREAM;
 #ifndef TRACY_ONLY_LOCALHOST
-    hints.ai_flags = AI_PASSIVE;
+    const char* onlyLocalhost = getenv( "TRACY_ONLY_LOCALHOST" );
+    if( !onlyLocalhost || onlyLocalhost[0] != '1' )
+    {
+        hints.ai_flags = AI_PASSIVE;
+    }
 #endif
     char portbuf[32];
     sprintf( portbuf, "%i", port );
@@ -410,7 +414,11 @@ bool ListenSocket::Listen( int port, int backlog )
     struct addrinfo* res = nullptr;
 
 #ifndef TRACY_ONLY_IPV4
-    m_sock = addrinfo_and_socket_for_family(port, AF_INET6, &res);
+    const char* onlyIPv4 = getenv( "TRACY_ONLY_IPV4" );
+    if( !onlyIPv4 || onlyIPv4[0] != '1' )
+    {
+        m_sock = addrinfo_and_socket_for_family(port, AF_INET6, &res);
+    }
 #endif
     if (m_sock == -1)
     {

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -425,9 +425,9 @@ By default Tracy client will announce its presence to the local network\footnote
 
 \subsubsection{Client network interface}
 
-By default Tracy client will listen on all network interfaces. If you want to restrict it to only listening on the localhost interface, define the \texttt{TRACY\_ONLY\_LOCALHOST} macro.
+By default Tracy client will listen on all network interfaces. If you want to restrict it to only listening on the localhost interface, define the \texttt{TRACY\_ONLY\_LOCALHOST} macro at compile time, or set the \texttt{TRACY\_ONLY\_LOCALHOST} environment variable to $1$ at runtime.
 
-By default Tracy client will listen on IPv6 interfaces, falling back to IPv4 only if IPv6 is not available. If you want to restrict it to only listening on IPv4 interfaces, define the \texttt{TRACY\_ONLY\_IPV4} macro.
+By default Tracy client will listen on IPv6 interfaces, falling back to IPv4 only if IPv6 is not available. If you want to restrict it to only listening on IPv4 interfaces, define the \texttt{TRACY\_ONLY\_IPV4} macro at compile time, or set the \texttt{TRACY\_ONLY\_IPV4} environment variable to $1$ at runtime.
 
 \subsubsection{Setup for multi-DLL projects}
 

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -427,6 +427,8 @@ By default Tracy client will announce its presence to the local network\footnote
 
 By default Tracy client will listen on all network interfaces. If you want to restrict it to only listening on the localhost interface, define the \texttt{TRACY\_ONLY\_LOCALHOST} macro.
 
+By default Tracy client will listen on IPv6 interfaces, falling back to IPv4 only if IPv6 is not available. If you want to restrict it to only listening on IPv4 interfaces, define the \texttt{TRACY\_ONLY\_IPV4} macro.
+
 \subsubsection{Setup for multi-DLL projects}
 
 In projects that consist of multiple DLLs/shared objects things are a bit different. Compiling \texttt{TracyClient.cpp} into every DLL is not an option because this would result in several instances of Tracy objects lying around in the process. We rather need to pass the instances of them to the different DLLs to be reused there.


### PR DESCRIPTION
When running a tracy client inside kubernetes, IPv6 port-forwarding is not available, only IPv4. It is therefore desirable to disable listening on IPv6 and use only IPv4. This patch enables such behaviour.