### PR TITLE
Make Tracy usable in UWP applications

### DIFF
--- a/client/TracyCallstack.h
+++ b/client/TracyCallstack.h
@@ -6,7 +6,11 @@
 #endif
 
 #if defined _WIN32
-#  define TRACY_HAS_CALLSTACK 1
+#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
+      !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#  else
+#    define TRACY_HAS_CALLSTACK 1
+#  endif
 #elif defined __ANDROID__
 #  if !defined __arm__ || __ANDROID_API__ >= 21
 #    define TRACY_HAS_CALLSTACK 2

--- a/client/TracyCallstack.h
+++ b/client/TracyCallstack.h
@@ -6,9 +6,8 @@
 #endif
 
 #if defined _WIN32
-#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
-      !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#  else
+#  include "../common/TracyUwp.hpp"
+#  ifndef TRACY_UWP
 #    define TRACY_HAS_CALLSTACK 1
 #  endif
 #elif defined __ANDROID__

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -450,22 +450,22 @@ static const char* GetHostInfo()
 #  endif
     if( !GetVersion )
     {
-#    ifdef __MINGW32__
+#  ifdef __MINGW32__
         ptr += sprintf( ptr, "OS: Windows (MingW)\n" );
-#    else
+#  else
         ptr += sprintf( ptr, "OS: Windows\n" );
-#    endif
+#  endif
     }
     else
     {
         RTL_OSVERSIONINFOW ver = { sizeof( RTL_OSVERSIONINFOW ) };
         GetVersion( &ver );
 
-#    ifdef __MINGW32__
+#  ifdef __MINGW32__
         ptr += sprintf( ptr, "OS: Windows %i.%i.%i (MingW)\n", (int)ver.dwMajorVersion, (int)ver.dwMinorVersion, (int)ver.dwBuildNumber );
-#    else
+#  else
         ptr += sprintf( ptr, "OS: Windows %i.%i.%i\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber );
-#    endif
+#  endif
     }
 #elif defined __linux__
     struct utsname utsName;

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -9,11 +9,7 @@
 #  include <tlhelp32.h>
 #  include <inttypes.h>
 #  include <intrin.h>
-
-#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
-      !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#    define TRACY_ON_UWP
-#  endif
+#  include "../common/TracyUwp.hpp"
 #else
 #  include <sys/time.h>
 #  include <sys/param.h>
@@ -319,7 +315,7 @@ static void InitFailure( const char* msg )
     }
     else
     {
-#  if !defined TRACY_ON_UWP
+#  ifndef TRACY_UWP
         MessageBoxA( nullptr, msg, "Tracy Profiler initialization failure", MB_ICONSTOP );
 #  endif
     }
@@ -447,11 +443,12 @@ static const char* GetHostInfo()
     static char buf[1024];
     auto ptr = buf;
 #if defined _WIN32
-#  if defined TRACY_ON_UWP
-    ptr += sprintf(ptr, "OS: Windows 10\n");
+#  ifdef TRACY_UWP
+    auto GetVersion = &::GetVersionEx;
 #  else
