### PR TITLE
Fix compilation warning

### DIFF
--- a/client/TracyCallstack.cpp
+++ b/client/TracyCallstack.cpp
@@ -341,7 +341,7 @@ CallstackEntryData DecodeCallstackPtr( uint64_t ptr )
 #if !defined TRACY_NO_CALLSTACK_INLINES
     BOOL doInline = FALSE;
     DWORD ctx = 0;
-    DWORD inlineNum;
+    DWORD inlineNum = 0;
     if( _SymAddrIncludeInlineTrace )
     {
         inlineNum = _SymAddrIncludeInlineTrace( proc, ptr );


### PR DESCRIPTION
Sorry for the smallest PR in history, but this is what set off MS analyzer when I was updating to Tracy 0.7.8+, I thought would be good to fix it