### PR TITLE
CMake: Mark include directories as SYSTEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(Threads REQUIRED)
 
 add_library(TracyClient TracyClient.cpp)
 target_compile_features(TracyClient PUBLIC cxx_std_11)
-target_include_directories(TracyClient PUBLIC 
+target_include_directories(TracyClient SYSTEM PUBLIC 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> 
     $<INSTALL_INTERFACE:include>)
 target_link_libraries(


### PR DESCRIPTION
This usually prevents the compiler from emitting warnings about stuff it found in
the included files.
Since the CMakeLists.txt seems to be exclusively meant for code that is making use
of Tracy rather than Tracy itself using it to build, silencing the warnings should probably
be what most folks would want.

This will prevent things like #126