### PR TITLE
Full CMake integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,10 +55,3 @@ set_option(TRACY_NO_FRAME_IMAGE)
 set_option(TRACE_NO_SAMPLING)
 set_option(TRACY_NO_VERIFY)
 set_option(TRACY_NO_VSYNC_CAPTURE)
-
-if(NOT TRACY_PORT)
-    set(TRACY_PORT 8086)
-endif()
-
-message(STATUS "TRACY_PORT: ${TRACY_PORT}")
-target_compile_definitions(TracyClient PUBLIC TRACY_PORT=${TRACY_PORT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,64 @@
 cmake_minimum_required(VERSION 3.10)
-project(TracyClient LANGUAGES CXX)
-add_library(TracyClient INTERFACE)
-target_include_directories(TracyClient INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+project(Tracy LANGUAGES CXX)
+
+find_package(Threads REQUIRED)
+
+option(TRACY_ENABLE "Enable profiling" ON)
+option(TRACY_ON_DEMAND "On-demand profiling" OFF)
+option(TRACY_CALLSTACK "Collect call stacks" OFF)
+option(TRACY_ONLY_LOCALHOST "Only listen on the localhost interface" OFF)
+option(TRACY_NO_BROADCAST "Disable client discovery by broadcast to local network" OFF)
+option(TRACY_NO_CODE_TRANSFER "Disable collection of source code" OFF)
+option(TRACY_NO_CONTEXT_SWITCH "Disable capture of context switches" OFF)
+option(TRACY_NO_EXIT "Client executable does not exit until all profile data is sent to server" OFF)
+option(TRACY_NO_FRAME_IMAGE "Disable capture of frame images" OFF)
+option(TRACE_NO_SAMPLING "Disable call stack sampling" OFF)
+option(TRACY_NO_VERIFY "Disable zone validation for C API" OFF)
+option(TRACY_NO_VSYNC_CAPTURE "Disable capture of hardware Vsync events" OFF)
+
+add_library(TracyClient TracyClient.cpp)
+target_compile_features(TracyClient PUBLIC cxx_std_11)
+target_include_directories(TracyClient PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(
+    TracyClient
+    PUBLIC
+        Threads::Threads
+        ${CMAKE_DL_LIBS}
+)
+
+if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+    find_library(EXECINFO_LIBRARY NAMES execinfo REQUIRED)
+    target_link_libraries(TracyClient PUBLIC ${EXECINFO_LIBRARY})
+endif()
+
+add_library(Tracy::TracyClient ALIAS TracyClient)
+
+macro(set_option OPTION)
+    if(${OPTION})
+        message(STATUS "${OPTION}: ON")
+        target_compile_definitions(TracyClient PUBLIC ${OPTION})
+    else()
+        message(STATUS "${OPTION}: OFF")
+    endif()
+endmacro()
+
+set_option(TRACY_ENABLE)
+set_option(TRACY_ON_DEMAND)
+set_option(TRACY_CALLSTACK)
+set_option(TRACY_ONLY_LOCALHOST)
+set_option(TRACY_NO_BROADCAST)
+set_option(TRACY_NO_CODE_TRANSFER)
+set_option(TRACY_NO_CONTEXT_SWITCH)
+set_option(TRACY_NO_EXIT)
+set_option(TRACY_NO_FRAME_IMAGE)
+set_option(TRACE_NO_SAMPLING)
+set_option(TRACY_NO_VERIFY)
+set_option(TRACY_NO_VSYNC_CAPTURE)
+
+if(NOT TRACY_PORT)
+    set(TRACY_PORT 8086)
+endif()
+
+message(STATUS "TRACY_PORT: ${TRACY_PORT}")
+target_compile_definitions(TracyClient PUBLIC TRACY_PORT=${TRACY_PORT})

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -425,6 +425,27 @@ The application you want to profile should be compiled with all the usual optimi
 
 Finally, on Unix make sure that the application is linked with libraries \texttt{libpthread} and \texttt{libdl}. BSD systems will also need to be linked with \texttt{libexecinfo}.
 
+\begin{bclogo}[
+noborder=true,
+couleur=black!5,
+logo=\bclampe
+]{CMake integration}
+You can integrate Tracy easily with CMake by adding the git submodule folder as a subdirectory.
+
+\begin{lstlisting}
+# set options before add_subdirectory
+# available options: TRACY_ENABLE, TRACY_ON_DEMAND, TRACY_NO_BROADCAST, TRACY_NO_CODE_TRANSFER, ...
+option(TRACY_ENABLE "" ON)
+option(TRACY_ON_DEMAND "" ON)
+add_subdirectory(3rdparty/tracy)  # target: TracyClient or alias Tracy::TracyClient
+\end{lstlisting}
+
+Link \texttt{Tracy::TracyClient} to any target where you use Tracy for profiling:
+
+\begin{lstlisting}
+target_link_libraries(<TARGET> PUBLIC Tracy::TracyClient)
+\end{lstlisting}
+\end{bclogo}
 
 \begin{bclogo}[
 noborder=true,
@@ -448,7 +469,7 @@ FetchContent_MakeAvailable(tracy)
 Then add this to any target where you use tracy for profiling:
 
 \begin{lstlisting}
-target_link_libraries(${_target} PUBLIC TracyClient)
+target_link_libraries(<TARGET> PUBLIC TracyClient)
 \end{lstlisting}
 \end{bclogo}
 


### PR DESCRIPTION
Add full CMake support to easily integrate it in CMake projects. (`TracyClient.cpp` had to be compiled manually before.)
Most (common) compile flags are configured as options.

I tried to implement the `libexecinfo` dependency for FreeBSD but couldn't test it.

Major parts are taken from here: https://github.com/wolfpld/tracy/issues/2#issuecomment-632594050