### PR TITLE
fix TRACY_NO_FILESELECTOR macro

### DIFF
--- a/manual/techdoc.tex
+++ b/manual/techdoc.tex
@@ -143,6 +143,8 @@ In the header of the \texttt{build.mk} file you can find definitions of the resu
 
 By default, the profiler uses X11 on Linux.  If you would like to support Wayland instead, set the environment variable \texttt{TRACY\_USE\_WAYLAND} before running make.
 
+Additionally, the variable \texttt{TRACY\_NO\_FILESELECTOR} may be set to remove Tracy's GTK 3 dependency at the expense of a file selection dialog.  Note that this means you will not be able to use certain features, e.g. opening a saved trace.
+
 \section{Client part}
 
 The client portion of Tracy is basically a queue. Application threads are producing queue items through the instrumentation macros and a dedicated profiler thread consumes the items to send them over the network, to the server.

--- a/profiler/build/unix/build.mk
+++ b/profiler/build/unix/build.mk
@@ -19,14 +19,18 @@ IMAGE := $(PROJECT)-$(BUILD)
 FILTER := ../../../nfd/nfd_win.cpp
 include ../../../common/src-from-vcxproj.mk
 
-UNAME := $(shell uname -s)
-ifeq ($(UNAME),Darwin)
-	SRC3 += ../../../nfd/nfd_cocoa.m
-	LIBS +=  -framework CoreFoundation -framework AppKit
+ifdef TRACY_NO_FILESELECTOR
+	CXXFLAGS += -DTRACY_NO_FILESELECTOR
 else
-	SRC2 += ../../../nfd/nfd_gtk.c
-	INCLUDES += $(shell pkg-config --cflags gtk+-3.0)
-	LIBS += $(shell pkg-config --libs gtk+-3.0)
+	UNAME := $(shell uname -s)
+	ifeq ($(UNAME),Darwin)
+		SRC3 += ../../../nfd/nfd_cocoa.m
+		LIBS +=  -framework CoreFoundation -framework AppKit
+	else
+		SRC2 += ../../../nfd/nfd_gtk.c
+		INCLUDES += $(shell pkg-config --cflags gtk+-3.0)
+		LIBS += $(shell pkg-config --libs gtk+-3.0)
+	endif
 endif
 
 include ../../../common/unix.mk

--- a/profiler/src/main.cpp
+++ b/profiler/src/main.cpp
@@ -15,9 +15,12 @@
 #include <GL/gl3w.h>
 #include <GLFW/glfw3.h>
 #include <memory>
-#include "../nfd/nfd.h"
 #include <sys/stat.h>
 #include <locale.h>
+
+#ifndef TRACY_NO_FILESELECTOR
+#  include "../nfd/nfd.h"
+#endif
 
 #ifdef _WIN32
 #  include <windows.h>
@@ -747,6 +750,8 @@ static void DrawContents()
             }
         }
         ImGui::SameLine( 0, ImGui::GetFontSize() * 2 );
+
+#ifndef TRACY_NO_FILESELECTOR
         if( ImGui::Button( ICON_FA_FOLDER_OPEN " Open saved trace" ) && !loadThread.joinable() )
         {
             nfdchar_t* fn;
@@ -792,6 +797,7 @@ static void DrawContents()
             if( loadThread.joinable() ) { loadThread.join(); }
             tracy::BadVersion( badVer );
         }
+#endif
 
         if( !clients.empty() )
         {

--- a/server/TracySourceView.cpp
+++ b/server/TracySourceView.cpp
@@ -3785,6 +3785,7 @@ void SourceView::CheckWrite( size_t line, RegsX86 reg, size_t limit )
     }
 }
 
+#ifndef TRACY_NO_FILESELECTOR
 void SourceView::Save( const Worker& worker, size_t start, size_t stop )
 {
     assert( start < m_asm.size() );
@@ -3867,5 +3868,6 @@ void SourceView::Save( const Worker& worker, size_t start, size_t stop )
         }
     }
 }
+#endif
 
 }


### PR DESCRIPTION
I tried to building without GTK, and discovered `TRACY_NO_FILESELECTOR` which helped a little, but was incomplete.  This PR adds a few more guards around usage of the file selector, and adds a build variable to control TRACY_NO_FILESELECTOR.  Additionally, linking of GTK is disabled when you pass this.  

I haven't updated the docs yet since I didn't want to do the work unless you seemed receptive to this feature.