### PR TITLE
The value for paramter 'compressed_ttf_size' passed to 'AddFontFromMemoryCompressedTTF' seems to be a typo.

### DIFF
--- a/profiler/src/main.cpp
+++ b/profiler/src/main.cpp
@@ -330,8 +330,8 @@ int main( int argc, char** argv )
     io.Fonts->AddFontFromMemoryCompressedTTF( tracy::Arimo_compressed_data, tracy::Arimo_compressed_size, 15.0f * dpiScale, &configBasic, rangesBasic );
     io.Fonts->AddFontFromMemoryCompressedTTF( tracy::FontAwesomeSolid_compressed_data, tracy::FontAwesomeSolid_compressed_size, 14.0f * dpiScale, &configMerge, rangesIcons );
     fixedWidth = io.Fonts->AddFontFromMemoryCompressedTTF( tracy::Cousine_compressed_data, tracy::Cousine_compressed_size, 14.0f * dpiScale, &configBasic );
-    bigFont = io.Fonts->AddFontFromMemoryCompressedTTF( tracy::Arimo_compressed_data, tracy::Cousine_compressed_size, 20.0f * dpiScale, &configBasic );
-    smallFont = io.Fonts->AddFontFromMemoryCompressedTTF( tracy::Arimo_compressed_data, tracy::Cousine_compressed_size, 10.0f * dpiScale, &configBasic );
+    bigFont = io.Fonts->AddFontFromMemoryCompressedTTF( tracy::Arimo_compressed_data, tracy::Arimo_compressed_size, 20.0f * dpiScale, &configBasic );
+    smallFont = io.Fonts->AddFontFromMemoryCompressedTTF( tracy::Arimo_compressed_data, tracy::Arimo_compressed_size, 10.0f * dpiScale, &configBasic );
 
     ImGui::StyleColorsDark();
     auto& style = ImGui::GetStyle();


### PR DESCRIPTION
The value for paramter 'compressed_ttf_size' passed to 'AddFontFromMemoryCompressedTTF' seems to be a typo.