### PR TITLE
Use file:line when comparing traces

### DIFF
--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -11420,7 +11420,7 @@ void View::DrawCompare()
                                 auto& srcloc = m_compare.second->GetSourceLocation( v );
                                 auto string = m_compare.second->GetString( srcloc.name.active ? srcloc.name : srcloc.function );
                                 auto file = m_compare.second->GetString( srcloc.file );
-                                if( strcmp( string0, string ) == 0 && strcmp( file0, file) == 0 && srcloc0.line == srcloc.line  )
+                                if( strcmp( string0, string ) == 0 && strcmp( file0, file ) == 0 && srcloc0.line == srcloc.line )
                                 {
                                     m_compare.selMatch[1] = idx;
                                     break;
@@ -11436,7 +11436,7 @@ void View::DrawCompare()
                                 auto& srcloc = m_worker.GetSourceLocation( v );
                                 auto string = m_worker.GetString( srcloc.name.active ? srcloc.name : srcloc.function );
                                 auto file = m_compare.second->GetString( srcloc.file );
-                                if( strcmp( string1, string ) == 0 && strcmp( file1, file) == 0 && srcloc1.line == srcloc.line  )
+                                if( strcmp( string1, string ) == 0 && strcmp( file1, file ) == 0 && srcloc1.line == srcloc.line )
                                 {
                                     m_compare.selMatch[0] = idx;
                                     break;

--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -11407,8 +11407,10 @@ void View::DrawCompare()
                     auto& srcloc1 = m_compare.second->GetSourceLocation( m_compare.match[1][m_compare.selMatch[1]] );
                     auto string0 = m_worker.GetString( srcloc0.name.active ? srcloc0.name : srcloc0.function );
                     auto string1 = m_compare.second->GetString( srcloc1.name.active ? srcloc1.name : srcloc1.function );
+                    auto file0 = m_worker.GetString( srcloc0.file );
+                    auto file1 = m_compare.second->GetString( srcloc1.file );
 
-                    if( strcmp( string0, string1 ) != 0 )
+                    if( strcmp( string0, string1 ) != 0 || strcmp( file0, file1 ) != 0 || srcloc0.line != srcloc1.line )
                     {
                         idx = 0;
                         if( prev0 != m_compare.selMatch[0] )
@@ -11417,7 +11419,8 @@ void View::DrawCompare()
                             {
                                 auto& srcloc = m_compare.second->GetSourceLocation( v );
                                 auto string = m_compare.second->GetString( srcloc.name.active ? srcloc.name : srcloc.function );
-                                if( strcmp( string0, string ) == 0 )
+                                auto file = m_compare.second->GetString( srcloc.file );
+                                if( strcmp( string0, string ) == 0 && strcmp( file0, file) == 0 && srcloc0.line == srcloc.line  )
                                 {
                                     m_compare.selMatch[1] = idx;
                                     break;
@@ -11432,7 +11435,8 @@ void View::DrawCompare()
                             {
                                 auto& srcloc = m_worker.GetSourceLocation( v );
                                 auto string = m_worker.GetString( srcloc.name.active ? srcloc.name : srcloc.function );
-                                if( strcmp( string1, string ) == 0 )
+                                auto file = m_compare.second->GetString( srcloc.file );
+                                if( strcmp( string1, string ) == 0 && strcmp( file1, file) == 0 && srcloc1.line == srcloc.line  )
                                 {
                                     m_compare.selMatch[0] = idx;
                                     break;

--- a/server/TracyView.hpp
+++ b/server/TracyView.hpp
@@ -251,6 +251,7 @@ private:
     uint64_t GetZoneThread( const ZoneEvent& zone ) const;
     uint64_t GetZoneThread( const GpuEvent& zone ) const;
     const GpuCtxData* GetZoneCtx( const GpuEvent& zone ) const;
+    bool FindMatchingZone( int prev0, int prev1, int flags );
     const ZoneEvent* FindZoneAtTime( uint64_t thread, int64_t time ) const;
     uint64_t GetFrameNumber( const FrameData& fd, int i, uint64_t offset ) const;
     const char* GetFrameText( const FrameData& fd, int i, uint64_t ftime, uint64_t offset ) const;
@@ -445,6 +446,13 @@ private:
         Inert,
         Saving,
         NeedsJoin
+    };
+
+    enum
+    {
+        FindMatchingZoneFlagDefault = 0,
+        FindMatchingZoneFlagSourceFile = (1 << 0),
+        FindMatchingZoneFlagLineNum = (1 << 1),
     };
 
     std::atomic<SaveThreadState> m_saveThreadState { SaveThreadState::Inert };


### PR DESCRIPTION
When comparing traces, where multiple classes share the same zone
names, the behavior prior to this patch was to auto-select the first
matching zone name in the other trace. Instead, find the most correct
zone by using filename and line number.