### PR TITLE
Fix switch for memory free.

### DIFF
--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -1748,10 +1748,13 @@ static void FreeAssociatedMemory( const QueueItem& item )
         ptr = MemRead<uint64_t>( &item.zoneTextFat.text );
         tracy_free( (void*)ptr );
         break;
-    case QueueType::Message:
     case QueueType::MessageColor:
-    case QueueType::MessageCallstack:
     case QueueType::MessageColorCallstack:
+        ptr = MemRead<uint64_t>( &item.messageColorFat.text );
+        tracy_free( (void*)ptr );
+        break;
+    case QueueType::Message:
+    case QueueType::MessageCallstack:
 #ifndef TRACY_ON_DEMAND
     case QueueType::MessageAppInfo:
 #endif


### PR DESCRIPTION
Because of the layout difference between messageFat and
messageColorFat, this was referencing the text member
3-bytes offset from where it should have been.