### PR TITLE
Add ability to filter callstacks in memory tab by inactive allocations.

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3284,7 +3284,7 @@ Each tree node consists of the function name, the source file location, and the 
 
 The \emph{Group by function name} option controls how tree nodes are grouped. If it is disabled, the grouping is performed at a machine instruction-level granularity. This may result in a very verbose output, but the displayed source locations are precise. To make the tree more readable, you may opt to perform grouping at the function name level, which will result in less valid source file locations, as multiple entries are collapsed into one.
 
-Enabling the \emph{Only active allocations} option will limit the call stack tree only to display active allocations.
+Enabling the \emph{Only active allocations} option will limit the call stack tree only to display active allocations. Enabling \emph{Only inactive allocations} option will have similar effect for inactive allocations. Both are mutually exclusive, enabling one disables the other. Displaing inactive allocations, when combined with \emph{Limit range}, will show short lived allocatios highlighting potentially unwanted behavior in the code.
 
 Clicking the \RMB{}~right mouse button on the function name will open the allocations list window (see section \ref{alloclist}), which lists all the allocations included at the current call stack tree level. Likewise, clicking the \RMB{}~right mouse button on the source file location will open the source file view window (if applicable, see section~\ref{sourceview}).
 

--- a/server/TracyView.hpp
+++ b/server/TracyView.hpp
@@ -147,6 +147,13 @@ private:
         LastRange
     };
 
+    enum class MemRange
+    {
+        Full,
+        Active,
+        Inactive
+    };
+
     struct ZoneColorData
     {
         uint32_t color;
@@ -227,7 +234,7 @@ private:
 
     void ListMemData( std::vector<const MemEvent*>& vec, std::function<void(const MemEvent*)> DrawAddress, const char* id = nullptr, int64_t startTime = -1, uint64_t pool = 0 );
 
-    unordered_flat_map<uint32_t, MemPathData> GetCallstackPaths( const MemData& mem, bool onlyActive ) const;
+    unordered_flat_map<uint32_t, MemPathData> GetCallstackPaths( const MemData& mem, MemRange memRange ) const;
     unordered_flat_map<uint64_t, MemCallstackFrameTree> GetCallstackFrameTreeBottomUp( const MemData& mem ) const;
     unordered_flat_map<uint64_t, MemCallstackFrameTree> GetCallstackFrameTreeTopDown( const MemData& mem ) const;
     void DrawFrameTreeLevel( const unordered_flat_map<uint64_t, MemCallstackFrameTree>& tree, int& idx );
@@ -494,8 +501,8 @@ private:
 
     bool m_groupCallstackTreeByNameBottomUp = true;
     bool m_groupCallstackTreeByNameTopDown = true;
-    bool m_activeOnlyBottomUp = false;
-    bool m_activeOnlyTopDown = false;
+    MemRange m_memRangeBottomUp = MemRange::Full;
+    MemRange m_memRangeTopDown = MemRange::Full;
 
     enum class SaveThreadState
     {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1197433/171344803-07f032cd-8552-4f23-9893-d9e1057ab879.png)

Filtering by inactive allocations helps to pin point wasteful allocations in the app.
