### PR TITLE
Require C++17 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Tracy LANGUAGES CXX)
 find_package(Threads REQUIRED)
 
 add_library(TracyClient TracyClient.cpp)
-target_compile_features(TracyClient PUBLIC cxx_std_11)
+target_compile_features(TracyClient PUBLIC cxx_std_17)
 target_include_directories(TracyClient SYSTEM PUBLIC 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> 
     $<INSTALL_INTERFACE:include>)


### PR DESCRIPTION
I previously [packaged](https://conan.io/center/tracy) the client library in conan, and tried to [update it to tracy v0.8](https://github.com/conan-io/conan-center-index/pull/10061).
But compilation [fails](https://c3i.jfrog.io/c3i/misc/summary.html?json=https://c3i.jfrog.io/c3i/misc/logs/pr/10061/1-configs/windows-visual_studio/tracy/0.8//summary.json) with msvc `19.16.xxxx` ([build log](https://c3i.jfrog.io/c3i/misc/logs/pr/10061/1-configs/windows-visual_studio/tracy/0.8//32792631a966cce35e0d697d7161840d8e8d957e-build.txt)).

```
c:\j\w\prod\buildsinglereference\.conan\data\tracy\0.8\_\_\build\32792631a966cce35e0d697d7161840d8e8d957e\source_subfolder\client\tracy_SPSCQueue.h(82): error C2429: attribute 'nodiscard' requires compiler flag '/std:c++17' [C:\J\w\prod\BuildSingleReference\.conan\data\tracy\0.8\_\_\build\32792631a966cce35e0d697d7161840d8e8d957e\source_subfolder\TracyClient.vcxproj]
  c:\j\w\prod\buildsinglereference\.conan\data\tracy\0.8\_\_\build\32792631a966cce35e0d697d7161840d8e8d957e\source_subfolder\client\tracy_SPSCQueue.h(143): note: see reference to class template instantiation 'tracy::SPSCQueue<T>' being compiled
c:\j\w\prod\buildsinglereference\.conan\data\tracy\0.8\_\_\build\32792631a966cce35e0d697d7161840d8e8d957e\source_subfolder\client\tracy_SPSCQueue.h(106): error C2429: attribute 'nodiscard' requires compiler flag '/std:c++17' [C:\J\w\prod\BuildSingleReference\.conan\data\tracy\0.8\_\_\build\32792631a966cce35e0d697d7161840d8e8d957e\source_subfolder\TracyClient.vcxproj]
c:\j\w\prod\buildsinglereference\.conan\data\tracy\0.8\_\_\build\32792631a966cce35e0d697d7161840d8e8d957e\source_subfolder\client\tracy_SPSCQueue.h(115): error C2429: attribute 'nodiscard' requires compiler flag '/std:c++17' [C:\J\w\prod\BuildSingleReference\.conan\data\tracy\0.8\_\_\build\32792631a966cce35e0d697d7161840d8e8d957e\source_subfolder\TracyClient.vcxproj]
c:\j\w\prod\buildsinglereference\.conan\data\tracy\0.8\_\_\build\32792631a966cce35e0d697d7161840d8e8d957e\source_subfolder\client\tracy_SPSCQueue.h(120): error C2429: attribute 'nodiscard' requires compiler flag '/std:c++17' [C:\J\w\prod\BuildSingleReference\.conan\data\tracy\0.8\_\_\build\32792631a966cce35e0d697d7161840d8e8d957e\source_subfolder\TracyClient.vcxproj]
```