### PR TITLE
Filter samples by zones source locations

### DIFF
--- a/server/TracyEvent.hpp
+++ b/server/TracyEvent.hpp
@@ -268,6 +268,7 @@ enum { SampleDataSize = sizeof( SampleData ) };
 struct SampleDataRange
 {
     Int48 time;
+    uint16_t thread;
     CallstackFrameId ip;
 };
 

--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -10699,59 +10699,6 @@ void View::DrawFindZone()
         SmallCheckbox( "Show zone time in frames", &m_findZone.showZoneInFrames );
         ImGui::Separator();
 
-        const bool hasSamples = m_worker.AreCallstackSamplesReady() && m_worker.GetCallstackSampleCount() > 0;
-        if( hasSamples && ImGui::TreeNodeEx( "Samples", ImGuiTreeNodeFlags_None ) )
-        {
-            {
-                ImGui::Checkbox( ICON_FA_STOPWATCH " Show time", &m_statSampleTime );
-                ImGui::SameLine();
-                ImGui::Spacing();
-                ImGui::SameLine();
-                ImGui::Checkbox( ICON_FA_EYE_SLASH " Hide unknown", &m_statHideUnknown );
-                ImGui::SameLine();
-                ImGui::Spacing();
-                ImGui::SameLine();
-                ImGui::Checkbox( ICON_FA_SITEMAP " Inlines", &m_statSeparateInlines );
-                ImGui::SameLine();
-                ImGui::Spacing();
-                ImGui::SameLine();
-                ImGui::Checkbox( ICON_FA_AT " Address", &m_statShowAddress );
-                ImGui::SameLine();
-                ImGui::Spacing();
-                ImGui::SameLine();
-                if( ImGui::Checkbox( ICON_FA_HAT_WIZARD " Include kernel", &m_statShowKernel ))
-                {
-                    m_findZone.samples.scheduleUpdate = true;
-                }
-            }
-
-            if( !m_findZone.samples.enabled )
-            {
-                m_findZone.samples.enabled = true;
-                m_findZone.samples.scheduleUpdate = true;
-                m_findZone.scheduleResetMatch = true;
-            }
-            
-            Vector<SymList> data;
-            data.reserve( m_findZone.samples.counts.size() );
-            for( auto it: m_findZone.samples.counts ) data.push_back_no_space_check( it );
-            int64_t timeRange = ( m_findZone.selGroup != m_findZone.Unselected ) ? m_findZone.selTotal : m_findZone.total;
-            DrawSamplesStatistics( data, timeRange, AccumulationMode::SelfOnly );
-
-            ImGui::TreePop();
-        } 
-        else
-        {
-            if( m_findZone.samples.enabled )
-            {
-                m_findZone.samples.enabled = false;
-                m_findZone.samples.scheduleUpdate = false;
-                m_findZone.samples.counts = Vector<SymList>();
-                for( auto& it: m_findZone.groups ) it.second.zonesTids.clear();
-            }
-        }
-        ImGui::Separator();
-
         ImGui::TextUnformatted( "Found zones:" );
         ImGui::SameLine();
         DrawHelpMarker( "Left click to highlight entry." );
@@ -11233,6 +11180,59 @@ void View::DrawFindZone()
                     if( pass ) count ++;
                 }
                 if( count > 0 )  m_findZone.samples.counts.push_back_no_space_check( SymList { v.first, 0, count } );
