### PR TITLE
Fix call to clRetainEvent inside assert in OpenCLCtxScope

### DIFF
--- a/TracyOpenCL.hpp
+++ b/TracyOpenCL.hpp
@@ -125,7 +125,8 @@ namespace tracy {
                 if (eventInfo.phase == EventPhase::End)
                 {
                     // Done with the event, so release it
-                    assert(clReleaseEvent(event) == CL_SUCCESS);
+                    err = clReleaseEvent(event);
+                    assert(err == CL_SUCCESS);
                 }
 
                 m_tail = (m_tail + 1) % QueryCount;

--- a/TracyOpenCL.hpp
+++ b/TracyOpenCL.hpp
@@ -261,7 +261,8 @@ namespace tracy {
         tracy_force_inline void SetEvent(cl_event event)
         {
             m_event = event;
-            assert(clRetainEvent(m_event) == CL_SUCCESS);
+            cl_int err = clRetainEvent(m_event);
+            assert(err == CL_SUCCESS);
             m_ctx->GetQuery(m_beginQueryId).event = m_event;
         }
 


### PR DESCRIPTION
In `OpenCLCtxScope::SetEvent`, the necessary `clRetainEvent`
call was inside an assert, thus never called if `NDEBUG`
was defined.  This change asserts only on the return value
of the function, as in other parts of the code.