### PR TITLE
Indenting empty GPU zone tree nodes when grouped to keep zones aligned.

### DIFF
--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -7929,7 +7929,9 @@ void View::DrawZoneInfoChildren( const V& children, int64_t ztime )
         pdqsort_branchless( cgvec.begin(), cgvec.end(), []( const auto& lhs, const auto& rhs ) { return lhs->t > rhs->t; } );
 
         ImGui::Columns( 2 );
+        ImGui::Indent( ImGui::GetTreeNodeToLabelSpacing() * 2 );
         TextColoredUnformatted( ImVec4( 1.0f, 1.0f, 0.4f, 1.0f ), "Self time" );
+        ImGui::Unindent( ImGui::GetTreeNodeToLabelSpacing() * 2 );
         ImGui::NextColumn();
         char buf[128];
         PrintStringPercent( buf, TimeToString( ztime - ctime ), double( ztime - ctime ) / ztime * 100 );
@@ -7945,11 +7947,11 @@ void View::DrawZoneInfoChildren( const V& children, int64_t ztime )
             {
                 auto& cev = a(children[cgr.v.front()]);
                 const auto txt = m_worker.GetZoneName( cev );
-                bool b = false;
                 SmallColorBox( GetSrcLocColor( srcloc, 0 ) );
                 ImGui::SameLine();
                 ImGui::PushID( (int)cgr.v.front() );
-                if( ImGui::Selectable( txt, &b, ImGuiSelectableFlags_SpanAllColumns ) )
+                ImGui::TreeNodeEx( txt, ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen );
+                if( ImGui::IsItemClicked() )
                 {
                     ShowZoneInfo( cev );
                 }
@@ -8064,7 +8066,9 @@ void View::DrawZoneInfoChildren( const V& children, int64_t ztime )
         pdqsort_branchless( cti.get(), cti.get() + children.size(), [&ctt] ( const auto& lhs, const auto& rhs ) { return ctt[lhs] > ctt[rhs]; } );
 
         ImGui::Columns( 2 );
+        ImGui::Indent( ImGui::GetTreeNodeToLabelSpacing() );
         TextColoredUnformatted( ImVec4( 1.0f, 1.0f, 0.4f, 1.0f ), "Self time" );
+        ImGui::Unindent( ImGui::GetTreeNodeToLabelSpacing() );
         ImGui::NextColumn();
         char buf[128];
         PrintStringPercent( buf, TimeToString( ztime - ctime ), double( ztime - ctime ) / ztime * 100 );
@@ -8373,7 +8377,9 @@ void View::DrawGpuInfoChildren( const V& children, int64_t ztime )
         pdqsort_branchless( cgvec.begin(), cgvec.end(), []( const auto& lhs, const auto& rhs ) { return lhs->t > rhs->t; } );
 
         ImGui::Columns( 2 );
+        ImGui::Indent( ImGui::GetTreeNodeToLabelSpacing() );
         TextColoredUnformatted( ImVec4( 1.0f, 1.0f, 0.4f, 1.0f ), "Self time" );
+        ImGui::Unindent( ImGui::GetTreeNodeToLabelSpacing() );
         ImGui::NextColumn();
         char buf[128];
         PrintStringPercent( buf, TimeToString( ztime - ctime ), double( ztime - ctime ) / ztime * 100 );
@@ -8389,9 +8395,9 @@ void View::DrawGpuInfoChildren( const V& children, int64_t ztime )
             {
                 auto& cev = a(children[cgr.v.front()]);
                 const auto txt = m_worker.GetZoneName( cev );
-                bool b = false;
                 ImGui::PushID( (int)cgr.v.front() );
-                if( ImGui::Selectable( txt, &b, ImGuiSelectableFlags_SpanAllColumns ) )
+                ImGui::TreeNodeEx( txt, ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen );
+                if( ImGui::IsItemClicked() )
                 {
                     ShowZoneInfo( cev, m_gpuInfoWindowThread );
                 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/75337/126044154-245e3477-c505-40d0-b70c-43cd52b84887.png)

After:
![image](https://user-images.githubusercontent.com/75337/126046820-9d6a31a8-76ec-4262-8be1-b1e7c583e38f.png)

![image](https://user-images.githubusercontent.com/75337/126046798-ac0b1d86-62a3-4afe-b500-af35aaa903ce.png)
