### PR TITLE
Fix MSVC warnings

### DIFF
--- a/client/TracyCallstack.cpp
+++ b/client/TracyCallstack.cpp
@@ -340,7 +340,7 @@ CallstackSymbolData DecodeSymbolAddress( uint64_t ptr )
 
 CallstackSymbolData DecodeCodeAddress( uint64_t ptr )
 {
-    CallstackSymbolData sym;
+    CallstackSymbolData sym = {};
     const auto proc = GetCurrentProcess();
     bool done = false;
 

--- a/client/tracy_SPSCQueue.h
+++ b/client/tracy_SPSCQueue.h
@@ -30,6 +30,11 @@ SOFTWARE.
 
 #include "../common/TracyAlloc.hpp"
 
+#if defined (_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4324)
+#endif
+
 namespace tracy {
 
 template <typename T> class SPSCQueue {
@@ -134,3 +139,7 @@ private:
   char padding_[kCacheLineSize - sizeof(writeIdxCache_)];
 };
 } // namespace rigtorp
+
+#if defined (_MSC_VER)
+#pragma warning(pop)
+#endif


### PR DESCRIPTION
The code as is produces the following warnings on MSVC with VS2019 toolchain using /W4 flags:
`
\tracy\client\tracy_SPSCQueue.h(132,1): warning C4324: 'tracy::SPSCQueue<tracy::Profiler::SymbolQueueItem>': structure was padded due to alignment specifier
\tracy\client\TracyProfiler.hpp(871): message : see reference to class template instantiation 'tracy::SPSCQueue<tracy::Profiler::SymbolQueueItem>' being compiled
\tracy\client\tracy_SPSCQueue.h(133,1): warning C4324: 'tracy::SPSCQueue<tracy::Profiler::SymbolQueueItem>': structure was padded due to alignment specifier
\tracy\client\tracy_SPSCQueue.h(134,1): warning C4324: 'tracy::SPSCQueue<tracy::Profiler::SymbolQueueItem>': structure was padded due to alignment specifier
\tracy\client\tracy_SPSCQueue.h(135,1): warning C4324: 'tracy::SPSCQueue<tracy::Profiler::SymbolQueueItem>': structure was padded due to alignment specifier
\tracy\client\TracyCallstack.cpp(417): warning C4701: potentially uninitialized local variable 'sym' used
`

This PR silences the first 4 warnings as this is intended behaviour and fixes the last one by initializing the variable with zeros.