### PR TITLE
add TRACY_CALLSTACK_IGNORE_INLINES

### DIFF
--- a/client/TracyCallstack.cpp
+++ b/client/TracyCallstack.cpp
@@ -81,6 +81,7 @@ extern "C"
     t_RtlWalkFrameChain RtlWalkFrameChain = 0;
 }
 
+#ifndef TRACY_CALLSTACK_IGNORE_INLINES
 #if defined __MINGW32__ && API_VERSION_NUMBER < 12
 extern "C" {
 // Actual required API_VERSION_NUMBER is unknown because it is undocumented. These functions are not present in at least v11.
@@ -92,6 +93,7 @@ BOOL IMAGEAPI SymFromInlineContext(HANDLE hProcess, DWORD64 Address, ULONG Inlin
 BOOL IMAGEAPI SymGetLineFromInlineContext(HANDLE hProcess, DWORD64 qwAddr, ULONG InlineContext,
     DWORD64 qwModuleBaseAddress, PDWORD pdwDisplacement, PIMAGEHLP_LINE64 Line64);
 };
+#endif
 #endif
 
 #ifndef __CYGWIN__
@@ -292,7 +294,7 @@ CallstackSymbolData DecodeCodeAddress( uint64_t ptr )
 #ifdef TRACY_DBGHELP_LOCK
     DBGHELP_LOCK;
 #endif
-#ifndef __CYGWIN__
+#if !defined(__CYGWIN__) && !defined(TRACY_CALLSTACK_IGNORE_INLINES)
     DWORD inlineNum = SymAddrIncludeInlineTrace( proc, ptr );
     DWORD ctx = 0;
     DWORD idx;
@@ -335,7 +337,7 @@ CallstackEntryData DecodeCallstackPtr( uint64_t ptr )
 #ifdef TRACY_DBGHELP_LOCK
     DBGHELP_LOCK;
 #endif
-#ifndef __CYGWIN__
+#if !defined(__CYGWIN__) && !defined(TRACY_CALLSTACK_IGNORE_INLINES)
     DWORD inlineNum = SymAddrIncludeInlineTrace( proc, ptr );
     if( inlineNum > MaxCbTrace - 1 ) inlineNum = MaxCbTrace - 1;
     DWORD ctx = 0;
@@ -393,7 +395,7 @@ CallstackEntryData DecodeCallstackPtr( uint64_t ptr )
         }
     }
 
-#ifndef __CYGWIN__
+#if !defined(__CYGWIN__) && !defined(TRACY_CALLSTACK_IGNORE_INLINES)
     if( doInline )
     {
         for( DWORD i=0; i<inlineNum; i++ )

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -1688,9 +1688,12 @@ void Profiler::Worker()
             }
 
             bool connActive = true;
-            while( m_sock->HasData() && connActive )
+            int queryCounter = 0;
+            constexpr int flushPeriod = 500;
+            while ( m_sock->HasData() && connActive && queryCounter < flushPeriod )
             {
                 connActive = HandleServerQuery();
+                queryCounter++;
             }
             if( !connActive ) break;
         }


### PR DESCRIPTION
In some cases, during a profiling session Tracy appears to be 'stuck' with a large backlog of requests for a very long time that doesn't seem to ever reduce. 

I think it's from two causes:
 * the client tries to process all the queries it received before sending the results back -> the profiler is blocked while the results accumulate on the client.

 * this situation occurs because the Win32 dbghelp SymAddrIncludeInlineTrace() call is very slow, several orders of magnitude slower than the simple ones.  (the client goes from overall answering 20000 queries per second to 70)

I don't know if it's the correct approach, but here are a pair of changes to flush once in a while to accumulated query results and add a define to disable the inline resolution code.
