### PR TITLE
Expose TRACY_MANUAL_LIFETIME APIs to C API clients 

### DIFF
--- a/TracyC.h
+++ b/TracyC.h
@@ -101,6 +101,12 @@ struct ___tracy_c_zone_context
 // This struct, as visible to user, is immutable, so treat it as if const was declared here.
 typedef /*const*/ struct ___tracy_c_zone_context TracyCZoneCtx;
 
+
+#ifdef TRACY_MANUAL_LIFETIME
+TRACY_API void ___tracy_startup_profiler(void);
+TRACY_API void ___tracy_shutdown_profiler(void);
+#endif
+
 TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz );
 TRACY_API uint64_t ___tracy_alloc_srcloc_name( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz );
 

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -3602,6 +3602,18 @@ TRACY_API uint64_t ___tracy_alloc_srcloc_name( uint32_t line, const char* source
     return tracy::Profiler::AllocSourceLocation( line, source, sourceSz, function, functionSz, name, nameSz );
 }
 
+#  ifdef TRACY_MANUAL_LIFETIME
+TRACY_API void ___tracy_startup_profiler( void )
+{
+    tracy::StartupProfiler();
+}
+
+TRACY_API void ___tracy_shutdown_profiler( void )
+{
+    tracy::ShutdownProfiler();
+}
+#  endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -1793,7 +1793,8 @@ You can collect call stacks of zones and memory allocation events, as described 
 Tracy C API exposes functions with the \texttt{\_\_\_tracy} prefix that may be used to write bindings to other programming languages. Most of the functions available are a counterpart to macros described in section~\ref{capi}. Some functions do not have macro equivalents and are dedicated expressly for binding implementation purposes. This includes the following:
 
 \begin{itemize}
-\item \texttt{\_\_\_tracy\_init\_thread(void)}
+\item \texttt{\_\_\_tracy\_startup\_profiler(void)}
+\item \texttt{\_\_\_tracy\_shutdown\_profiler(void)}
 \item \texttt{\_\_\_tracy\_alloc\_srcloc(uint32\_t line, const char* source, size\_t sourceSz, const char* function, size\_t functionSz)}
 \item \texttt{\_\_\_tracy\_alloc\_srcloc\_name(uint32\_t line, const char* source, size\_t sourceSz, const char* function, size\_t functionSz, const char* name, size\_t nameSz)}
 \end{itemize}
@@ -1808,11 +1809,6 @@ return an \texttt{uint64\_t} source location identifier corresponding to an \emp
 location}. As these functions do not require for the provided string data to be available after they
 return, calling code is free to deallocate them at any time afterwards. This way the string
 lifetime requirements described in section~\ref{textstrings} are relaxed.
-
-Before the \texttt{\_\_\_tracy\_alloc\_*} functions are called on a non-main thread for the first
-time, care should be taken to ensure that \texttt{\_\_\_tracy\_init\_thread} has been called first.
-The \texttt{\_\_\_tracy\_init\_thread} function initializes per-thread structures Tracy uses and
-can be safely called multiple times.
 
 The \texttt{uint64\_t} return value from allocation functions must be passed to one of the zone
 begin functions:


### PR DESCRIPTION
These are extremely useful for ecosystems such as Rust. There are a
couple of reasons why:

1. Rust strongly advises against relying on life before/after main, as
   it is difficult to reason about. Most users working in Rust will
   generally be quite surprised when encountering this concept.
2. Rust and its package manager makes it easy to use packages (crates)
   and somewhat less straightforward to consider the implications of
   including a dependency.

   In case of the `rust_tracy_client` set of packages, I currently have
   to warn throughout the documentation of the package that simply
   adding a dependency on the bindings package is sufficient to
   potentially accidentally broadcast a lot of information about the
   instrumented binary to the broader world. This seems like a major
   footgun given how easy is it to forget about having added this
   dependency.

Ability to manually manage the lifetime of the profiler would be a great
solution to these problems.

---

Some things to think about:

1. We could approach the implementation by doing something along the lines of

```
#define StartupProfiler() ___tracy_startup_profiler()
#define ShutdownProfiler() ___tracy_shutdown_profiler()
```

or some such to avoid a wrapper function.

2. Shed colour: `___tracy_startup`, `___tracy_shutdown` sound as descriptive as the variants with `profiler` in it.