### PR TITLE
Avoid caching very large files (that crash the UI and bloat traces).

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -49,6 +49,8 @@ static bool SourceFileValid( const char* fn, uint64_t olderThan )
     struct stat buf;
     if( stat( fn, &buf ) == 0 && ( buf.st_mode & S_IFREG ) != 0 )
     {
+        // Avoid caching very large files (such as those in unity builds).
+        if ( buf.st_size >= 2 * 1024 * 1024 ) return false;
         return (uint64_t)buf.st_mtime < olderThan;
     }
     return false;


### PR DESCRIPTION
[Unity builds](https://onqtam.com/programming/2018-07-07-unity-builds/) or generated source files can exceed a reasonable size and cause Tracy to crash in various ways (source file tokenization/imgui handling/etc). This change bails when a file is "too large" (heuristically chosen for the largest file I was able to load and similar to what tools like vscode do when warning about large files). If there's a place this could be added as a configuration variable (`TRACY_MAXIMUM_SOURCE_FILE_SIZE`) I can replace the inlined magic number with that to allow user control.