### PR TITLE
fix tracy worker threads conflict

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -7162,6 +7162,7 @@ void Worker::ReconstructMemAllocPlot( MemData& mem )
     {
         std::lock_guard<std::mutex> lock( m_data.lock );
         plot = m_slab.AllocInit<PlotData>();
+        plot->data.reserve_exact( psz, m_slab );
     }
 
     plot->name = mem.name;
@@ -7170,7 +7171,6 @@ void Worker::ReconstructMemAllocPlot( MemData& mem )
     plot->showSteps = true;
     plot->fill = true;
     plot->color = 0;
-    plot->data.reserve_exact( psz, m_slab );
 
     auto aptr = mem.data.begin();
     auto aend = mem.data.end();


### PR DESCRIPTION
tracy [launches multiple threads](https://github.com/wolfpld/tracy/blob/cb58b4803a2beb36d4c6cf89593865af1ef6fec3/server/TracyWorker.cpp#L1814) exec ReconstructMemAllocPlot(). In that function, [it uses lock to coordinate memory allocations between threads, but forgot to include plot->data.reserve_exact() in the locked scope too, so sometimes two data have overlap in the allocated memory block](https://github.com/wolfpld/tracy/blob/cb58b4803a2beb36d4c6cf89593865af1ef6fec3/server/TracyWorker.cpp#L7112-L7119).