### PR TITLE
Add new TRACY_ON_DEMAND_GPU_SYNC define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ endmacro()
 
 set_option(TRACY_ENABLE "Enable profiling" ON)
 set_option(TRACY_ON_DEMAND "On-demand profiling" OFF)
+set_option(TRACY_ON_DEMAND_GPU_SYNC "Synchronize with GPU on first TracyGpuCollect, drop any previous measurements (OpenGL only)" OFF)
 set_option(TRACY_CALLSTACK "Collect call stacks" OFF)
 set_option(TRACY_ONLY_LOCALHOST "Only listen on the localhost interface" OFF)
 set_option(TRACY_NO_BROADCAST "Disable client discovery by broadcast to local network" OFF)

--- a/TracyOpenGL.hpp
+++ b/TracyOpenGL.hpp
@@ -190,10 +190,10 @@ private:
         MemWrite( &item->gpuNewContext.flags, uint8_t(0) );
         MemWrite( &item->gpuNewContext.type, GpuContextType::OpenGl );
 
-#if defined( TRACY_ON_DEMAND )
-        GetProfiler().DeferItem( *item );
-#elif defined( TRACY_ON_DEMAND_GPU_SYNC )
+#if defined( TRACY_ON_DEMAND_GPU_SYNC )
         m_isContextReady = true;
+#elif defined( TRACY_ON_DEMAND )
+        GetProfiler().DeferItem( *item );
 #endif
 
         TracyLfqCommit;

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -1379,6 +1379,7 @@ To mark that a separate memory pool is to be tracked you should use the named ve
 Tracy provides bindings for profiling OpenGL, Vulkan, Direct3D 11, Direct3D 12, and OpenCL execution time on GPU.
 
 Note that the CPU and GPU timers may be unsynchronized unless you create a calibrated context, but the availability of calibrated contexts is limited. You can try to correct the desynchronization of uncalibrated contexts in the profiler's options (section~\ref{options}).
+In on-demand mode, by defining the macro \texttt{TRACY\_ON\_DEMAND\_GPU\_SYNC}, you can ask tracy to do re-synchronize the clock on the first \texttt{tracyCollect} call. However it will not do any measurements until \texttt{tracyCollect} is called. While this does not fix drift issues, it ensures that the GPU timings offset is not too big when starting a new capture. This is only available for the OpenGL backend.
 
 \begin{bclogo}[
 noborder=true,

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -1379,6 +1379,7 @@ To mark that a separate memory pool is to be tracked you should use the named ve
 Tracy provides bindings for profiling OpenGL, Vulkan, Direct3D 11, Direct3D 12, and OpenCL execution time on GPU.
 
 Note that the CPU and GPU timers may be unsynchronized unless you create a calibrated context, but the availability of calibrated contexts is limited. You can try to correct the desynchronization of uncalibrated contexts in the profiler's options (section~\ref{options}).
+
 In on-demand mode, by defining the macro \texttt{TRACY\_ON\_DEMAND\_GPU\_SYNC}, you can ask tracy to do re-synchronize the clock on the first \texttt{tracyCollect} call. However it will not do any measurements until \texttt{tracyCollect} is called. While this does not fix drift issues, it ensures that the GPU timings offset is not too big when starting a new capture. This is only available for the OpenGL backend.
 
 \begin{bclogo}[


### PR DESCRIPTION
When using the tracy `TRACY_ON_DEMAND` mode, it is ok in most cases to drop measurements and do a GPU clock synchronization (that may stall, sometimes up to 10ms) during the first `tracyCollect`. This is not enabled by default in the `CMakeLists.txt` for backward compatibility and because it may be a bit intrusive.
This commit also makes the OpenGL tracy `TracyGpuZone*` a tiny bit more efficient by not calling the threadlocal `GetGpuCtx()` multiple times. It is also more resilient if no context has been declared on this thread. This means that the application will not crash if a context was used on different threads even though declared only on one (thus `GetGpuCtx().ptr == nullptr`). Tracy does not support  this scenario, so on one hand this helps users by not crashing, on the other it is an error that is now silent.

This is only one way to implement (the other would require changes to the communication protocol), and I'd understand if this was not getting merged.