+            }
+        }
+
+        ImGui::Separator();
+        const bool hasSamples = m_worker.AreCallstackSamplesReady() && m_worker.GetCallstackSampleCount() > 0;
+        if( hasSamples && ImGui::TreeNodeEx( "Samples", ImGuiTreeNodeFlags_None ) )
+        {
+            {
+                ImGui::Checkbox( ICON_FA_STOPWATCH " Show time", &m_statSampleTime );
+                ImGui::SameLine();
+                ImGui::Spacing();
+                ImGui::SameLine();
+                ImGui::Checkbox( ICON_FA_EYE_SLASH " Hide unknown", &m_statHideUnknown );
+                ImGui::SameLine();
+                ImGui::Spacing();
+                ImGui::SameLine();
+                ImGui::Checkbox( ICON_FA_SITEMAP " Inlines", &m_statSeparateInlines );
+                ImGui::SameLine();
+                ImGui::Spacing();
+                ImGui::SameLine();
+                ImGui::Checkbox( ICON_FA_AT " Address", &m_statShowAddress );
+                ImGui::SameLine();
+                ImGui::Spacing();
+                ImGui::SameLine();
+                if( ImGui::Checkbox( ICON_FA_HAT_WIZARD " Include kernel", &m_statShowKernel ))
+                {
+                    m_findZone.samples.scheduleUpdate = true;
+                }
+            }
+
+            if( !m_findZone.samples.enabled )
+            {
+                m_findZone.samples.enabled = true;
+                m_findZone.samples.scheduleUpdate = true;
+                m_findZone.scheduleResetMatch = true;
+            }
+            
+            Vector<SymList> data;
+            data.reserve( m_findZone.samples.counts.size() );
+            for( auto it: m_findZone.samples.counts ) data.push_back_no_space_check( it );
+            int64_t timeRange = ( m_findZone.selGroup != m_findZone.Unselected ) ? m_findZone.selTotal : m_findZone.total;
+            DrawSamplesStatistics( data, timeRange, AccumulationMode::SelfOnly );
+
+            ImGui::TreePop();
+        } 
+        else
+        {
+            if( m_findZone.samples.enabled )
+            {
+                m_findZone.samples.enabled = false;
+                m_findZone.samples.scheduleUpdate = false;
+                m_findZone.samples.counts = Vector<SymList>();
+                for( auto& it: m_findZone.groups ) it.second.zonesTids.clear();
             }
         }
 

--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -10862,6 +10862,7 @@ void View::DrawFindZone()
                 threadZones->reserve( 1024 );
             }
             threadZones->push_back_non_empty(ev.Zone());
+            m_findZone.samplesCache.scheduleUpdate = true;
         }
         m_findZone.processed = zptr - zones.data();
 
@@ -11099,50 +11100,75 @@ void View::DrawFindZone()
                 ImGui::SameLine();
                 ImGui::Spacing();
                 ImGui::SameLine();
-                ImGui::Checkbox( ICON_FA_HAT_WIZARD " Include kernel", &m_statShowKernel );
+                if( ImGui::Checkbox( ICON_FA_HAT_WIZARD " Include kernel", &m_statShowKernel ))
+                {
+                    m_findZone.samplesCache.scheduleUpdate = true;
+                }
             }
             
