### PR TITLE
Change ev.ptr nullptr early-out to properly handle nullptrs

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -5602,11 +5602,11 @@ MemEvent* Worker::ProcessMemFreeImpl( uint64_t memname, MemData& memdata, const 
     const auto refTime = m_refTimeSerial + ev.time;
     m_refTimeSerial = refTime;
 
-    if( ev.ptr == 0 ) return nullptr;
-
     auto it = memdata.active.find( ev.ptr );
     if( it == memdata.active.end() )
     {
+        if( ev.ptr == 0 ) return nullptr;
+
         if( !m_ignoreMemFreeFaults )
         {
             CheckThreadString( ev.thread );


### PR DESCRIPTION
This changes the Worker::ProcessMemFreeImpl() method so that its ev.ptr nullptr early-out happen only when there is not a previous allocation for address 0. 

Custom memory pools (like custom allocators for Vulkan memory pools) can allocate at address 0, so the previous code would generate a MemAllocTwiceFailure when this happened:

0) alloc(0, size)
1) free(0)
2) alloc(0, size2)

The issue with the old code was that in step (1) the free(0) would early-out because the ptr was null. 

The above pattern is very common in our Vulkan memory pool allocators. Those memory pools start at 0 because they are sub-allocating from a buffer, so address 0 is a valid address and shouldn't be skipped.

This change still early-outs when the ptr passed to free() is null, but only if there was not a previous call to alloc(null), so I think this is a safe change. For example, if the app has overrided new/delete, and the delete(nullptr) calls TracyFree*(), the code behaves the same way as the old version. But if the app first calls TracyAlloc(0) and then calls TracyFree(0), it will correctly match the free with the alloc.

