### PR TITLE
Removing explicit compiler define check for GL_TIMESTAMP

### DIFF
--- a/TracyOpenGL.hpp
+++ b/TracyOpenGL.hpp
@@ -31,10 +31,6 @@ public:
 
 #else
 
-#if !defined GL_TIMESTAMP && !defined GL_TIMESTAMP_EXT
-#  error "You must include OpenGL 3.2 headers before including TracyOpenGL.hpp"
-#endif
-
 #include <atomic>
 #include <assert.h>
 #include <stdlib.h>


### PR DESCRIPTION
Some OpenGL binding frameworks (glbindings (https://github.com/cginternals/glbinding) in my example) are not defining the OpenGL constants using preprocessor defines but using enum values instead.  So even when I include the file before, this check will fail as it is not a preprocessor define.  Just defining it by hand before the TracyOpenGL.h include does not work either as it leads to further compile errors down the line because of name collisions