### PR TITLE
make progress info and ANSI escapes conditional on being a TTY

### DIFF
--- a/capture/src/capture.cpp
+++ b/capture/src/capture.cpp
@@ -68,24 +68,24 @@ bool IsStdoutATerminal() { return s_isStdoutATerminal; }
 // Like printf, but if stdout is a terminal, prepends the output with
 // the given `ansiEscape` and appends ANSI_RESET.
 void AnsiPrintf( const char* ansiEscape, const char* format, ... ) {
-  if( IsStdoutATerminal() )
-  {
-    // Prepend ansiEscape and append ANSI_RESET.
-    char buf[256];
-    va_list args;
-    va_start( args, format );
-    vsnprintf( buf, sizeof buf, format, args );
-    va_end( args );
-    printf( "%s%s" ANSI_RESET, ansiEscape, buf );
-  }
-  else
-  {
-    // Just a normal printf.
-    va_list args;
-    va_start( args, format );
-    vfprintf( stdout, format, args );
-    va_end( args );
-  }
+    if( IsStdoutATerminal() )
+    {
+        // Prepend ansiEscape and append ANSI_RESET.
+        char buf[256];
+        va_list args;
+        va_start( args, format );
+        vsnprintf( buf, sizeof buf, format, args );
+        va_end( args );
+        printf( "%s%s" ANSI_RESET, ansiEscape, buf );
+    }
+    else
+    {
+        // Just a normal printf.
+        va_list args;
+        va_start( args, format );
+        vfprintf( stdout, format, args );
+        va_end( args );
+    }
 }
 
 [[noreturn]] void Usage()


### PR DESCRIPTION
This queries whether `stdout` is a terminal as opposed to another kind of file/pipe, and adjusts logging accordingly:
* Only terminals are likely to support ANSI escapes.
* Even without ANSI escapes, the data transfer progress info can make log files much larger in our experience (we run Tracy capture as part of continuous integration [here](https://buildkite.com/iree/iree-benchmark/builds)).

Notes:
* The Windows path (using `_isatty`) is untested - hope I got it right. I read Microsoft docs and saw that `<io.h>` was the right header.
* I think this actually **fixes a tiny bug** in the last ANSI escape sequence at the end of the main function in the failure case: `\033[31;1failed!` was missing the final `m` closing the escape sequence.
* Noticing: one of the places actually selects **black** foreground color.  Wouldn't that be invisible on many terminals where black is the background color?