### PR TITLE
Ignore uninitialized GPU contexts when rendering GPU events

### DIFF
--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -19245,7 +19245,7 @@ uint64_t View::GetZoneThread( const GpuEvent& zone ) const
     {
         for( const auto& ctx : m_worker.GetGpuData() )
         {
-            assert( ctx->threadData.size() == 1 );
+            if ( ctx->threadData.size() != 1 ) continue;
             const Vector<short_ptr<GpuEvent>>* timeline = &ctx->threadData.begin()->second.timeline;
             if( timeline->empty() ) continue;
             for(;;)


### PR DESCRIPTION
This fixes an assertion crash when viewing GPU zones when no zones have been
recorded on a GPU context if the client is compiled with TRACY_ON_DEMAND.

Am I understanding this correctly? Is this a reasonable fix for the issue?