### PR TITLE
Use tracy_malloc rather than 'new' in ProfilerThreadDataKey

### DIFF
--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -1069,7 +1069,9 @@ public:
         void* p = pthread_getspecific(m_key);
         if (!p)
         {
-            p = new ProfilerThreadData(GetProfilerData());
+            RPMallocInit init;
+            p = (ProfilerThreadData*)tracy_malloc( sizeof( ProfilerThreadData ) );
+            new (p) ProfilerThreadData(GetProfilerData());
             pthread_setspecific(m_key, p);
         }
         return *static_cast<ProfilerThreadData*>(p);
@@ -1079,7 +1081,8 @@ private:
 
     static void sDestructor(void* p)
     {
-        delete static_cast<ProfilerThreadData*>(p);
+        ((ProfilerThreadData*)p)->~ProfilerThreadData();
+        tracy_free(p);
     }
 };
 


### PR DESCRIPTION
This codepath, involving a workaround for GCC < 8.4, called 'new' and
'delete' directly, which could cause infinite recursion when
user-provided versions of those functions were themselves using Tracy
functionality.

Now, this codepath uses Tracy's internal allocator.

See issues #194, #196