### PR TITLE
Make Tracy run natively on Wayland

### DIFF
--- a/manual/techdoc.tex
+++ b/manual/techdoc.tex
@@ -141,6 +141,8 @@ The \texttt{debug.mk} and \texttt{release.mk} files only set a few of the optimi
 
 In the header of the \texttt{build.mk} file you can find definitions of the resulting executable name, list of used libraries, required include paths, etc. Most of the file is boilerplate required to extract build dependencies, or pass the appropriate flags to compiler and linker.
 
+By default, the profiler uses X11 on Linux.  If you would like to support Wayland instead, set the environment variable \texttt{TRACY\_USE\_WAYLAND} before running make.
+
 \section{Client part}
 
 The client portion of Tracy is basically a queue. Application threads are producing queue items through the instrumentation macros and a dedicated profiler thread consumes the items to send them over the network, to the server.

--- a/profiler/build/unix/build.mk
+++ b/profiler/build/unix/build.mk
@@ -5,11 +5,12 @@ INCLUDES := $(shell pkg-config --cflags glfw3 freetype2 capstone) -I../../../img
 LIBS := $(shell pkg-config --libs glfw3 freetype2 capstone) -lpthread -ldl
 
 DISPLAY_SERVER := X11
-libwayland_client := $(shell pkg-config --libs --silence-errors wayland-client)
-ifeq ($(.SHELLSTATUS),0)
+
+ifdef TRACY_USE_WAYLAND
 	DISPLAY_SERVER := WAYLAND
-	LIBS += $(libwayland_client)
+	LIBS += $(shell pkg-config --libs wayland-client)
 endif
+
 CXXFLAGS += -D"DISPLAY_SERVER_$(DISPLAY_SERVER)"
 
 PROJECT := Tracy

--- a/profiler/build/unix/build.mk
+++ b/profiler/build/unix/build.mk
@@ -3,6 +3,15 @@ CXXFLAGS := $(CFLAGS) -std=c++17
 DEFINES += -DIMGUI_IMPL_OPENGL_LOADER_GL3W
 INCLUDES := $(shell pkg-config --cflags glfw3 freetype2 capstone) -I../../../imgui -I../../libs/gl3w
 LIBS := $(shell pkg-config --libs glfw3 freetype2 capstone) -lpthread -ldl
+
+DISPLAY_SERVER := X11
+libwayland_client := $(shell pkg-config --libs --silence-errors wayland-client)
+ifeq ($(.SHELLSTATUS),0)
+	DISPLAY_SERVER := WAYLAND
+	LIBS += $(libwayland_client)
+endif
+CXXFLAGS += -D"DISPLAY_SERVER_$(DISPLAY_SERVER)"
+
 PROJECT := Tracy
 IMAGE := $(PROJECT)-$(BUILD)
 

--- a/profiler/src/NativeWindow.cpp
+++ b/profiler/src/NativeWindow.cpp
@@ -6,7 +6,13 @@
 #  define GLFW_EXPOSE_NATIVE_WIN32
 #  include <GLFW/glfw3native.h>
 #elif defined __linux__
-#  define GLFW_EXPOSE_NATIVE_X11
+#  ifdef DISPLAY_SERVER_X11
+#    define GLFW_EXPOSE_NATIVE_X11
+#  elif defined DISPLAY_SERVER_WAYLAND
+#    define GLFW_EXPOSE_NATIVE_WAYLAND
+#  else
+#    error "unsupported linux display server"
+#  endif
 #  include <GLFW/glfw3native.h>
 #endif
 
@@ -17,7 +23,11 @@ void* GetMainWindowNative()
 #ifdef _WIN32
     return (void*)glfwGetWin32Window( s_glfwWindow );
 #elif defined __linux__
+#  ifdef DISPLAY_SERVER_X11
     return (void*)glfwGetX11Window( s_glfwWindow );
+#  elif defined DISPLAY_SERVER_WAYLAND
+    return (void*)glfwGetWaylandWindow( s_glfwWindow );
+#  endif
 #else
     return nullptr;
 #endif

--- a/profiler/src/main.cpp
+++ b/profiler/src/main.cpp
@@ -244,7 +244,9 @@ int main( int argc, char** argv )
     // Setup window
     glfwSetErrorCallback(glfw_error_callback);
     if( !glfwInit() ) return 1;
+#ifndef DISPLAY_SERVER_WAYLAND
     glfwWindowHint(GLFW_VISIBLE, 0);
+#endif
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);

--- a/profiler/src/main.cpp
+++ b/profiler/src/main.cpp
@@ -244,7 +244,9 @@ int main( int argc, char** argv )
     // Setup window
     glfwSetErrorCallback(glfw_error_callback);
     if( !glfwInit() ) return 1;
-#ifndef DISPLAY_SERVER_WAYLAND
+#ifdef DISPLAY_SERVER_WAYLAND
+    glfwWindowHint(GLFW_ALPHA_BITS, 0);
+#else
     glfwWindowHint(GLFW_VISIBLE, 0);
 #endif
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);


### PR DESCRIPTION
Hello, this commit lets me run Tracy on wayland.  

The display server detection is a bit basic, maybe you would prefer an environment variable switch?

GLFW gives errors about the following unsupported features:
```
Error 65548: Wayland: The platform does not support setting the input focus
Error 65548: Wayland: The platform does not support setting the window icon
Error 65548: Wayland: The platform does not support setting the window position
```

I had to add `glfwWindowHint(GLFW_ALPHA_BITS, 0);` to prevent transparent windows in Tracy from making the whole window transparent

glfw issue: https://github.com/glfw/glfw/issues/1434

I also had to remove `glfwWindowHint(GLFW_VISIBLE, 0);` to avoid this error:
```
xdg_wm_base@9: error 3: xdg_surface must not have a buffer at creation
```
which prevents Tracy from running.

glfw issue: https://github.com/glfw/glfw/issues/1268