### PR TITLE
Fix a crash in Worker c-tor when converting certain JSON files

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -371,6 +371,8 @@ Worker::Worker( const char* name, const char* program, const std::vector<ImportE
         else
         {
             auto td = NoticeThread( v.tid );
+            if (td->zoneIdStack.empty())
+                continue;
             td->zoneIdStack.pop_back();
             auto& stack = td->stack;
             auto zone = stack.back_and_pop();


### PR DESCRIPTION
Hit the problem with specific type of JSON files damage causing a crash in the `import-chrome`. While the JSON files are technically not correct, with the fix, this specific type of failure was processed alright.
The issue is that sometimes, when profiling is not properly enabled, there are asymmetric end events in the JSON profile, this is the simplest example:
[current_profile_out.json.zip](https://github.com/wolfpld/tracy/files/6680290/current_profile_out.json.zip)

This fix is generally useful since it prevents crashes. Maybe some meaningful error message should be added? In any case, with this fix, I am getting a useful file, while before the conversion utility was simply crashing with no output at all:
![image](https://user-images.githubusercontent.com/11299031/122636444-26d78200-d09e-11eb-9577-b55170d327a0.png)

