### PR TITLE
Multi Dll Proj will Crash, Under Unity

### DIFF
--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -963,7 +963,7 @@ ProfilerData* s_profilerData = nullptr;
 static ProfilerThreadData& GetProfilerThreadData();
 TRACY_API void StartupProfiler()
 {
-    s_profilerData = (ProfilerData*)tracy_malloc(sizeof(ProfilerData));
+    s_profilerData = (ProfilerData*)tracy_malloc( sizeof( ProfilerData ));
     new (s_profilerData) ProfilerData();
     s_profilerData->profiler.SpawnWorkerThreads();
     GetProfilerThreadData().token = ProducerWrapper(*s_profilerData);
@@ -976,7 +976,7 @@ static ProfilerData& GetProfilerData()
 TRACY_API void ShutdownProfiler()
 {
     s_profilerData->~ProfilerData();
-    tracy_free(s_profilerData);
+    tracy_free( s_profilerData );
     s_profilerData = nullptr;
     rpmalloc_finalize();
     RpThreadInitDone = false;

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -963,7 +963,7 @@ ProfilerData* s_profilerData = nullptr;
 static ProfilerThreadData& GetProfilerThreadData();
 TRACY_API void StartupProfiler()
 {
-    s_profilerData = (ProfilerData*)tracy_malloc( sizeof( ProfilerData ) );
+    s_profilerData = (ProfilerData*)tracy_malloc(sizeof(ProfilerData));
     new (s_profilerData) ProfilerData();
     s_profilerData->profiler.SpawnWorkerThreads();
     GetProfilerThreadData().token = ProducerWrapper(*s_profilerData);
@@ -976,7 +976,7 @@ static ProfilerData& GetProfilerData()
 TRACY_API void ShutdownProfiler()
 {
     s_profilerData->~ProfilerData();
-    tracy_free( s_profilerData );
+    tracy_free(s_profilerData);
     s_profilerData = nullptr;
     rpmalloc_finalize();
     RpThreadInitDone = false;

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -960,11 +960,13 @@ thread_local bool RpThreadInitDone = false;
 
 #  ifdef TRACY_MANUAL_LIFETIME
 ProfilerData* s_profilerData = nullptr;
+static ProfilerThreadData& GetProfilerThreadData();
 TRACY_API void StartupProfiler()
 {
     s_profilerData = (ProfilerData*)tracy_malloc( sizeof( ProfilerData ) );
     new (s_profilerData) ProfilerData();
     s_profilerData->profiler.SpawnWorkerThreads();
+    GetProfilerThreadData().token = ProducerWrapper(*s_profilerData);
 }
 static ProfilerData& GetProfilerData()
 {
@@ -977,6 +979,8 @@ TRACY_API void ShutdownProfiler()
     tracy_free( s_profilerData );
     s_profilerData = nullptr;
     rpmalloc_finalize();
+    RpThreadInitDone = false;
+    RpInitDone.store(0, std::memory_order_release);
 }
 #  else
 static std::atomic<int> profilerDataLock { 0 };

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -963,14 +963,14 @@ ProfilerData* s_profilerData = nullptr;
 static ProfilerThreadData& GetProfilerThreadData();
 TRACY_API void StartupProfiler()
 {
-    s_profilerData = (ProfilerData*)tracy_malloc( sizeof( ProfilerData ));
+    s_profilerData = (ProfilerData*)tracy_malloc( sizeof( ProfilerData ) );
     new (s_profilerData) ProfilerData();
     s_profilerData->profiler.SpawnWorkerThreads();
-    GetProfilerThreadData().token = ProducerWrapper(*s_profilerData);
+    GetProfilerThreadData().token = ProducerWrapper( *s_profilerData );
 }
 static ProfilerData& GetProfilerData()
 {
-    assert(s_profilerData);
+    assert( s_profilerData );
     return *s_profilerData;
 }
 TRACY_API void ShutdownProfiler()
@@ -980,7 +980,7 @@ TRACY_API void ShutdownProfiler()
     s_profilerData = nullptr;
     rpmalloc_finalize();
     RpThreadInitDone = false;
-    RpInitDone.store(0, std::memory_order_release);
+    RpInitDone.store( 0, std::memory_order_release );
 }
 #  else
 static std::atomic<int> profilerDataLock { 0 };


### PR DESCRIPTION
Under unity, 

the dll(.so) will not be completely uninstalled, 

so the stack and the heap content of the thread needs to be regenerated when StartupProfiler()