### PR TITLE
Fixes for OpenCLCtxScope when not active

### DIFF
--- a/TracyOpenCL.hpp
+++ b/TracyOpenCL.hpp
@@ -261,6 +261,7 @@ namespace tracy {
 
         tracy_force_inline void SetEvent(cl_event event)
         {
+            if (!m_active) return;
             m_event = event;
             cl_int err = clRetainEvent(m_event);
             assert(err == CL_SUCCESS);
@@ -269,6 +270,7 @@ namespace tracy {
 
         tracy_force_inline ~OpenCLCtxScope()
         {
+            if (!m_active) return;
             const auto queryId = m_ctx->NextQueryId(EventInfo{ m_event, EventPhase::End });
 
             auto item = Profiler::QueueSerial();


### PR DESCRIPTION
Both setEvent and the destructor should
return immediately when !m_active, as the
scope is not properly initialized (m_beginQueryId
in particular.)