### PR TITLE
Add `-s <seconds>` parameter to capture.cpp

### DIFF
--- a/capture/src/capture.cpp
+++ b/capture/src/capture.cpp
@@ -34,7 +34,7 @@ void SigInt( int )
 
 [[noreturn]] void Usage()
 {
-    printf( "Usage: capture -o output.tracy [-a address] [-p port] [-f]\n" );
+    printf( "Usage: capture -o output.tracy [-a address] [-p port] [-f] [-s seconds]\n" );
     exit( 1 );
 }
 
@@ -52,9 +52,10 @@ int main( int argc, char** argv )
     const char* address = "127.0.0.1";
     const char* output = nullptr;
     int port = 8086;
+    int seconds = -1;
 
     int c;
-    while( ( c = getopt( argc, argv, "a:o:p:f" ) ) != -1 )
+    while( ( c = getopt( argc, argv, "a:o:p:fs:" ) ) != -1 )
     {
         switch( c )
         {
@@ -69,6 +70,9 @@ int main( int argc, char** argv )
             break;
         case 'f':
             overwrite = true;
+            break;
+        case 's':
+            seconds = atoi (optarg);
             break;
         default:
             Usage();
@@ -137,6 +141,7 @@ int main( int argc, char** argv )
         {
             worker.Disconnect();
             disconnect = false;
+            break;
         }
 
         lock.lock();
@@ -162,6 +167,14 @@ int main( int argc, char** argv )
         fflush( stdout );
 
         std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+        if( seconds != -1 )
+        {
+            const auto dur = std::chrono::high_resolution_clock::now() - t0;
+            if( std::chrono::duration_cast<std::chrono::seconds>(dur).count() >= seconds )
+            {
+                disconnect = true;
+            }
+        }
     }
     const auto t1 = std::chrono::high_resolution_clock::now();
 

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -2017,6 +2017,7 @@ You can capture a trace using a command line utility contained in the \texttt{ca
 \item \texttt{-a address} -- specifies the IP address (or a domain name) of the client application (uses \texttt{localhost} if not provided).
 \item \texttt{-p port} -- network port which should be used (optional).
 \item \texttt{-f} -- force overwrite, if output file already exists.
+\item \texttt{-s seconds} -- number of seconds to capture before automatically disconnecting (optional).
 \end{itemize}
 
 If there is no client running at the given address, the server will wait until a connection can be made. During the capture the following information will be displayed:
@@ -2031,7 +2032,7 @@ Timer resolution: 3 ns
 
 The \emph{queue delay} and \emph{timer resolution} parameters are calibration results of timers used by the client. The next line is a status bar, which displays: network connection speed, connection compression ratio, and the resulting uncompressed data rate; total amount of data transferred over the network; memory usage of the capture utility; time extent of the captured data.
 
-You can disconnect from the client and save the captured trace by pressing \keys{\ctrl + C}.
+You can disconnect from the client and save the captured trace by pressing \keys{\ctrl + C}. If you prefer to disconnect after a fixed time, use the \texttt{-s seconds} parameter.
 
 \subsection{Interactive profiling}
 \label{interactiveprofiling}


### PR DESCRIPTION
This adds a `-s <seconds>` parameter to capture.cpp, to make it easier to automate fixed-size captures from scripts.