### PR TITLE
Actually check for the required feature

### DIFF
--- a/TracyD3D12.hpp
+++ b/TracyD3D12.hpp
@@ -91,10 +91,8 @@ namespace tracy
 			{
 				D3D12_FEATURE_DATA_D3D12_OPTIONS3 featureData{};
 
-				if (FAILED(device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS3, &featureData, sizeof(featureData))))
-				{
-					assert(false && "Platform does not support profiling of copy queues.");
-				}
+				bool Success = SUCCEEDED(device->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS3, &featureData, sizeof(featureData)));
+				assert(Success && featureData.CopyQueueTimestampQueriesSupported && "Platform does not support profiling of copy queues.");
 			}
 
 			uint64_t timestampFrequency;


### PR DESCRIPTION
It's not enough to only call the CheckFeatureSupport, but we also have to check the actual CopyQueueTimestampQueriesSupported field of the featureData structure.