### PR TITLE
Add tool to CMake setup, improve vcpkg workflow and simple CMake Github Worklfow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,61 @@
+name: CMake
+
+on: push
+
+jobs:
+  build-and-install:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macOS-latest
+          - ubuntu-20.04
+          - windows-2022
+        include:
+          - os: windows-2022
+            platform: windows
+            triplet: x64-windows-static
+          - os: ubuntu-20.04
+            platform: linux
+            triplet: x64-linux
+          - os: macOS-latest
+            platform: macos
+            triplet: x64-osx
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - uses: actions/checkout@v3
+      name: Get vcpkg
+      with:
+        repository: 'microsoft/vcpkg'
+        ref: '2022.03.10'
+        path: '${{ github.workspace }}/_vcpkg'
+
+    # Install CMake 3.20 
+    - uses: lukka/get-cmake@latest
+      name: Get CMake
+
+    - name: Install Linux dependencies for (glfw3, nfd, std parallel primitives)
+      run: |
+        sudo apt-get update
+        sudo apt install libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev libgtk-3-dev libtbb-dev
+      if: ${{ matrix.platform == 'linux' }}
+
+    - uses: ilammy/msvc-dev-cmd@v1  
+      name: Setup Windows dev environment
+      with:
+        arch: 'x64'
+      if: ${{ matrix.platform == 'windows' }}
+
+    - name: 'Configure, Build and Install'
+      run: |
+        cmake --preset=${{ matrix.platform }}-x64 -DVCPKG_TARGET_TRIPLET:STRING=${{ matrix.triplet }} -DTRACY_BUILD_CAPTURE:BOOL=ON -DTRACY_BUILD_PROFILER:BOOL=ON
+        cmake --build --preset build-${{ matrix.platform }}
+        cmake --build --preset install-${{ matrix.platform }}
+      env:
+          VCPKG_ROOT: '${{ github.workspace }}/_vcpkg'
+          VCPKG_FEATURE_FLAGS: 'manifests,versions,binarycaching,registries'

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ vcpkg/*
 .dirstamp
 .vscode/
 
+/build
 /_*/**
 /**/__pycache__/**
 extra/vswhere.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,26 @@ set_option(TRACY_NO_FRAME_IMAGE  "Disable the frame image support and its thread
 set_option(TRACY_DELAYED_INIT "Enable delayed initialization of the library (init on first call)" OFF)
 set_option(TRACY_MANUAL_LIFETIME "Enable the manual lifetime management of the profile" OFF)
 set_option(TRACY_FIBERS "Enable fibers support" OFF)
+set_option(TRACY_BUILD_CAPTURE "Build capture tool" OFF)
+set_option(TRACY_BUILD_PROFILER "Build profiler tool" OFF)
+set_option(TRACY_USE_WAYLAND "Use Wayland backend for GLFW windows" OFF)
+
+if(TRACY_BUILD_CAPTURE OR TRACY_BUILD_PROFILER)
+    find_package(capstone CONFIG REQUIRED)
+    find_package(freetype CONFIG REQUIRED)
+    find_package(zstd CONFIG REQUIRED)
+    if(TRACY_BUILD_PROFILER)
+        find_package(glfw3 CONFIG REQUIRED)
+    endif()
+    if(UNIX AND NOT APPLE)
+        include(FindPkgConfig)
+        pkg_check_modules(GTK3 REQUIRED IMPORTED_TARGET gtk+-3.0)
+        pkg_check_modules(TBB REQUIRED IMPORTED_TARGET tbb)
+        if(TRACY_USE_WAYLAND)
+            pkg_check_modules(WAYLAND REQUIRED IMPORTED_TARGET wayland-client)
+        endif()
+    endif()
+endif()
 
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(TracyClient PRIVATE TRACY_EXPORTS)
@@ -108,7 +128,33 @@ set(common_includes
     ${CMAKE_CURRENT_LIST_DIR}/common/TracyUwp.hpp
     ${CMAKE_CURRENT_LIST_DIR}/common/TracyYield.hpp)
 
-install(TARGETS TracyClient
+if(TRACY_BUILD_CAPTURE OR TRACY_BUILD_PROFILER)
+    add_subdirectory(common)
+    if(WIN32)
+        add_subdirectory(getopt)
+    endif()
+    add_subdirectory(imgui)
+    add_subdirectory(server)
+    if(TRACY_BUILD_CAPTURE)
+        add_subdirectory(capture)
+    endif()
+    if(TRACY_BUILD_PROFILER)
+        add_subdirectory(nfd)
+        add_subdirectory(profiler)
+    endif()
+endif()
+
+set(installed_targets
+    TracyClient
+)
+if(TRACY_BUILD_CAPTURE)
+    list(APPEND installed_targets TracyCapture)
+endif()
+if(TRACY_BUILD_PROFILER)
+    list(APPEND installed_targets TracyProfiler)
+endif()
+
+install(TARGETS ${installed_targets}
         EXPORT TracyConfig
         RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,105 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "locations-base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}"
+    },
+    {
+      "name": "vcpkg-base",
+      "hidden": true,
+      "toolchainFile": "$penv{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    },
+    {
+      "name": "warnings-base",
+      "hidden": true,
+      "warnings": {
+        "dev": true,
+        "deprecated": true,
+        "systemVars": true
+      },
+      "errors": {
+        "dev": true,
+        "deprecated": true
+      }
+    },
+    {
+      "name": "ninja",
+      "hidden": true,
+      "generator": "Ninja Multi-Config",
+      "cacheVariables": {
+        "CMAKE_DEFAULT_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "x64",
+      "hidden": true,
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      }
+    },
+    {
+      "name": "linux-x64",
+      "inherits": [ "ninja", "x64", "locations-base", "vcpkg-base", "warnings-base" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux"},
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
+      "name": "macos-x64",
+      "inherits": [ "ninja", "x64", "locations-base", "vcpkg-base", "warnings-base" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Darwin"}
+    },
+    {
+      "name": "windows-x64",
+      "inherits": [ "ninja", "x64", "locations-base", "vcpkg-base", "warnings-base" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows"}
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "build-linux",
+      "configurePreset": "linux-x64",
+      "nativeToolOptions": [ "-v" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux"}
+    },
+    {
+      "name": "build-macos",
+      "configurePreset": "macos-x64",
+      "nativeToolOptions": [ "-v" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Darwin"}
+    },
+    {
+      "name": "build-windows",
+      "configurePreset": "windows-x64",
+      "nativeToolOptions": [ "-v" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows"}
+    },
+    {
+      "name": "install-linux",
+      "configurePreset": "linux-x64",
+      "inherits": "build-linux",
+      "targets": [ "install" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux"}
+    },
+    {
+      "name": "install-macos",
+      "configurePreset": "macos-x64",
+      "inherits": "build-macos",
+      "targets": [ "install" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Darwin"}
+    },
+    {
+      "name": "install-windows",
+      "configurePreset": "windows-x64",
+      "inherits": "build-windows",
+      "targets": [ "install" ],
+      "condition": {"type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows"}
+    }
+  ]
+}

--- a/capture/CMakeLists.txt
+++ b/capture/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(TracyCapture LANGUAGES CXX)
+
+add_executable(TracyCapture)
+add_executable(Tracy::TracyCapture ALIAS TracyCapture)
+
+target_sources(TracyCapture
+    PRIVATE
+        src/capture.cpp
+)
+target_compile_definitions(TracyCapture
+    PRIVATE
+        TRACY_NO_STATISTICS
+        $<$<PLATFORM_ID:Windows>:
+            _CRT_SECURE_NO_DEPRECATE
+            _CRT_NONSTDC_NO_DEPRECATE
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            _USE_MATH_DEFINES
+        >
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /permissive-
+            /W3
+        >
+)
+target_compile_features(TracyCapture
+    PRIVATE
+        cxx_std_17
+)
+target_link_libraries(TracyCapture
+    PRIVATE
+        TracyCommon
+        TracyServer
+        $<$<PLATFORM_ID:Windows>:TracyGetOpt>
+)
+set_target_properties(TracyCapture
+    PROPERTIES
+        CXX_STANDARD          17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS        OFF
+        OUTPUT_NAME           "capture"
+)
+

--- a/capture/build/win32/capture.vcxproj
+++ b/capture/build/win32/capture.vcxproj
@@ -54,7 +54,7 @@
       <PreprocessorDefinitions>TRACY_NO_STATISTICS;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;WIN32_LEAN_AND_MEAN;NOMINMAX;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalIncludeDirectories>..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include\capstone;$(VcpkgRoot)\installed\$(VcpkgTriplet)\include\capstone</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;$(VcpkgRoot)\installed\$(VcpkgTriplet)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ws2_32.lib;capstone.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -74,7 +74,7 @@
       <PreprocessorDefinitions>TRACY_NO_STATISTICS;NDEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;WIN32_LEAN_AND_MEAN;NOMINMAX;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalIncludeDirectories>..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include\capstone;$(VcpkgRoot)\installed\$(VcpkgTriplet)\include\capstone</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;$(VcpkgRoot)\installed\$(VcpkgTriplet)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(TracyCommon LANGUAGES C CXX)
+
+add_library(TracyCommon STATIC)
+add_library(Tracy::TracyCommon ALIAS TracyCommon)
+
+target_sources(TracyCommon
+    PRIVATE
+        tracy_lz4.cpp
+        tracy_lz4.hpp
+        tracy_lz4hc.cpp
+        tracy_lz4hc.hpp
+        TracyAlign.hpp
+        TracyAlloc.hpp
+        TracyApi.h
+        TracyColor.hpp
+        TracyForceInline.hpp
+        TracyMutex.hpp
+        TracyProtocol.hpp
+        TracyQueue.hpp
+        TracySocket.cpp
+        TracySocket.hpp
+        TracyStackFrames.cpp
+        TracyStackFrames.hpp
+        TracySystem.cpp
+        TracySystem.hpp
+        TracyUwp.hpp
+        TracyYield.hpp
+)
+target_include_directories(TracyCommon
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+)
+target_compile_definitions(TracyCommon
+    PRIVATE
+        $<$<PLATFORM_ID:Windows>:
+            _CRT_SECURE_NO_DEPRECATE
+            _CRT_NONSTDC_NO_DEPRECATE
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            _USE_MATH_DEFINES
+        >
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /permissive-
+            /W3
+        >
+)
+target_compile_features(TracyCommon
+    PUBLIC
+        cxx_std_17
+)
+target_link_libraries(TracyCommon
+    PUBLIC
+        $<$<PLATFORM_ID:Windows>:
+            ws2_32.lib
+        >
+        $<$<PLATFORM_ID:Linux>:
+            PkgConfig::TBB
+        >
+)
+set_target_properties(TracyCommon
+    PROPERTIES
+        CXX_STANDARD          17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS        OFF
+)
+

--- a/getopt/CMakeLists.txt
+++ b/getopt/CMakeLists.txt
@@ -1,0 +1,21 @@
+project(TracyGetOpt LANGUAGES C)
+
+add_library(TracyGetOpt STATIC)
+add_library(Tracy::TracyGetOpt ALIAS TracyGetOpt)
+
+target_sources(TracyGetOpt
+    PRIVATE
+        getopt.c
+        getopt.h
+)
+target_include_directories(TracyGetOpt
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+)
+target_compile_definitions(TracyGetOpt
+    PRIVATE
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /permissive-
+            /W3
+        >
+)

--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(TracyImGui LANGUAGES C CXX)
+
+add_library(TracyImGui STATIC)
+add_library(Tracy::TracyImGui ALIAS TracyImGui)
+
+target_sources(TracyImGui
+    PRIVATE
+        imconfig.h              
+        imgui.cpp               
+        imgui.h                 
+        imgui_demo.cpp          
+        imgui_draw.cpp          
+        imgui_internal.h        
+        imgui_tables.cpp        
+        imgui_widgets.cpp       
+        imstb_rectpack.h        
+        imstb_textedit.h        
+        imstb_truetype.h        
+        misc/freetype/imgui_freetype.cpp        
+        misc/freetype/imgui_freetype.h        
+)
+target_include_directories(TracyImGui
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+)
+target_compile_definitions(TracyImGui
+    PUBLIC
+        IMGUI_ENABLE_FREETYPE
+    PRIVATE
+        $<$<PLATFORM_ID:Windows>:
+            _CRT_SECURE_NO_DEPRECATE
+            _CRT_NONSTDC_NO_DEPRECATE
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            _USE_MATH_DEFINES
+        >
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /permissive-
+            /W3
+        >
+)
+target_compile_features(TracyImGui
+    PUBLIC
+        cxx_std_17
+)
+target_link_libraries(TracyImGui
+    PRIVATE
+        freetype
+)
+set_target_properties(TracyImGui
+    PROPERTIES
+        CXX_STANDARD          17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS        OFF
+)
+

--- a/nfd/CMakeLists.txt
+++ b/nfd/CMakeLists.txt
@@ -1,0 +1,44 @@
+project(TracyNFD LANGUAGES C)
+
+add_library(TracyNFD STATIC)
+add_library(Tracy::TracyNFD ALIAS TracyNFD)
+
+target_sources(TracyNFD
+    PRIVATE
+        common.h                 
+        LICENSE                  
+        nfd.h                    
+        nfd_common.c             
+        nfd_common.h             
+        $<$<PLATFORM_ID:Linux>:nfd_gtk.c>                
+        $<$<PLATFORM_ID:Darwin>:nfd_cocoa.m>              
+        $<$<PLATFORM_ID:Windows>:nfd_win.cpp>       
+)
+target_include_directories(TracyNFD
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+)
+target_compile_definitions(TracyNFD
+    PRIVATE
+        $<$<PLATFORM_ID:Windows>:
+            _CRT_SECURE_NO_DEPRECATE
+            _CRT_NONSTDC_NO_DEPRECATE
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            _USE_MATH_DEFINES
+        >
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /permissive-
+            /W3
+        >
+)
+target_link_libraries(TracyNFD
+    PRIVATE
+        $<$<PLATFORM_ID:Linux>:
+            PkgConfig::GTK3
+        >
+        $<$<PLATFORM_ID:Darwin>:
+            "-framework CoreFoundation"
+            "-framework AppKit"
+        >
+)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(TracyProfiler LANGUAGES CXX)
+
+add_executable(TracyProfiler)
+add_executable(Tracy::TracyProfiler ALIAS TracyProfiler)
+
+target_sources(TracyProfiler
+    PRIVATE
+        src/DroidSans.hpp               
+        src/FiraCodeRetina.hpp          
+        src/FontAwesomeSolid.hpp        
+        src/HttpRequest.cpp             
+        src/HttpRequest.hpp             
+        src/icon.hpp                    
+        src/imgui_impl_glfw.cpp         
+        src/imgui_impl_glfw.h           
+        src/imgui_impl_opengl3.cpp      
+        src/imgui_impl_opengl3.h        
+        src/imgui_impl_opengl3_loader.h 
+        src/main.cpp                    
+        src/NativeWindow.cpp            
+        src/NativeWindow.hpp            
+        src/ResolvService.cpp           
+        src/ResolvService.hpp           
+        src/stb_image.h                 
+        src/winmain.cpp                 
+        src/winmainArchDiscovery.cpp    
+        $<$<PLATFORM_ID:Windows>:build/win32/Tracy.manifest>
+        $<$<PLATFORM_ID:Windows>:build/win32/Tracy.rc>
+)
+target_compile_definitions(TracyProfiler
+    PRIVATE
+        TRACY_NO_STATISTICS
+        $<$<PLATFORM_ID:Windows>:
+            _CRT_SECURE_NO_DEPRECATE
+            _CRT_NONSTDC_NO_DEPRECATE
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            _USE_MATH_DEFINES
+        >
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /permissive-
+            /W3
+        >
+)
+target_compile_features(TracyProfiler
+    PRIVATE
+        cxx_std_17
+)
+target_link_libraries(TracyProfiler
+    PRIVATE
+        TracyCommon
+        TracyImGui
+        TracyNFD
+        TracyServer
+        glfw
+)
+set_target_properties(TracyProfiler
+    PROPERTIES
+        CXX_STANDARD          17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS        OFF
+        OUTPUT_NAME           "Tracy"
+)
+
+if(UNIX AND NOT APPLE)
+    if(TRACY_USE_WAYLAND)
+        target_compile_definitions(TracyProfiler
+            PRIVATE
+                DISPLAY_SERVER_WAYLAND
+        )
+        target_link_libraries(TracyProfiler
+            PRIVATE
+                PkgConfig::WAYLAND
+        )
+    else()
+        target_compile_definitions(TracyProfiler
+            PRIVATE
+                DISPLAY_SERVER_X11
+        )
+    endif()
+endif()

--- a/profiler/build/win32/Tracy.vcxproj
+++ b/profiler/build/win32/Tracy.vcxproj
@@ -57,7 +57,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;WIN32_LEAN_AND_MEAN;NOMINMAX;_USE_MATH_DEFINES;IMGUI_ENABLE_FREETYPE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\imgui;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include\capstone;$(VcpkgRoot)\installed\$(VcpkgTriplet)\include\capstone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\imgui;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;$(VcpkgRoot)\installed\$(VcpkgTriplet)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <ConformanceMode>true</ConformanceMode>
@@ -83,7 +83,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;WIN32_LEAN_AND_MEAN;NOMINMAX;_USE_MATH_DEFINES;IMGUI_ENABLE_FREETYPE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\..\imgui;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include\capstone;$(VcpkgRoot)\installed\$(VcpkgTriplet)\include\capstone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\imgui;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;..\..\..\vcpkg\vcpkg\installed\x64-windows-static\include;$(VcpkgRoot)\installed\$(VcpkgTriplet)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ConformanceMode>true</ConformanceMode>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,0 +1,109 @@
+project(TracyServer LANGUAGES CXX)
+
+add_library(TracyServer STATIC)
+add_library(Tracy::TracyServer ALIAS TracyServer)
+
+target_sources(TracyServer
+    PRIVATE
+        IconsFontAwesome5.h                
+        tracy_pdqsort.h                    
+        tracy_robin_hood.h                 
+        tracy_xxhash.h                     
+        TracyBadVersion.cpp                
+        TracyBadVersion.hpp                
+        TracyBuzzAnim.hpp                  
+        TracyCharUtil.hpp                  
+        TracyColor.cpp                     
+        TracyColor.hpp                     
+        TracyDecayValue.hpp                
+        TracyEvent.hpp                     
+        TracyEventDebug.cpp                
+        TracyEventDebug.hpp                
+        TracyFileHeader.hpp                
+        TracyFileRead.hpp                  
+        TracyFilesystem.cpp                
+        TracyFilesystem.hpp                
+        TracyFileWrite.hpp                 
+        TracyImGui.hpp                     
+        TracyMemory.cpp                    
+        TracyMemory.hpp                    
+        TracyMicroArchitecture.cpp         
+        TracyMicroArchitecture.hpp         
+        TracyMmap.cpp                      
+        TracyMmap.hpp                      
+        TracyMouse.cpp                     
+        TracyMouse.hpp                     
+        TracyPopcnt.hpp                    
+        TracyPrint.cpp                     
+        TracyPrint.hpp                     
+        TracyShortPtr.hpp                  
+        TracySlab.hpp                      
+        TracySort.hpp                      
+        TracySortedVector.hpp              
+        TracySourceContents.cpp            
+        TracySourceContents.hpp            
+        TracySourceTokenizer.cpp           
+        TracySourceTokenizer.hpp           
+        TracySourceView.cpp                
+        TracySourceView.hpp                
+        TracyStorage.cpp                   
+        TracyStorage.hpp                   
+        TracyStringDiscovery.hpp           
+        TracyTaskDispatch.cpp              
+        TracyTaskDispatch.hpp              
+        TracyTexture.cpp                   
+        TracyTexture.hpp                   
+        TracyTextureCompression.cpp        
+        TracyTextureCompression.hpp        
+        TracyThreadCompress.cpp            
+        TracyThreadCompress.hpp            
+        TracyUserData.cpp                  
+        TracyUserData.hpp                  
+        TracyVarArray.hpp                  
+        TracyVector.hpp                    
+        TracyVersion.hpp                   
+        TracyView.cpp                      
+        TracyView.hpp                      
+        TracyViewData.hpp                  
+        TracyWeb.cpp                       
+        TracyWeb.hpp                       
+        TracyWorker.cpp                    
+        TracyWorker.hpp                    
+)
+target_include_directories(TracyServer
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+)
+target_compile_definitions(TracyServer
+    PRIVATE
+        $<$<PLATFORM_ID:Windows>:
+            _CRT_SECURE_NO_DEPRECATE
+            _CRT_NONSTDC_NO_DEPRECATE
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            _USE_MATH_DEFINES
+        >
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /permissive-
+            /W3
+        >
+)
+target_compile_features(TracyServer
+    PUBLIC
+        cxx_std_17
+)
+target_link_libraries(TracyServer
+    PUBLIC
+        TracyCommon
+        TracyImGui
+        $<IF:$<TARGET_EXISTS:zstd::libzstd_static>,zstd::libzstd_static,zstd::libzstd_shared>
+    PRIVATE
+        capstone::capstone
+)
+set_target_properties(TracyServer
+    PROPERTIES
+        CXX_STANDARD          17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS        OFF
+)
+

--- a/server/TracySourceView.cpp
+++ b/server/TracySourceView.cpp
@@ -2,7 +2,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 
-#include <capstone.h>
+#include <capstone/capstone.h>
 
 #include "imgui.h"
 #include "TracyCharUtil.hpp"

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -19,7 +19,7 @@
 #include <inttypes.h>
 #include <sys/stat.h>
 
-#include <capstone.h>
+#include <capstone/capstone.h>
 
 #define ZDICT_STATIC_LINKING_ONLY
 #include "../zstd/zdict.h"

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,12 @@
+{
+    "registries": [
+        {
+            "kind": "git",
+            "repository": "https://github.com/theblackunknown/vcpkg-registry.git",
+            "baseline": "e1d1a7e49dc9f84f411f8cc4d4b914908a04fb1a",
+            "packages": [
+                "capstone"
+            ]
+        }
+    ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "tracy",
+    "version-semver": "0.8.0",
+    "port-version": 0,
+    "description": "C++ frame profiler",
+    "homepage": "https://github.com/wolfpld/tracy",
+    "builtin-baseline": "af2287382b1991dbdcb7e5112d236f3323b9dd7a",
+    "dependencies": [
+        { "name": "capstone", "features":[ "arm", "arm64", "x86" ] },
+        "freetype",
+        "glfw3",
+        "zstd"
+    ]
+}

--- a/zstd/CMakeLists.txt
+++ b/zstd/CMakeLists.txt
@@ -1,0 +1,107 @@
+project(TracyZSTD LANGUAGES C ASM)
+
+add_library(TracyZSTD)
+add_library(Tracy::TracyZSTD ALIAS TracyZSTD)
+
+target_sources(TracyZSTD
+    PRIVATE
+        zdict.h         
+        zstd.h          
+        zstd_errors.h   
+        common/bitstream.h                
+        common/compiler.h                 
+        common/cpu.h                      
+        common/debug.c                    
+        common/debug.h                    
+        common/entropy_common.c           
+        common/error_private.c            
+        common/error_private.h            
+        common/fse.h                      
+        common/fse_decompress.c           
+        common/huf.h                      
+        common/mem.h                      
+        common/pool.c                     
+        common/pool.h                     
+        common/portability_macros.h       
+        common/threading.c                
+        common/threading.h                
+        common/xxhash.c                   
+        common/xxhash.h                   
+        common/zstd_common.c              
+        common/zstd_deps.h                
+        common/zstd_internal.h            
+        common/zstd_trace.h    
+        compress/clevels.h                             
+        compress/fse_compress.c                        
+        compress/hist.c                                
+        compress/hist.h                                
+        compress/huf_compress.c                        
+        compress/zstd_compress.c                       
+        compress/zstd_compress_internal.h              
+        compress/zstd_compress_literals.c              
+        compress/zstd_compress_literals.h              
+        compress/zstd_compress_sequences.c             
+        compress/zstd_compress_sequences.h             
+        compress/zstd_compress_superblock.c            
+        compress/zstd_compress_superblock.h            
+        compress/zstd_cwksp.h                          
+        compress/zstd_double_fast.c                    
+        compress/zstd_double_fast.h                    
+        compress/zstd_fast.c                           
+        compress/zstd_fast.h                           
+        compress/zstd_lazy.c                           
+        compress/zstd_lazy.h                           
+        compress/zstd_ldm.c                            
+        compress/zstd_ldm.h                            
+        compress/zstd_ldm_geartab.h                    
+        compress/zstd_opt.c                            
+        compress/zstd_opt.h                            
+        compress/zstdmt_compress.c                     
+        compress/zstdmt_compress.h           
+        decompress/huf_decompress.c                  
+        decompress/huf_decompress_amd64.S            
+        decompress/zstd_ddict.c                      
+        decompress/zstd_ddict.h                      
+        decompress/zstd_decompress.c                 
+        decompress/zstd_decompress_block.c           
+        decompress/zstd_decompress_block.h           
+        decompress/zstd_decompress_internal.h   
+        dictBuilder/cover.c             
+        dictBuilder/cover.h             
+        dictBuilder/divsufsort.c        
+        dictBuilder/divsufsort.h        
+        dictBuilder/fastcover.c         
+        dictBuilder/zdict.c                                       
+)
+target_include_directories(TracyZSTD
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+)
+target_compile_definitions(TracyZSTD
+    PRIVATE
+        $<$<PLATFORM_ID:Windows>:
+            _CRT_SECURE_NO_DEPRECATE
+            _CRT_NONSTDC_NO_DEPRECATE
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            _USE_MATH_DEFINES
+        >
+        $<$<CXX_COMPILER_ID:MSVC>:
+            /permissive-
+            /W3
+        >
+)
+target_compile_features(TracyZSTD
+    PUBLIC
+        cxx_std_17
+)
+set_target_properties(TracyZSTD
+    PROPERTIES
+        CXX_STANDARD          17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS        OFF
+)
+set_source_files_properties(decompress/huf_decompress_amd64.S
+    PROPERTIES
+        LANGUAGE ASM
+)


### PR DESCRIPTION
## Description

This PR add `capture` and `profiler` tool to the existing CMake setup.
Moreover, vpckg workflow is improved by adding a [vcpkg manifest](https://vcpkg.io/en/docs/users/manifests.html) which simplify how to declare `vcpkg` dependencies and how to use them in a CMake project.
The above is tested through a simple CMake Github Workflow, which relies on a `CMakePresets.json` to centralize the cross-platform CMake setup (outcome example here: https://github.com/theblackunknown/tracy/actions/workflows/cmake.yml).

Changes Highlights:
- `profiler` (aka `Tracy`) can be built through the CMake setup
- `capture` can be built through the CMake setup
- Internal Tracy library are declared as CMake targets (e.g. `server`, `common`)
- CMake dependency management is improved to support cross-platform development (e.g. leverage `pkg-config` on Linux platform)
- To use CMake presets, it is required to declare an environment variable `VCPKG_ROOT` pointing to a `vcpkg` repository. 
- `capstone` dependency has been upgraded to a `5.0.0` pre-release version to allow a clean `vcpkg` integration. This is not yet (pending PR microsoft/vcpkg#23979) an official port so I have routed it to my own vcpkg registry for now. 