### PR TITLE
Fix macOS GCC 11/12 compile error

### DIFF
--- a/libbacktrace/macho.cpp
+++ b/libbacktrace/macho.cpp
@@ -1292,7 +1292,7 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
   else
     {
       if (found_sym)
-	backtrace_atomic_store_pointer (&state->syminfo_fn, macho_syminfo);
+	backtrace_atomic_store_pointer (&state->syminfo_fn, &macho_syminfo);
       else
 	(void) __sync_bool_compare_and_swap (&state->syminfo_fn, NULL,
 					     macho_nosyms);
@@ -1338,7 +1338,7 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
   else
     {
       if (found_sym)
-	backtrace_atomic_store_pointer (&state->syminfo_fn, macho_syminfo);
+	backtrace_atomic_store_pointer (&state->syminfo_fn, &macho_syminfo);
       else
 	(void) __sync_bool_compare_and_swap (&state->syminfo_fn, NULL,
 					     macho_nosyms);


### PR DESCRIPTION
GCC 11 and 12 installed via HomeBrew on macOS cause a compile error:

```
brew install gcc@11 gcc@12
cd tracy/test
CC=gcc-11 CXX=g++-11 make
```

```
../libbacktrace/macho.cpp: In function 'int tracy::backtrace_initialize(backtrace_state*, const char*, int, backtrace_error_callback, void*, int (**)(backtrace_state*, uintptr_t, backtrace_full_callback, backtrace_error_callback, void*))':
../libbacktrace/macho.cpp:1295:61: error: cannot convert 'tracy::macho_syminfo' from type 'void(tracy::backtrace_state*, uintptr_t, tracy::backtrace_syminfo_callback, tracy::backtrace_error_callback, void*)' {aka 'void(tracy::backtrace_state*, long unsigned int, void (*)(void*, long unsigned int, const char*, long unsigned int, long unsigned int), void (*)(void*, const char*, int), void*)'} to type 'void (*)(tracy::backtrace_state*, uintptr_t, tracy::backtrace_syminfo_callback, tracy::backtrace_error_callback, void*)' {aka 'void (*)(tracy::backtrace_state*, long unsigned int, void (*)(void*, long unsigned int, const char*, long unsigned int, long unsigned int), void (*)(void*, const char*, int), void*)'}
 1295 |         backtrace_atomic_store_pointer (&state->syminfo_fn, macho_syminfo);
```

This minor change allows compilation.