-            for (auto& t: m_findZone.threads) {
-                pdqsort_branchless( t.second.begin(), t.second.end(), []( const auto& lhs, const auto& rhs ) { return (*lhs).Start() < (*rhs).Start(); } );
-            }
+            if (m_findZone.samplesCache.scheduleUpdate && !m_findZone.scheduleResetMatch) {
+                m_findZone.samplesCache.scheduleUpdate = false;
 
-            const auto& symMap = m_worker.GetSymbolMap();
-            Vector<SymList> data;
-            data.reserve( symMap.size() );
-            for( auto& v : symMap )
-            {
-                bool pass = ( m_statShowKernel || ( v.first >> 63 ) == 0 );
-                if( !pass && v.second.size.Val() == 0 )
-                {
-                    const auto parentAddr = m_worker.GetSymbolForAddress( v.first );
-                    if( parentAddr != 0 )
+                m_findZone.samplesCache.timeRange = 0;
+                for (auto& t: m_findZone.samplesCache.threads) {
+                    pdqsort_branchless( t.second.begin(), t.second.end(), []( const auto& lhs, const auto& rhs ) { return (*lhs).Start() < (*rhs).Start(); } );
+                    int64_t prevEnd = 0;
+                    for (const auto& it : t.second)
                     {
-                        auto pit = symMap.find( parentAddr );
-                        if( pit != symMap.end() )
-                        {
-                            pass = ( m_statShowKernel || ( parentAddr >> 63 ) == 0 );
+                        int64_t start =  (*it).Start();
+                        int64_t end =  (*it).End();
+                        if (start < prevEnd) start = prevEnd;
+                        if (start < end) {
+                            prevEnd = end;
+                            m_findZone.samplesCache.timeRange += end - start;
                         }
                     }
                 }
-                if (!pass) continue;
 
-                auto samples = m_worker.GetSamplesForSymbol( v.first );
-                if( !samples )  continue;
+                const auto& symMap = m_worker.GetSymbolMap();
+                m_findZone.samplesCache.counts.clear();
+                m_findZone.samplesCache.counts.reserve( symMap.size() );
 
-                uint32_t count = 0;
-                for (auto it: *samples) {
-                    const auto time = it.time.Val();
-                    const auto& zones = m_findZone.threads[it.thread];
-                    auto z = std::lower_bound( zones.begin(), zones.end(), time, [] ( const auto& l, const auto& r ) { return l->Start() < r; } );
-                    if( z == zones.end() ) continue;
-                    if (z != zones.begin()) --z;
-                    if (time >= (*z)->Start() && time < (*z)->End())
-                        count++;
+                for( auto& v : symMap )
+                {
+                    bool pass = ( m_statShowKernel || ( v.first >> 63 ) == 0 );
+                    if( !pass && v.second.size.Val() == 0 )
+                    {
+                        const auto parentAddr = m_worker.GetSymbolForAddress( v.first );
+                        if( parentAddr != 0 )
+                        {
+                            auto pit = symMap.find( parentAddr );
+                            if( pit != symMap.end() )
+                            {
+                                pass = ( m_statShowKernel || ( parentAddr >> 63 ) == 0 );
+                            }
+                        }
+                    }
+                    if (!pass) continue;
+
+                    auto samples = m_worker.GetSamplesForSymbol( v.first );
+                    if( !samples )  continue;
+
+                    uint32_t count = 0;
+                    for (auto it: *samples) {
+                        const auto time = it.time.Val();
+                        const auto& zones = m_findZone.samplesCache.threads[it.thread];
+                        auto z = std::lower_bound( zones.begin(), zones.end(), time, [] ( const auto& l, const auto& r ) { return l->Start() < r; } );
+                        if( z == zones.end() ) continue;
+                        if (z != zones.begin()) --z;
+                        if (time >= (*z)->Start() && time < (*z)->End())
+                            count++;
+                    }
+                    if (count > 0)
+                        m_findZone.samplesCache.counts.push_back_no_space_check( SymList { v.first, 0, count } );
                 }
-                if (count > 0)
-                    data.push_back_no_space_check( SymList { v.first, 0, count } );
             }
-            DrawSamplesStatistics(data, m_worker.GetLastTime(), AccumulationMode::SelfOnly);
+
+            Vector<SymList> data;
+            data.reserve(m_findZone.samplesCache.counts.size());
+            for (auto it: m_findZone.samplesCache.counts) data.push_back_no_space_check(it);
+            DrawSamplesStatistics(data, m_findZone.samplesCache.timeRange, AccumulationMode::SelfOnly);
+
             ImGui::TreePop();
         } 
 

--- a/server/TracyView.hpp
+++ b/server/TracyView.hpp
@@ -153,6 +153,13 @@ private:
         bool highlight;
     };
 
+    struct SymList
+    {
+        uint64_t symAddr;
+        uint32_t incl, excl;
+        uint32_t count;
+    };
+
     void InitMemory();
     void InitTextEditor( ImFont* font );
 
@@ -196,6 +203,7 @@ private:
     void DrawFindZone();
     void AccumulationModeComboBox();
     void DrawStatistics();
+    void DrawSamplesStatistics(Vector<SymList>& data, int64_t timeRange);
     void DrawMemory();
     void DrawAllocList();
     void DrawCompare();

--- a/server/TracyView.hpp
+++ b/server/TracyView.hpp
@@ -516,6 +516,7 @@ private:
         {
             uint16_t id;
             Vector<short_ptr<ZoneEvent>> zones;
+            Vector<uint16_t> zonesTids;
             int64_t time = 0;
         };
 
@@ -563,12 +564,10 @@ private:
         } binCache;
 
         struct {
-            unordered_flat_map<uint16_t, Vector<short_ptr<ZoneEvent>> > threads;
             Vector<SymList> counts;
-            int64_t timeRange = 0;
             bool scheduleUpdate = false;
-            bool needZonesPerThread = false;
-        } samplesCache;
+            bool enabled = false;
+        } samples;
 
         void Reset()
         {
@@ -595,8 +594,6 @@ private:
         {
             ResetSelection();
             groups.clear();
-            samplesCache.threads.clear();
-            samplesCache.counts.clear();
             processed = 0;
             groupId = 0;
             selCs = 0;
@@ -613,6 +610,8 @@ private:
             selTotal = 0;
             selTime = 0;
             binCache.numBins = -1;
+            samples.counts.clear();
+            samples.scheduleUpdate = true;
         }
 
         void ShowZone( int16_t srcloc, const char* name )

--- a/server/TracyView.hpp
+++ b/server/TracyView.hpp
@@ -203,7 +203,7 @@ private:
     void DrawFindZone();
     void AccumulationModeComboBox();
     void DrawStatistics();
-    void DrawSamplesStatistics(Vector<SymList>& data, int64_t timeRange);
+    void DrawSamplesStatistics(Vector<SymList>& data, int64_t timeRange, AccumulationMode accumulationMode);
     void DrawMemory();
     void DrawAllocList();
     void DrawCompare();
@@ -523,6 +523,7 @@ private:
         bool ignoreCase = false;
         std::vector<int16_t> match;
         unordered_flat_map<uint64_t, Group> groups;
+        unordered_flat_map<uint16_t, Vector<short_ptr<ZoneEvent>> > threads;
         size_t processed;
         uint16_t groupId;
         int selMatch = 0;
@@ -587,6 +588,7 @@ private:
         {
             ResetSelection();
             groups.clear();
+            threads.clear();
             processed = 0;
             groupId = 0;
             selCs = 0;

--- a/server/TracyView.hpp
+++ b/server/TracyView.hpp
@@ -523,7 +523,6 @@ private:
         bool ignoreCase = false;
         std::vector<int16_t> match;
         unordered_flat_map<uint64_t, Group> groups;
-        unordered_flat_map<uint16_t, Vector<short_ptr<ZoneEvent>> > threads;
         size_t processed;
         uint16_t groupId;
         int selMatch = 0;
@@ -563,6 +562,13 @@ private:
             ptrdiff_t distEnd;
         } binCache;
 
+        struct {
+            unordered_flat_map<uint16_t, Vector<short_ptr<ZoneEvent>> > threads;
+            Vector<SymList> counts;
+            int64_t timeRange = 0;
+            bool scheduleUpdate = false;
+        } samplesCache;
+
         void Reset()
         {
             ResetMatch();
@@ -588,7 +594,8 @@ private:
         {
             ResetSelection();
             groups.clear();
-            threads.clear();
+            samplesCache.threads.clear();
+            samplesCache.counts.clear();
             processed = 0;
             groupId = 0;
             selCs = 0;

--- a/server/TracyView.hpp
+++ b/server/TracyView.hpp
@@ -567,6 +567,7 @@ private:
             Vector<SymList> counts;
             int64_t timeRange = 0;
             bool scheduleUpdate = false;
+            bool needZonesPerThread = false;
         } samplesCache;
 
         void Reset()

--- a/server/TracyView.hpp
+++ b/server/TracyView.hpp
@@ -576,6 +576,7 @@ private:
             selMatch = 0;
             selGroup = Unselected;
             highlight.active = false;
+            samples.counts.clear();
         }
 
         void ResetMatch()
@@ -610,7 +611,6 @@ private:
             selTotal = 0;
             selTime = 0;
             binCache.numBins = -1;
-            samples.counts.clear();
             samples.scheduleUpdate = true;
         }
 


### PR DESCRIPTION
Give a view of the samples by "zone" to get further insight on the time spent in the instrumented zones without additional instrumentation.
(using all the samples from identical "source locations" of the whole capture)

not sure if it's done properly (I'm not very familiar with the code base, nor with the stl...)  but it seems to work for me.
~~it is limited to exclusive samples, couldn't get the inclusive to work.~~

note: It is also possible to implement along with other filtering options, but it is slow (need to examine all individual samples in the range and find the matching zone) and probably not that useful.