### PR TITLE
Set thread init false on thread exit for manual lifetime cases

### DIFF
--- a/client/TracyThread.hpp
+++ b/client/TracyThread.hpp
@@ -14,6 +14,10 @@
 namespace tracy
 {
 
+#ifdef TRACY_MANUAL_LIFETIME
+extern thread_local bool RpThreadInitDone;
+#endif
+
 class ThreadExitHandler
 {
 public:
@@ -21,6 +25,7 @@ public:
     {
 #ifdef TRACY_MANUAL_LIFETIME
         rpmalloc_thread_finalize();
+        RpThreadInitDone = false;
 #endif
     }
 };


### PR DESCRIPTION
When starting/stopping tracy via manual lifetime the thread local init variable was not reset to false. Added a change to reset the variable back to false upon thread exit after the finalize function completes.