### PR TITLE
Tiny fix in manual

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -1121,7 +1121,7 @@ enum SubSystems
 ...
 
 // Preferably a define in the build system
-#define SUBSYSTEMS Sys_Physics | Sys_NasalDemons
+#define SUBSYSTEMS (Sys_Physics | Sys_NasalDemons)
 
 ...
 


### PR DESCRIPTION
Without parentheses, bitwise-and takes precedence over bitwise-or.