### PR TITLE
tracy_rpmalloc: let allocating 0 bytes return NULL

### DIFF
--- a/client/tracy_rpmalloc.cpp
+++ b/client/tracy_rpmalloc.cpp
@@ -1341,7 +1341,9 @@ _memory_allocate_oversized(heap_t* heap, size_t size) {
 //! Allocate a block of the given size
 static void*
 _memory_allocate(heap_t* heap, size_t size) {
-	if (EXPECTED(size <= SMALL_SIZE_LIMIT))
+	if (size == 0)
+	    return nullptr;
+	else if (EXPECTED(size <= SMALL_SIZE_LIMIT))
 		return _memory_allocate_small(heap, size);
 	else if (size <= _memory_medium_size_limit)
 		return _memory_allocate_medium(heap, size);


### PR DESCRIPTION
Although not required, it is a common thing do do, in malloc implementations, to let `malloc(0)` return NULL. This is legal because the only requirement on the return value of `malloc(0)` is that one may pass it to `free()`, and NULL is accepted by `free()`.

In PR #347 we are fixing a bug where we were inadvertently passing 0 as the size argument to `malloc` to allocate an actual, non-zero-sized buffer, and subsequently dereferencing that. Because `malloc(0)` was returning a non-NULL pointer, and as we were being "lucky", this didn't immediately crash and the actual crash came later, farther away from the root cause, making that hard to debug. I basically debugged into the `rpmalloc` implementation, guessed that having `class_idx==0` likely meant a 0-byte allocation, then I wrote the diff in that PR and suddenly the crash occured right at the root cause.
