### PR TITLE
set s_numCpus before reading it

### DIFF
--- a/client/TracySysTrace.cpp
+++ b/client/TracySysTrace.cpp
@@ -817,6 +817,8 @@ bool SysTraceStart( int64_t& samplingPeriod )
     samplingPeriod = GetSamplingPeriod();
     uint32_t currentPid = (uint32_t)getpid();
 
+    s_numCpus = (int)std::thread::hardware_concurrency();
+
     const auto maxNumBuffers = s_numCpus * (
         1 +     // software sampling
         2 +     // CPU cycles + instructions retired
@@ -824,7 +826,6 @@ bool SysTraceStart( int64_t& samplingPeriod )
         2 +     // branch retired + miss
         2       // context switches + wakeups
     );
-    s_numCpus = (int)std::thread::hardware_concurrency();
     s_ring = (RingBuffer*)tracy_malloc( sizeof( RingBuffer ) * maxNumBuffers );
     s_numBuffers = 0;
 


### PR DESCRIPTION
This wasn't technically an *uninitialized* value. Because `s_numCpus` was a global, it was implicitly zero-initialized. So we were setting `maxNumBuffers = 0` and so at [this line](https://github.com/wolfpld/tracy/blob/master/client/TracySysTrace.cpp#L828) we were calling `tracy_malloc(0)` to allocate `s_ring`.

Note, because `tracy_malloc(0)` calls `rpmalloc(0)` which currently returns a non-null pointer, we weren't necessarily crashing as soon as we dereferenced `s_ring`.  On my machine, this issue manifested itself as a crash in `rpmalloc` internals [here](https://github.com/wolfpld/tracy/blob/fd604444eb1dc5a375db28d43bb480d2641681fc/client/tracy_rpmalloc.cpp#L1285) during a subsequent allocation. It was crashing doing a `free_list_pop` on an already-empty `free_list`. I guess that the reason is that as we performed out-of-bounds writes to `s_ring` (since we allocated 0 bytes but used the resulting pointers as if we had actually allocated N bytes), we may have scribbled over allocator state.

I'm sending out a PR #348  to change `rpmalloc(0)` behavior to return null, which would make such bugs much easier to debug by crashing as soon as the returned pointer is dereferenced. (It's how I debugged this in the first place).