### PR TITLE
Fix crash when compare trace not selected

### DIFF
--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -11822,8 +11822,8 @@ void View::DrawCompare()
                 {
                     m_compare.badVer.state = BadVersionState::ReadError;
                 }
+                NFD_FreePathU8( fn );
             }
-            NFD_FreePathU8( fn );
         }
         tracy::BadVersion( m_compare.badVer, m_bigFont );
         ImGui::End();


### PR DESCRIPTION
`NFD_FreePathU8` freed invalid pointer if the user closed the file selection dialog without selecting a file. Now it's the same as when opening a trace in `main.cpp`.