### PR TITLE
Removing C++11 option from msvc in meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -141,17 +141,23 @@ tracy_src = [
 
 tracy_public_include_dirs = include_directories('.')
 
+compiler = meson.get_compiler('cpp')
+override_options = []
+if compiler.get_id() != 'msvc'
+  override_options += 'cpp_std=c++11'
+endif
+
 if tracy_shared_libs
   tracy = shared_library('tracy', tracy_src, tracy_header_files,
     dependencies        : [ threads_dep ],
     include_directories : tracy_public_include_dirs,
-    override_options    : [ 'cpp_std=c++11' ],
+    override_options    : override_options,
     install             : true)
 else
   tracy = static_library('tracy', tracy_src, tracy_header_files,
     dependencies        : [ threads_dep ],
     include_directories : tracy_public_include_dirs,
-    override_options    : [ 'cpp_std=c++11' ],
+    override_options    : override_options,
     install             : true)
 endif
 


### PR DESCRIPTION
This PR is twofold; permission to add tracy to meson's wrapdb and a fix for the failed build on the wrapdb repo (https://github.com/mesonbuild/wrapdb/pull/399)

MSVC apparently doesn't support C++11. The relevant error from the CI:
```
Found ninja-1.10.2 at "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.EXE"
WARNING: msvc does not support C++11; attempting best effort; setting the standard to C++14

ERROR: Fatal warnings enabled, aborting
```