### PR TITLE
Improve import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 x64
 Release
 Debug
+_build
+_compiler
+tools/*
 *.d
 *.o
 *.so
@@ -28,3 +31,7 @@ vcpkg/*
 !vcpkg/install_vcpkg_dependencies.bat
 .deps/
 .dirstamp
+.vscode/
+
+/_*/**
+/**/__pycache__/**

--- a/client/TracySysTrace.cpp
+++ b/client/TracySysTrace.cpp
@@ -706,10 +706,10 @@ static void SetupSampling( int64_t& samplingPeriod )
         for( int i=0; i<s_numCpus; i++ ) s_ring[i].Enable();
         for(;;)
         {
-            if( !traceActive.load( std::memory_order_relaxed ) ) break;
             bool hadData = false;
             for( int i=0; i<s_numCpus; i++ )
             {
+                if( !traceActive.load( std::memory_order_relaxed ) ) break;
                 if( !s_ring[i].HasData() ) continue;
                 hadData = true;
 

--- a/client/TracySysTrace.cpp
+++ b/client/TracySysTrace.cpp
@@ -706,10 +706,10 @@ static void SetupSampling( int64_t& samplingPeriod )
         for( int i=0; i<s_numCpus; i++ ) s_ring[i].Enable();
         for(;;)
         {
+            if( !traceActive.load( std::memory_order_relaxed ) ) break;
             bool hadData = false;
             for( int i=0; i<s_numCpus; i++ )
             {
-                if( !traceActive.load( std::memory_order_relaxed ) ) break;
                 if( !s_ring[i].HasData() ) continue;
                 hadData = true;
 

--- a/import-chrome/src/import-chrome.cpp
+++ b/import-chrome/src/import-chrome.cpp
@@ -194,11 +194,15 @@ int main( int argc, char** argv )
     printf( "\33[2KProcessing...\r" );
     fflush( stdout );
 
-    auto program = input;
-    while( *program ) program++;
-    program--;
-    while( program > input && ( *program != '/' || *program != '\\' ) ) program--;
-    tracy::Worker worker( program, timeline, messages, plots, threadNames );
+    auto&& getFilename = [](const char* in) {
+        auto out = in;
+        while (*out) ++out;
+        --out;
+        while (out > in && (*out != '/' || *out != '\\')) out--;
+        return out;
+    };
+
+    tracy::Worker worker( getFilename(output), getFilename(input), timeline, messages, plots, threadNames );
 
     auto w = std::unique_ptr<tracy::FileWrite>( tracy::FileWrite::Open( output, clev ) );
     if( !w )

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -275,7 +275,7 @@ Worker::Worker( const char* addr, uint16_t port )
     m_threadNet = std::thread( [this] { SetThreadName( "Tracy Network" ); Network(); } );
 }
 
-Worker::Worker( const std::string& program, const std::vector<ImportEventTimeline>& timeline, const std::vector<ImportEventMessages>& messages, const std::vector<ImportEventPlots>& plots )
+Worker::Worker( const std::string& program, const std::vector<ImportEventTimeline>& timeline, const std::vector<ImportEventMessages>& messages, const std::vector<ImportEventPlots>& plots, const std::unordered_map<uint64_t, std::string>& threadNames )
     : m_hasData( true )
     , m_delay( 0 )
     , m_resolution( 0 )
@@ -428,9 +428,19 @@ Worker::Worker( const std::string& program, const std::vector<ImportEventTimelin
 
     for( auto& t : m_threadMap )
     {
-        char buf[64];
-        sprintf( buf, "%" PRIu64, t.first );
-        AddThreadString( t.first, buf, strlen( buf ) );
+        auto name = threadNames.find(t.first);
+        if (name != threadNames.end())
+        {
+            char buf[128];
+            int len = snprintf(buf, sizeof(buf), "(%" PRIu64 ") %s", t.first, name->second.c_str());
+            AddThreadString(t.first, buf, len);
+        }
+        else
+        {
+            char buf[64];
+            sprintf( buf, "%" PRIu64, t.first );
+            AddThreadString( t.first, buf, strlen( buf ) );
+        }
     }
 
     m_data.framesBase = m_data.frames.Retrieve( 0, [this] ( uint64_t name ) {

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -512,6 +512,8 @@ Worker::Worker( FileRead& f, EventType::Type eventMask, bool bgTasks )
         char tmp[1024];
         f.Read( tmp, sz );
         m_captureName = std::string( tmp, tmp+sz );
+        if (m_captureName.empty())
+            m_captureName = f.GetFilename();
     }
     {
         f.Read( sz );

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -275,10 +275,11 @@ Worker::Worker( const char* addr, uint16_t port )
     m_threadNet = std::thread( [this] { SetThreadName( "Tracy Network" ); Network(); } );
 }
 
-Worker::Worker( const std::string& program, const std::vector<ImportEventTimeline>& timeline, const std::vector<ImportEventMessages>& messages, const std::vector<ImportEventPlots>& plots, const std::unordered_map<uint64_t, std::string>& threadNames )
+Worker::Worker( const char* name, const char* program, const std::vector<ImportEventTimeline>& timeline, const std::vector<ImportEventMessages>& messages, const std::vector<ImportEventPlots>& plots, const std::unordered_map<uint64_t, std::string>& threadNames )
     : m_hasData( true )
     , m_delay( 0 )
     , m_resolution( 0 )
+    , m_captureName( name )
     , m_captureProgram( program )
     , m_captureTime( 0 )
     , m_pid( 0 )

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -394,7 +394,7 @@ public:
     };
 
     Worker( const char* addr, uint16_t port );
-    Worker( const std::string& program, const std::vector<ImportEventTimeline>& timeline, const std::vector<ImportEventMessages>& messages, const std::vector<ImportEventPlots>& plots );
+    Worker( const std::string& program, const std::vector<ImportEventTimeline>& timeline, const std::vector<ImportEventMessages>& messages, const std::vector<ImportEventPlots>& plots, const std::unordered_map<uint64_t, std::string>& threadNames );
     Worker( FileRead& f, EventType::Type eventMask = EventType::All, bool bgTasks = true );
     ~Worker();
 

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <string.h>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "../common/TracyForceInline.hpp"

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -395,7 +395,7 @@ public:
     };
 
     Worker( const char* addr, uint16_t port );
-    Worker( const std::string& program, const std::vector<ImportEventTimeline>& timeline, const std::vector<ImportEventMessages>& messages, const std::vector<ImportEventPlots>& plots, const std::unordered_map<uint64_t, std::string>& threadNames );
+    Worker( const char* name, const char* program, const std::vector<ImportEventTimeline>& timeline, const std::vector<ImportEventMessages>& messages, const std::vector<ImportEventPlots>& plots, const std::unordered_map<uint64_t, std::string>& threadNames );
     Worker( FileRead& f, EventType::Type eventMask = EventType::All, bool bgTasks = true );
     ~Worker();
 


### PR DESCRIPTION
Resolves #163 by adding the filename to the titlebar if the imported .tracy file does not have a name (which is the case for imported Chrome traces).

Also carries over thread names from Chrome traces.