### PR TITLE
Fix macOS build breaks when _GNU_SOURCE defined

### DIFF
--- a/client/TracyProfiler.cpp
+++ b/client/TracyProfiler.cpp
@@ -391,7 +391,7 @@ static const char* GetProcessName()
     auto buf = getprogname();
     if( buf ) processName = buf;
 #  endif
-#elif defined _GNU_SOURCE
+#elif defined __linux__ && defined _GNU_SOURCE
     if( program_invocation_short_name ) processName = program_invocation_short_name;
 #elif defined __APPLE__ || defined BSD
     auto buf = getprogname();
@@ -408,7 +408,7 @@ static const char* GetProcessExecutablePath()
     return buf;
 #elif defined __ANDROID__
     return nullptr;
-#elif defined _GNU_SOURCE
+#elif defined __linux__ && defined _GNU_SOURCE
     return program_invocation_name;
 #elif defined __APPLE__
     static char buf[1024];

--- a/common/TracySystem.cpp
+++ b/common/TracySystem.cpp
@@ -155,14 +155,22 @@ TRACY_API void SetThreadName( const char* name )
         const auto sz = strlen( name );
         if( sz <= 15 )
         {
+#if defined __APPLE__
+            pthread_setname_np( name );
+#else
             pthread_setname_np( pthread_self(), name );
+#endif
         }
         else
         {
             char buf[16];
             memcpy( buf, name, 15 );
             buf[15] = '\0';
+#if defined __APPLE__
+            pthread_setname_np( buf );
+#else
             pthread_setname_np( pthread_self(), buf );
+#endif
         }
     }
 #endif


### PR DESCRIPTION
Fix two build failures when building on macOS and _GNU_SOURCE is defined.