### PR TITLE
Add right click jump to assembly loc in symbol view

### DIFF
--- a/server/TracySourceView.cpp
+++ b/server/TracySourceView.cpp
@@ -3293,7 +3293,10 @@ void SourceView::RenderLine( const Tokenizer::Line& line, int lineNum, const Add
         if( !mouseHandled && ( ImGui::IsMouseClicked( 0 ) || ImGui::IsMouseClicked( 1 ) ) )
         {
             m_displayMode = DisplayMixed;
-            SelectLine( lineNum, worker, ImGui::IsMouseClicked( 1 ) );
+            auto targetAddresses = worker->GetAddressesForLocation( m_source.idx(), lineNum );
+            auto hasTarget = targetAddresses && !targetAddresses->empty();
+            auto midAddress = hasTarget ? targetAddresses->operator[]( targetAddresses->size() / 2 ) : 0;
+            SelectLine( lineNum, worker, ImGui::IsMouseClicked( 1 ), midAddress );
         }
         else
         {


### PR DESCRIPTION
I feel like intuitively this should be a left click operation, but that is likely a matter of preference - and consistency is probably more important here.

(I'd also argue shift+click is more natural for 'selecting' a line, rather than left click)