### PR TITLE
CMake install should use the Tracy:: namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,5 +112,6 @@ install(FILES ${client_includes}
 install(FILES ${common_includes}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/common)
 install(EXPORT TracyConfig
+		NAMESPACE Tracy::
         FILE TracyConfig.cmake
         DESTINATION share/Tracy)


### PR DESCRIPTION
If we do not add the namespace to the install config, it means we can not use `Tracy::TracyClient` as target name when using `find_package` while we already have the alias (when using `add_subdirectory`).

This would yield the following error:

```
CMake Error at CMakeLists.txt:105 (add_library):
  Target "sedica" links to target "Tracy::TracyClient" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?
```

This is also an issue the case where you install a library that builds tracy with `add_subdirectory` and links Tracy::TracyClient then installs itself.

Note that this is a breaking change, as I suppose people were linking `TracyClient` instead of `Tracy::TracyClient` (which is dangerous because there is no guarantee it would link the version found by CMake without using an alias).
The issue is that CMake will not show any error but not propagate the includes if it does not find the target when not using an alias (which is exactly what we're trying to avoid).
So in the short term it might be an issue, but in the long term I think this is better.