-    t_RtlGetVersion RtlGetVersion = (t_RtlGetVersion)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "RtlGetVersion" );
-    if( !RtlGetVersion )
+    auto GetVersion = (t_RtlGetVersion)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "RtlGetVersion" );
+#  endif
+    if( !GetVersion )
     {
 #    ifdef __MINGW32__
         ptr += sprintf( ptr, "OS: Windows (MingW)\n" );
@@ -462,7 +459,7 @@ static const char* GetHostInfo()
     else
     {
         RTL_OSVERSIONINFOW ver = { sizeof( RTL_OSVERSIONINFOW ) };
-        RtlGetVersion( &ver );
+        GetVersion( &ver );
 
 #    ifdef __MINGW32__
         ptr += sprintf( ptr, "OS: Windows %i.%i.%i (MingW)\n", (int)ver.dwMajorVersion, (int)ver.dwMinorVersion, (int)ver.dwBuildNumber );
@@ -470,7 +467,6 @@ static const char* GetHostInfo()
         ptr += sprintf( ptr, "OS: Windows %i.%i.%i\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber );
 #    endif
     }
-#  endif
 #elif defined __linux__
     struct utsname utsName;
     uname( &utsName );
@@ -519,15 +515,15 @@ static const char* GetHostInfo()
     char hostname[512];
     gethostname( hostname, 512 );
 
-#  if defined TRACY_ON_UWP
-    ptr += sprintf(ptr, "Hostname: %s\n", hostname);
+#  ifdef TRACY_UWP
+    const char* user = "";
 #  else
     DWORD userSz = UNLEN+1;
     char user[UNLEN+1];
     GetUserNameA( user, &userSz );
+#  endif
 
     ptr += sprintf( ptr, "User: %s@%s\n", user, hostname );
-#  endif
 #else
     char hostname[_POSIX_HOST_NAME_MAX]{};
     char user[_POSIX_LOGIN_NAME_MAX]{};
@@ -722,7 +718,7 @@ static BroadcastMessage& GetBroadcastMessage( const char* procname, size_t pnsz,
     return msg;
 }
 
-#if defined _WIN32 && !defined TRACY_ON_UWP
+#if defined _WIN32 && !defined TRACY_UWP
 static DWORD s_profilerThreadId = 0;
 static char s_crashText[1024];
 
@@ -1397,7 +1393,7 @@ void Profiler::SpawnWorkerThreads()
     new(s_symbolThread) Thread( LaunchSymbolWorker, this );
 #endif
 
-#if defined _WIN32 && !defined TRACY_ON_UWP
+#if defined _WIN32 && !defined TRACY_UWP
     s_profilerThreadId = GetThreadId( s_thread->Handle() );
     m_exceptionHandler = AddVectoredExceptionHandler( 1, CrashFilter );
 #endif
@@ -1431,7 +1427,7 @@ Profiler::~Profiler()
 {
     m_shutdown.store( true, std::memory_order_relaxed );
 
-#if defined _WIN32 && !defined TRACY_ON_UWP
+#if defined _WIN32 && !defined TRACY_UWP
     if( m_crashHandlerInstalled ) RemoveVectoredExceptionHandler( m_exceptionHandler );
 #endif
 
@@ -3549,7 +3545,7 @@ void Profiler::ReportTopology()
     };
 
 #if defined _WIN32
-#  if defined TRACY_ON_UWP
+#  ifdef TRACY_UWP
     t_GetLogicalProcessorInformationEx _GetLogicalProcessorInformationEx = &::GetLogicalProcessorInformationEx;
 #  else
     t_GetLogicalProcessorInformationEx _GetLogicalProcessorInformationEx = (t_GetLogicalProcessorInformationEx)GetProcAddress( GetModuleHandleA( "kernel32.dll" ), "GetLogicalProcessorInformationEx" );

--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -9,6 +9,11 @@
 #  include <tlhelp32.h>
 #  include <inttypes.h>
 #  include <intrin.h>
+
+#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
+      !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#    define TRACY_ON_UWP
+#  endif
 #else
 #  include <sys/time.h>
 #  include <sys/param.h>
@@ -314,7 +319,9 @@ static void InitFailure( const char* msg )
     }
     else
     {
+#  if !defined TRACY_ON_UWP
         MessageBoxA( nullptr, msg, "Tracy Profiler initialization failure", MB_ICONSTOP );
+#  endif
     }
 #else
     fprintf( stderr, "Tracy Profiler initialization failure: %s\n", msg );
@@ -440,26 +447,30 @@ static const char* GetHostInfo()
     static char buf[1024];
     auto ptr = buf;
 #if defined _WIN32
+#  if defined TRACY_ON_UWP
+    ptr += sprintf(ptr, "OS: Windows 10\n");
+#  else
     t_RtlGetVersion RtlGetVersion = (t_RtlGetVersion)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "RtlGetVersion" );
     if( !RtlGetVersion )
     {
-#  ifdef __MINGW32__
+#    ifdef __MINGW32__
         ptr += sprintf( ptr, "OS: Windows (MingW)\n" );
-#  else
+#    else
         ptr += sprintf( ptr, "OS: Windows\n" );
-#  endif
+#    endif
     }
     else
     {
         RTL_OSVERSIONINFOW ver = { sizeof( RTL_OSVERSIONINFOW ) };
         RtlGetVersion( &ver );
 
-#  ifdef __MINGW32__
+#    ifdef __MINGW32__
         ptr += sprintf( ptr, "OS: Windows %i.%i.%i (MingW)\n", (int)ver.dwMajorVersion, (int)ver.dwMinorVersion, (int)ver.dwBuildNumber );
-#  else
+#    else
         ptr += sprintf( ptr, "OS: Windows %i.%i.%i\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber );
-#  endif
+#    endif
     }
+#  endif
 #elif defined __linux__
     struct utsname utsName;
     uname( &utsName );
@@ -508,11 +519,15 @@ static const char* GetHostInfo()
     char hostname[512];
     gethostname( hostname, 512 );
 
+#  if defined TRACY_ON_UWP
+    ptr += sprintf(ptr, "Hostname: %s\n", hostname);
+#  else
     DWORD userSz = UNLEN+1;
     char user[UNLEN+1];
     GetUserNameA( user, &userSz );
 
     ptr += sprintf( ptr, "User: %s@%s\n", user, hostname );
+#  endif
 #else
     char hostname[_POSIX_HOST_NAME_MAX]{};
     char user[_POSIX_LOGIN_NAME_MAX]{};
@@ -707,7 +722,7 @@ static BroadcastMessage& GetBroadcastMessage( const char* procname, size_t pnsz,
     return msg;
 }
 
-#if defined _WIN32
+#if defined _WIN32 && !defined TRACY_ON_UWP
 static DWORD s_profilerThreadId = 0;
 static char s_crashText[1024];
 
@@ -1382,7 +1397,7 @@ void Profiler::SpawnWorkerThreads()
     new(s_symbolThread) Thread( LaunchSymbolWorker, this );
 #endif
 
-#if defined _WIN32
+#if defined _WIN32 && !defined TRACY_ON_UWP
     s_profilerThreadId = GetThreadId( s_thread->Handle() );
     m_exceptionHandler = AddVectoredExceptionHandler( 1, CrashFilter );
 #endif
@@ -1416,7 +1431,7 @@ Profiler::~Profiler()
 {
     m_shutdown.store( true, std::memory_order_relaxed );
 
-#if defined _WIN32
+#if defined _WIN32 && !defined TRACY_ON_UWP
     if( m_crashHandlerInstalled ) RemoveVectoredExceptionHandler( m_exceptionHandler );
 #endif
 
@@ -3534,7 +3549,11 @@ void Profiler::ReportTopology()
     };
 
 #if defined _WIN32
+#  if defined TRACY_ON_UWP
+    t_GetLogicalProcessorInformationEx _GetLogicalProcessorInformationEx = &::GetLogicalProcessorInformationEx;
+#  else
     t_GetLogicalProcessorInformationEx _GetLogicalProcessorInformationEx = (t_GetLogicalProcessorInformationEx)GetProcAddress( GetModuleHandleA( "kernel32.dll" ), "GetLogicalProcessorInformationEx" );
+#  endif
     if( !_GetLogicalProcessorInformationEx ) return;
 
     DWORD psz = 0;

--- a/client/TracySysTrace.hpp
+++ b/client/TracySysTrace.hpp
@@ -2,9 +2,8 @@
 #define __TRACYSYSTRACE_HPP__
 
 #if !defined TRACY_NO_SYSTEM_TRACING && ( defined _WIN32 || defined __linux__ )
-#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
-      !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#  else
+#  include "../common/TracyUwp.hpp"
+#  ifndef TRACY_UWP
 #    define TRACY_HAS_SYSTEM_TRACING
 #  endif
 #endif

--- a/client/TracySysTrace.hpp
+++ b/client/TracySysTrace.hpp
@@ -2,7 +2,11 @@
 #define __TRACYSYSTRACE_HPP__
 
 #if !defined TRACY_NO_SYSTEM_TRACING && ( defined _WIN32 || defined __linux__ )
-#  define TRACY_HAS_SYSTEM_TRACING
+#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
+      !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#  else
+#    define TRACY_HAS_SYSTEM_TRACING
+#  endif
 #endif
 
 #ifdef TRACY_HAS_SYSTEM_TRACING

--- a/common/TracySystem.cpp
+++ b/common/TracySystem.cpp
@@ -10,11 +10,7 @@
 #  endif
 #  include <windows.h>
 #  include <malloc.h>
-
-#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && \
-      !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#    define TRACY_ON_UWP
-#  endif
+#  include "TracyUwp.hpp"
 #else
 #  include <pthread.h>
 #  include <string.h>
@@ -132,7 +128,7 @@ void ThreadNameMsvcMagic( const THREADNAME_INFO& info )
 TRACY_API void SetThreadName( const char* name )
 {
 #if defined _WIN32
-#  if defined TRACY_ON_UWP
+#  ifdef TRACY_UWP
     static auto _SetThreadDescription = &::SetThreadDescription;
 #  else
     static auto _SetThreadDescription = (t_SetThreadDescription)GetProcAddress( GetModuleHandleA( "kernel32.dll" ), "SetThreadDescription" );
@@ -200,7 +196,7 @@ TRACY_API const char* GetThreadName( uint32_t id )
     }
 #else
 #  if defined _WIN32
-#    if defined TRACY_ON_UWP
+#    ifdef TRACY_UWP
     static auto _GetThreadDescription = &::GetThreadDescription;
 #    else
     static auto _GetThreadDescription = (t_GetThreadDescription)GetProcAddress( GetModuleHandleA( "kernel32.dll" ), "GetThreadDescription" );

--- a/common/TracyUwp.hpp
+++ b/common/TracyUwp.hpp
@@ -1,0 +1,11 @@
+#ifndef __TRACYUWP_HPP__
+#define __TRACYUWP_HPP__
+
+#ifdef _WIN32
+#  include <winapifamily.h>
+#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#    define TRACY_UWP
+#  endif
+#endif
+
+#endif

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -522,6 +522,16 @@ In the case of some programming environments, you may need to take extra steps t
 
 If you are using MSVC, you will need to disable the \emph{Edit And Continue} feature, as it makes the compiler non-conformant to some aspects of the C++ standard. In order to do so, open the project properties and go to \menu[,]{C/C++,General,Debug Information Format} and make sure \emph{Program Database for Edit And Continue (/ZI)} is \emph{not} selected.
 
+\paragraph{Universal Windows Platform}
+
+Due to a restricted access to Win32 APIs and other sandboxing issues (like network isolation), several limitations apply to using Tracy in a UWP application compared to Windows Desktop:
+
+\begin{itemize}
+\item Call stack sampling is not available.
+\item System profiling is not available.
+\item To be able to connect from another machine on the local network, the app needs the \emph{privateNetworkClientServer} capability. To connect from localhost, an active inbound loopback exemption is also necessary \footnote{\url{https://docs.microsoft.com/en-us/windows/uwp/communication/interprocess-communication\#loopback}}.
+\end{itemize}
+
 \paragraph{Apple woes}
 
 Because Apple \emph{has} to be \emph{think different}, there are some problems with using Tracy on OSX and iOS. First, the performance hit due to profiling is higher than on other platforms. Second, some critical features are missing and won't be possible to achieve:


### PR DESCRIPTION
We want to use Tracy in our UWP application, but some Win32 APIs are unavailable on the platform, which have to be either substituted, or the features using them have to be disabled. Traditional Win32 apps are not affected by the change.