### PR TITLE
Fix unreachable error when compiling warnings as errors + timer fallback

### DIFF
--- a/client/TracyProfiler.hpp
+++ b/client/TracyProfiler.hpp
@@ -224,7 +224,9 @@ public:
 #  endif
 #endif
 
-        return 0;  // unreacheble branch
+#if !defined TRACY_TIMER_FALLBACK
+        return 0;  // unreachable branch
+#endif
     }
 
     tracy_force_inline uint32_t GetNextZoneId()


### PR DESCRIPTION
When we compile with warnings as errors and enable the timer fallback (for platforms that don't support the HW timer), run into an unreachable code error because the `return 0` can never be hit (i.e. either clock_gettime or std::chrono will return ahead of the return 0).



