### PR TITLE
Call SymLoadModuleEx for modules loaded after init (Fixes #293)

### DIFF
--- a/client/TracyCallstack.cpp
+++ b/client/TracyCallstack.cpp
@@ -296,6 +296,8 @@ static const char* GetModuleName( uint64_t addr )
                     const auto res = GetModuleFileNameA( mod[i], name, 1021 );
                     if( res > 0 )
                     {
+                        // since this is the first time we encounter this module, load its symbols (needed for modules loaded after SymInitialize)
+                        SymLoadModuleEx(proc, NULL, name, NULL, (DWORD64)info.lpBaseOfDll, info.SizeOfImage, NULL, 0);
                         auto ptr = name + res;
                         while( ptr > name && *ptr != '\\' && *ptr != '/' ) ptr--;
                         if( ptr > name ) ptr++;


### PR DESCRIPTION
Symbols were not loaded if the module is loaded dynamically after the `SymInitialize` call.
This may stall the symbol resolver thread a bit the first time a module is loaded.