### PR TITLE
Windows getenv fix

### DIFF
--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -1261,7 +1261,6 @@ Profiler::Profiler()
     CalibrateDelay();
     ReportTopology();
 
-    char buffer[32];
 #ifndef TRACY_NO_EXIT
     const char* noExitEnv = GetEnvVar( "TRACY_NO_EXIT" );
     if( noExitEnv && noExitEnv[0] == '1' )

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -175,6 +175,7 @@ struct ThreadHandleWrapper
 };
 #endif
 
+
 #if defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64
 static inline void CpuId( uint32_t* regs, uint32_t leaf )
 {
@@ -185,7 +186,6 @@ static inline void CpuId( uint32_t* regs, uint32_t leaf )
     __get_cpuid( leaf, regs, regs+1, regs+2, regs+3 );
 #endif
 }
-
 
 static void InitFailure( const char* msg )
 {

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -175,6 +175,42 @@ struct ThreadHandleWrapper
 };
 #endif
 
+static const char* GetEnvVar(const char* name, char* buffer, size_t maxLen)
+{
+#if defined _WIN32 || defined __CYGWIN__
+    // unfortunately getenv() on Windows is just fundamentally broken.  It caches the entire
+    // environment block once on startup, then never refreshes it again.  If any environment
+    // strings are added or modified after startup of the CRT, those changes will not be
+    // seen by getenv().  This removes the possibility of an app using this SDK from
+    // programmatically setting any of the behaviour controlling envvars here.
+    //
+    // To work around this, we'll instead go directly to the Win32 environment strings APIs
+    // to get the current value.
+    DWORD count = GetEnvironmentVariableA(name, buffer, maxLen);
+
+    if( count == 0 )
+        return nullptr;
+
+    if( count >= maxLen )
+    {
+        char* buf = reinterpret_cast<char*>(_alloca(count + 1));
+        count = GetEnvironmentVariableA(name, buf, count + 1);
+        memcpy(buffer, buf, maxLen);
+        buffer[maxLen - 1] = 0;
+    }
+
+    return buffer;
+#else
+    const char* value = getenv(name);
+
+    if (value == nullptr)
+        return nullptr;
+
+    strncpy(buffer, value, maxLen);
+    buffer[maxLen - 1] = 0;
+    return buffer;
+#endif
+}
 
 #if defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64
 static inline void CpuId( uint32_t* regs, uint32_t leaf )
@@ -223,43 +259,6 @@ static void InitFailure( const char* msg )
     fprintf( stderr, "Tracy Profiler initialization failure: %s\n", msg );
 #endif
     exit( 0 );
