### PR TITLE
Automatic timer fallback

### DIFF
--- a/client/TracyProfiler.hpp
+++ b/client/TracyProfiler.hpp
@@ -26,11 +26,11 @@
 #  include <mach/mach_time.h>
 #endif
 
-#if !defined TRACY_TIMER_FALLBACK && ( defined _WIN32 || ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 ) || ( defined TARGET_OS_IOS && TARGET_OS_IOS == 1 ) )
+#if ( defined _WIN32 || ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 ) || ( defined TARGET_OS_IOS && TARGET_OS_IOS == 1 ) )
 #  define TRACY_HW_TIMER
 #endif
 
-#if !defined TRACY_HW_TIMER
+#if defined TRACY_TIMER_FALLBACK || !defined TRACY_HW_TIMER
 #  include <chrono>
 #endif
 
@@ -66,6 +66,23 @@ TRACY_API GpuCtxWrapper& GetGpuCtx();
 TRACY_API uint32_t GetThreadHandle();
 TRACY_API bool ProfilerAvailable();
 TRACY_API int64_t GetFrequencyQpc();
+
+#if defined TRACY_TIMER_FALLBACK && defined TRACY_HW_TIMER && ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
+TRACY_API bool hardwareSupportsInvariantTSC();  // check, if we need fallback scenario
+#else
+#  if defined TRACY_HW_TIMER
+tracy_force_inline bool hardwareSupportsInvariantTSC()
+{
+    return true;  // this is checked at startup
+}
+#  else
+tracy_force_inline bool hardwareSupportsInvariantTSC()
+{
+    return false;
+}
+#  endif
+#endif
+
 
 struct SourceLocationData
 {
@@ -166,25 +183,39 @@ public:
     {
 #ifdef TRACY_HW_TIMER
 #  if defined TARGET_OS_IOS && TARGET_OS_IOS == 1
-        return mach_absolute_time();
+        if (hardwareSupportsInvariantTSC())
+        {
+            return mach_absolute_time();
+        }
 #  elif defined _WIN32
 #    ifdef TRACY_TIMER_QPC
         return GetTimeQpc();
 #    else
-        return int64_t( __rdtsc() );
+        if (hardwareSupportsInvariantTSC())
+        {
+            return int64_t( __rdtsc() );
+        }
 #    endif
 #  elif defined __i386 || defined _M_IX86
-        uint32_t eax, edx;
-        asm volatile ( "rdtsc" : "=a" (eax), "=d" (edx) );
-        return ( uint64_t( edx ) << 32 ) + uint64_t( eax );
+        if (hardwareSupportsInvariantTSC())
+        {
+            uint32_t eax, edx;
+            asm volatile ( "rdtsc" : "=a" (eax), "=d" (edx) );
+            return ( uint64_t( edx ) << 32 ) + uint64_t( eax );
+        }
 #  elif defined __x86_64__ || defined _M_X64
-        uint64_t rax, rdx;
-        asm volatile ( "rdtsc" : "=a" (rax), "=d" (rdx) );
-        return (int64_t)(( rdx << 32 ) + rax);
+        if (hardwareSupportsInvariantTSC())
+        {
+            uint64_t rax, rdx;
+            asm volatile ( "rdtsc" : "=a" (rax), "=d" (rdx) );
+            return (int64_t)(( rdx << 32 ) + rax);
+        }
 #  else
 #    error "TRACY_HW_TIMER detection logic needs fixing"
 #  endif
-#else
+#endif
+
+#if !defined TRACY_HW_TIMER || defined TRACY_TIMER_FALLBACK
 #  if defined __linux__ && defined CLOCK_MONOTONIC_RAW
         struct timespec ts;
         clock_gettime( CLOCK_MONOTONIC_RAW, &ts );
@@ -193,6 +224,8 @@ public:
         return std::chrono::duration_cast<std::chrono::nanoseconds>( std::chrono::high_resolution_clock::now().time_since_epoch() ).count();
 #  endif
 #endif
+
+        return 0;  // unreacheble branch
     }
 
     tracy_force_inline uint32_t GetNextZoneId()

--- a/client/TracyProfiler.hpp
+++ b/client/TracyProfiler.hpp
@@ -68,15 +68,15 @@ TRACY_API bool ProfilerAvailable();
 TRACY_API int64_t GetFrequencyQpc();
 
 #if defined TRACY_TIMER_FALLBACK && defined TRACY_HW_TIMER && ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
-TRACY_API bool hardwareSupportsInvariantTSC();  // check, if we need fallback scenario
+TRACY_API bool HardwareSupportsInvariantTSC();  // check, if we need fallback scenario
 #else
 #  if defined TRACY_HW_TIMER
-tracy_force_inline bool hardwareSupportsInvariantTSC()
+tracy_force_inline bool HardwareSupportsInvariantTSC()
 {
     return true;  // this is checked at startup
 }
 #  else
-tracy_force_inline bool hardwareSupportsInvariantTSC()
+tracy_force_inline bool HardwareSupportsInvariantTSC()
 {
     return false;
 }
@@ -183,28 +183,22 @@ public:
     {
 #ifdef TRACY_HW_TIMER
 #  if defined TARGET_OS_IOS && TARGET_OS_IOS == 1
-        if (hardwareSupportsInvariantTSC())
-        {
-            return mach_absolute_time();
-        }
+        if( HardwareSupportsInvariantTSC() ) return mach_absolute_time();
 #  elif defined _WIN32
 #    ifdef TRACY_TIMER_QPC
         return GetTimeQpc();
 #    else
-        if (hardwareSupportsInvariantTSC())
-        {
-            return int64_t( __rdtsc() );
-        }
+        if( HardwareSupportsInvariantTSC() ) return int64_t( __rdtsc() );
 #    endif
 #  elif defined __i386 || defined _M_IX86
-        if (hardwareSupportsInvariantTSC())
+        if( HardwareSupportsInvariantTSC() )
         {
             uint32_t eax, edx;
             asm volatile ( "rdtsc" : "=a" (eax), "=d" (edx) );
             return ( uint64_t( edx ) << 32 ) + uint64_t( eax );
         }
 #  elif defined __x86_64__ || defined _M_X64
-        if (hardwareSupportsInvariantTSC())
+        if( HardwareSupportsInvariantTSC() )
         {
             uint64_t rax, rdx;
             asm volatile ( "rdtsc" : "=a" (rax), "=d" (rdx) );


### PR DESCRIPTION
Hi. We've recently enabled TRACY_ON_DEMAND in our development build (since we measured that there are no critical performance issues about that). 
Problem we face is that sometimes we launch our binaries in virtual machine for CI tasks. And invariant TSC is unavailable there, so application crashes.  

Most convenient solution for us - firstly try to use TSC, and if it isn't available, fallback to std::chrono.

With this PR I propose following changes in logic of TRACY_TIMER_FALLBACK macros:

If TRACY_TIMER_FALLBACK is not enabled:
 * Try to use TSC 
 * Fail if it isn't available
 
If TRACY_TIMER_FALLBACK is enabled:
 * Try to use TSC 
 * If can't, use std::chrono

As a result, the same binaries may be runned with or without TSC, depending on a machine.