### PR TITLE
Undo my previous change regarding zig cc.

### DIFF
--- a/client/TracySysTrace.cpp
+++ b/client/TracySysTrace.cpp
@@ -52,21 +52,6 @@ static constexpr int GetSamplingPeriod()
 #    include "TracyProfiler.hpp"
 #    include "TracyThread.hpp"
 
-// Note: Mingw-w64 currently does not provide below declarations so we add them here.
-#ifdef __MINGW64__
-
-#define EVENT_FILTER_TYPE_EVENT_ID 0x80000200
-#define EVENT_ENABLE_PROPERTY_IGNORE_KEYWORD_0 0x010
-
-typedef struct _EVENT_FILTER_EVENT_ID {
-  BOOLEAN FilterIn;
-  UCHAR   Reserved;
-  USHORT  Count;
-  USHORT  Events[ANYSIZE_ARRAY];
-} EVENT_FILTER_EVENT_ID, *PEVENT_FILTER_EVENT_ID;
-
-#endif
-
 namespace tracy
 {
 


### PR DESCRIPTION
-D_WIN32_WINNT=0x601 must be defined when building TracyClient.cpp for mingw-w64 on Windows. In that case definitions I've added in my previous PR are not needed.

Sorry for the confusion.