### PR TITLE
Fix compilation on macOS 11.0.0 with XCode 12.5

### DIFF
--- a/server/TracyImGui.hpp
+++ b/server/TracyImGui.hpp
@@ -9,8 +9,8 @@
 #include <assert.h>
 #include <stdint.h>
 
-#include "../imgui/imgui.h"
-#include "../imgui/imgui_internal.h"
+#include "imgui.h"
+#include "imgui_internal.h"
 
 #include "../common/TracyForceInline.hpp"
 #include "IconsFontAwesome5.h"

--- a/server/TracyMouse.cpp
+++ b/server/TracyMouse.cpp
@@ -2,7 +2,7 @@
 
 #include "TracyMouse.hpp"
 
-#include "../imgui/imgui_internal.h"
+#include "imgui_internal.h"
 
 namespace tracy
 {

--- a/server/TracyMouse.hpp
+++ b/server/TracyMouse.hpp
@@ -1,7 +1,7 @@
 #ifndef __TRACYMOUSE_HPP__
 #define __TRACYMOUSE_HPP__
 
-#include "../imgui/imgui.h"
+#include "imgui.h"
 
 namespace tracy
 {

--- a/server/TracySourceView.cpp
+++ b/server/TracySourceView.cpp
@@ -4,7 +4,7 @@
 
 #include <capstone.h>
 
-#include "../imgui/imgui.h"
+#include "imgui.h"
 #include "TracyCharUtil.hpp"
 #include "TracyColor.hpp"
 #include "TracyFilesystem.hpp"

--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -45,7 +45,7 @@
 #include "TracyStackFrames.hpp"
 #include "TracyView.hpp"
 
-#include "../imgui/imgui_internal.h"
+#include "imgui_internal.h"
 
 #ifndef TRACY_NO_FILESELECTOR
 #  include "../nfd/nfd.h"


### PR DESCRIPTION
Apparently clang's `pragma once` mechanism gets confused by the fact imgui.h is included via different paths, even if they are actually the same file. While I am not sure wether this is not a bug in clang, this is how I got it back to work.