### PR TITLE
Fix integer type warnings

### DIFF
--- a/client/TracyCallstack.hpp
+++ b/client/TracyCallstack.hpp
@@ -100,8 +100,8 @@ static tracy_force_inline void* Callstack( int depth )
 {
     assert( depth >= 1 );
 
-    auto trace = (uintptr_t*)tracy_malloc( ( 1 + depth ) * sizeof( uintptr_t ) );
-    const auto num = backtrace( (void**)(trace+1), depth );
+    auto trace = (uintptr_t*)tracy_malloc( ( 1 + (size_t)depth ) * sizeof( uintptr_t ) );
+    const auto num = (size_t)backtrace( (void**)(trace+1), depth );
     *trace = num;
 
     return trace;

--- a/client/TracyFastVector.hpp
+++ b/client/TracyFastVector.hpp
@@ -98,8 +98,8 @@ public:
 private:
     tracy_no_inline void AllocMore()
     {
-        const auto cap = ( m_end - m_ptr ) * 2;
-        const auto size = m_write - m_ptr;
+        const auto cap = size_t( m_end - m_ptr ) * 2;
+        const auto size = size_t( m_write - m_ptr );
         T* ptr = (T*)tracy_malloc( sizeof( T ) * cap );
         memcpy( ptr, m_ptr, size * sizeof( T ) );
         tracy_free( m_ptr );

--- a/client/TracyProfiler.hpp
+++ b/client/TracyProfiler.hpp
@@ -144,7 +144,7 @@ public:
 #  elif defined __x86_64__ || defined _M_X64
         uint64_t rax, rdx;
         asm volatile ( "rdtsc" : "=a" (rax), "=d" (rdx) );
-        return ( rdx << 32 ) + rax;
+        return (int64_t)(( rdx << 32 ) + rax);
 #  else
 #    error "TRACY_HW_TIMER detection logic needs fixing"
 #  endif
@@ -639,7 +639,7 @@ private:
     {
         assert( len <= TargetFrameSize );
         bool ret = true;
-        if( m_bufferOffset - m_bufferStart + len > TargetFrameSize )
+        if( m_bufferOffset - m_bufferStart + (int)len > TargetFrameSize )
         {
             ret = CommitData();
         }


### PR DESCRIPTION
This is necessary to compile Tracy-instrumented code in codebases built with `-Werror`.