### PR TITLE
libbacktrace: correct memory lengths in Mach-O dsym support

### DIFF
--- a/libbacktrace/macho.cpp
+++ b/libbacktrace/macho.cpp
@@ -871,6 +871,7 @@ macho_add_dsym (struct backtrace_state *state, const char *filename,
   dsymsuffixdirlen = strlen (dsymsuffixdir);
 
   dsymlen = (dirnamelen
+	     + 1
 	     + basenamelen
 	     + dsymsuffixdirlen
 	     + basenamelen
@@ -893,7 +894,7 @@ macho_add_dsym (struct backtrace_state *state, const char *filename,
 
   if (diralc != NULL)
     {
-      backtrace_free (state, diralc, dirnamelen, error_callback, data);
+      backtrace_free (state, diralc, dirnamelen + 1, error_callback, data);
       diralc = NULL;
     }
 


### PR DESCRIPTION
This cherry pick upstream commit:
https://github.com/ianlancetaylor/libbacktrace/commit/030bd0a7099026833e437280915f1248395e7d0f

As discussed in https://github.com/wolfpld/tracy/issues/172