### PR TITLE
Make `disconnect` atomic as it's written by a signal handler.

### DIFF
--- a/capture/src/capture.cpp
+++ b/capture/src/capture.cpp
@@ -25,7 +25,7 @@
 #endif
 
 
-bool disconnect = false;
+volatile bool disconnect = false;
 
 void SigInt( int )
 {

--- a/capture/src/capture.cpp
+++ b/capture/src/capture.cpp
@@ -31,7 +31,7 @@
 // technically not allowed there, even though in practice it would work.
 // The good thing with C++11 atomics is that we can use atomic<bool> instead
 // here and be on the actually supported path.
-static std::atomic<bool> s_disconnect;
+static std::atomic<bool> s_disconnect { false };
 
 void SigInt( int )
 {


### PR DESCRIPTION
According to [cppreference](https://en.cppreference.com/w/cpp/utility/program/sig_atomic_t),

> Until C++11, which introduced [std::atomic](https://en.cppreference.com/w/cpp/atomic/atomic) and [std::atomic_signal_fence](https://en.cppreference.com/w/cpp/atomic/atomic_signal_fence), about the only thing a strictly conforming program could do in a signal handler was to assign a value to a volatile static std::sig_atomic_t variable and promptly return.

The `volatile` part seems important: without it, the program may not pick up updates to this value.

The `sig_atomic_t` type per se is probably not important in practice. The spec just needed a way to limit its atomicity commitment to suitably small types. `bool` is fine from that perspective.
