### PR TITLE
Fix missing TracyUwp in the CMake headers install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set(common_includes
     ${CMAKE_CURRENT_LIST_DIR}/common/TracySocket.hpp
     ${CMAKE_CURRENT_LIST_DIR}/common/TracyStackFrames.hpp
     ${CMAKE_CURRENT_LIST_DIR}/common/TracySystem.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/common/TracyUwp.hpp
     ${CMAKE_CURRENT_LIST_DIR}/common/TracyYield.hpp)
 
 install(TARGETS TracyClient


### PR DESCRIPTION
This adds the newly added `common/TracyUwp.hpp` to the list of headers to install by CMake