### PR TITLE
Slight tweak to get client library working with mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ target_link_libraries(
         ${CMAKE_DL_LIBS}
 )
 
+# Public dependency on some libraries required when using Mingw
+if(WIN32 AND ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+    target_link_libraries(TracyClient PUBLIC ws2_32 dbghelp)
+endif()
+
 if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
     find_library(EXECINFO_LIBRARY NAMES execinfo REQUIRED)
     target_link_libraries(TracyClient PUBLIC ${EXECINFO_LIBRARY})
@@ -123,6 +128,6 @@ install(FILES ${client_includes}
 install(FILES ${common_includes}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/common)
 install(EXPORT TracyConfig
-		NAMESPACE Tracy::
+        NAMESPACE Tracy::
         FILE TracyConfig.cmake
         DESTINATION share/Tracy)

--- a/client/TracySysTrace.cpp
+++ b/client/TracySysTrace.cpp
@@ -265,7 +265,7 @@ void WINAPI EventRecordCallbackVsync( PEVENT_RECORD record )
 
 static void SetupVsync()
 {
-#if _WIN32_WINNT >= _WIN32_WINNT_WINBLUE && !__MINGW32__
+#if _WIN32_WINNT >= _WIN32_WINNT_WINBLUE && !defined(__MINGW32__)
     const auto psz = sizeof( EVENT_TRACE_PROPERTIES ) + MAX_PATH;
     s_propVsync = (EVENT_TRACE_PROPERTIES*)tracy_malloc( psz );
     memset( s_propVsync, 0, sizeof( EVENT_TRACE_PROPERTIES ) );

--- a/client/TracySysTrace.cpp
+++ b/client/TracySysTrace.cpp
@@ -265,7 +265,7 @@ void WINAPI EventRecordCallbackVsync( PEVENT_RECORD record )
 
 static void SetupVsync()
 {
-#if _WIN32_WINNT >= _WIN32_WINNT_WINBLUE
+#if _WIN32_WINNT >= _WIN32_WINNT_WINBLUE && !__MINGW32__
     const auto psz = sizeof( EVENT_TRACE_PROPERTIES ) + MAX_PATH;
     s_propVsync = (EVENT_TRACE_PROPERTIES*)tracy_malloc( psz );
     memset( s_propVsync, 0, sizeof( EVENT_TRACE_PROPERTIES ) );


### PR DESCRIPTION
Opening this as a draft because I'm sure there are some side effects here that I'm not exactly privy to.

Tested against:
```
gcc --version
gcc (GCC) 11.2.0
```

I was curious about getting tracy working with Mingw for a side project of mine. Dug in a bit and came up with this change to just disable the body of SetupVsync when compiling with mingw. That and adding some public dependencies to make it easier to consume from CMake and this worked find with a test project of mine. However I didn't really do a complete exhaustive test. I figured discussion might be warranted / there might be a good reason why this isn't fit for upstream. I came across some gitter chat archive where mingw was known to be broken and purposefully disabled on CI but that was in the context of Mingw 8.1.0 IIRC.

Thoughts? Ideas for other stuff I should test with this?