-}
-
-static const char* GetEnvVar(const char* name, char* buffer, size_t maxLen)
-{
-#if defined _WIN32 || defined __CYGWIN__
-    // unfortunately getenv() on Windows is just fundamentally broken.  It caches the entire
-    // environment block once on startup, then never refreshes it again.  If any environment
-    // strings are added or modified after startup of the CRT, those changes will not be
-    // seen by getenv().  This removes the possibility of an app using this SDK from
-    // programmatically setting any of the behaviour controlling envvars here.
-    //
-    // To work around this, we'll instead go directly to the Win32 environment strings APIs
-    // to get the current value.
-    DWORD count = GetEnvironmentVariableA(name, buffer, maxLen);
-
-    if( count == 0 )
-        return nullptr;
-
-    if( count >= maxLen )
-    {
-        char* buf = reinterpret_cast<char*>(_alloca(count + 1));
-        count = GetEnvironmentVariableA(name, buf, count + 1);
-        memcpy(buffer, buf, maxLen);
-        buffer[maxLen - 1] = 0;
-    }
-
-    return buffer;
-#else
-    const char* value = getenv(name);
-
-    if (value == nullptr)
-        return nullptr;
-
-    strncpy(buffer, value, maxLen);
-    buffer[maxLen - 1] = 0;
-    return buffer;
-#endif
 }
 
 static int64_t SetupHwTimer()

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -270,8 +270,7 @@ static int64_t SetupHwTimer()
     CpuId( regs, 0x80000007 );
     if( !( regs[3] & ( 1 << 8 ) ) )
     {
-        char buffer[32];
-        const char* noCheck = GetEnvVar( "TRACY_NO_INVARIANT_CHECK", buffer, sizeof(buffer) / sizeof(buffer[0]) );
+        const char* noCheck = GetEnvVar( "TRACY_NO_INVARIANT_CHECK" );
         if( !noCheck || noCheck[0] != '1' )
         {
 #if defined _WIN32 || defined __CYGWIN__
@@ -1264,14 +1263,14 @@ Profiler::Profiler()
 
     char buffer[32];
 #ifndef TRACY_NO_EXIT
-    const char* noExitEnv = GetEnvVar( "TRACY_NO_EXIT", buffer, sizeof(buffer) / sizeof(buffer[0]) );
+    const char* noExitEnv = GetEnvVar( "TRACY_NO_EXIT" );
     if( noExitEnv && noExitEnv[0] == '1' )
     {
         m_noExit = true;
     }
 #endif
 
-    const char* userPort = GetEnvVar( "TRACY_PORT", buffer, sizeof(buffer) / sizeof(buffer[0]) );
+    const char* userPort = GetEnvVar( "TRACY_PORT" );
     if( userPort )
     {
         m_userPort = atoi( userPort );

--- a/common/TracySocket.cpp
+++ b/common/TracySocket.cpp
@@ -8,6 +8,7 @@
 
 #include "TracyAlloc.hpp"
 #include "TracySocket.hpp"
+#include "TracySystem.hpp"
 
 #ifdef _WIN32
 #  ifndef NOMINMAX
@@ -454,7 +455,7 @@ static int addrinfo_and_socket_for_family( uint16_t port, int ai_family, struct 
     hints.ai_family = ai_family;
     hints.ai_socktype = SOCK_STREAM;
 #ifndef TRACY_ONLY_LOCALHOST
-    const char* onlyLocalhost = getenv( "TRACY_ONLY_LOCALHOST" );
+    const char* onlyLocalhost = GetEnvVar( "TRACY_ONLY_LOCALHOST" );
     if( !onlyLocalhost || onlyLocalhost[0] != '1' )
     {
         hints.ai_flags = AI_PASSIVE;
@@ -475,7 +476,7 @@ bool ListenSocket::Listen( uint16_t port, int backlog )
     struct addrinfo* res = nullptr;
 
 #if !defined TRACY_ONLY_IPV4 && !defined TRACY_ONLY_LOCALHOST
-    const char* onlyIPv4 = getenv( "TRACY_ONLY_IPV4" );
+    const char* onlyIPv4 = GetEnvVar( "TRACY_ONLY_IPV4" );
     if( !onlyIPv4 || onlyIPv4[0] != '1' )
     {
         m_sock = addrinfo_and_socket_for_family( port, AF_INET6, &res );

--- a/common/TracySystem.cpp
+++ b/common/TracySystem.cpp
@@ -11,6 +11,7 @@
 #endif
 #if defined _WIN32 || defined __CYGWIN__
 #  include <windows.h>
+#  include <malloc.h>
 #else
 #  include <pthread.h>
 #  include <string.h>
@@ -234,6 +235,38 @@ TRACY_API const char* GetThreadName( uint64_t id )
 #endif
     sprintf( buf, "%" PRIu64, id );
     return buf;
+}
+
+TRACY_API const char* GetEnvVar( const char* name )
+{
+#if defined _WIN32 || defined __CYGWIN__
+    // unfortunately getenv() on Windows is just fundamentally broken.  It caches the entire
+    // environment block once on startup, then never refreshes it again.  If any environment
+    // strings are added or modified after startup of the CRT, those changes will not be
+    // seen by getenv().  This removes the possibility of an app using this SDK from
+    // programmatically setting any of the behaviour controlling envvars here.
+    //
+    // To work around this, we'll instead go directly to the Win32 environment strings APIs
+    // to get the current value.
+    static char buffer[1024];
+    DWORD const kBufferSize = DWORD(sizeof(buffer) / sizeof(buffer[0]));
+    DWORD count = GetEnvironmentVariableA(name, buffer, kBufferSize);
+
+    if( count == 0 )
+        return nullptr;
+
+    if( count >= kBufferSize )
+    {
+        char* buf = reinterpret_cast<char*>(_alloca(count + 1));
+        count = GetEnvironmentVariableA(name, buf, count + 1);
+        memcpy(buffer, buf, kBufferSize);
+        buffer[kBufferSize - 1] = 0;
+    }
+
+    return buffer;
+#else
+    return getenv(name);
+#endif
 }
 
 }

--- a/common/TracySystem.hpp
+++ b/common/TracySystem.hpp
@@ -25,6 +25,8 @@ static inline uint64_t GetThreadHandle()
 TRACY_API void SetThreadName( const char* name );
 TRACY_API const char* GetThreadName( uint64_t id );
 
+TRACY_API const char* GetEnvVar(const char* name);
+
 }
 
 #endif


### PR DESCRIPTION
From the code comment:

> unfortunately getenv() on Windows is just fundamentally broken.  It caches the entire environment block once on startup, then never refreshes it again.  If any environment strings are added or modified after startup of the CRT, those changes will not be seen by getenv().  This removes the possibility of an app using this SDK from programmatically setting any of the behaviour controlling envvars here.