### PR TITLE
Add lower case e and b tags

### DIFF
--- a/import-chrome/src/import-chrome.cpp
+++ b/import-chrome/src/import-chrome.cpp
@@ -218,7 +218,7 @@ int main( int argc, char** argv )
             }
         }
 
-        if( type == "B" )
+        if( type == "b" || type == "B" )
         {
             timeline.emplace_back( tracy::Worker::ImportEventTimeline {
                 getPseudoTid(v),
@@ -230,7 +230,7 @@ int main( int argc, char** argv )
                 locLine
             } );
         }
-        else if( type == "E" )
+        else if( type == "e" || type == "E" )
         {
             timeline.emplace_back( tracy::Worker::ImportEventTimeline {
                 getPseudoTid(v),


### PR DESCRIPTION
Trivial fix: Add lower case e and b tags for chrome importer. 
When using performance.measure to capture user timings they are written by chrome with lower case "b" and "e" tags. 
This change allows importing them. 