### PR TITLE
Add assembly syntax colouring

### DIFF
--- a/server/TracyImGui.hpp
+++ b/server/TracyImGui.hpp
@@ -53,6 +53,24 @@ static constexpr const ImVec4 SyntaxColorsDimmed[] = {
     { 0.21f, 0.69f, 0.89f, 0.6f },    // special
 };
 
+static constexpr const ImVec4 AsmSyntaxColors[] = {
+        { 0.25f, 0.52f, 0.96f, 1 },    // mnemonic
+        { 0.64f, 0.82f, 1,     1 },    // label
+        { 0.7f,  0.7f,  0.7f,  1 },    // default ('[', '+', '*', ',')
+        { 0.25f, 0.74f, 0.38f, 1 },    // dword/xmmword 'ptr'
+        { 0.78f, 0.46f, 0.75f, 1 },    // register
+        { 0.81f, 0.6f,  0.91f, 1 },    // literal
+};
+
+static constexpr const ImVec4 AsmSyntaxColorsDimmed[] = {
+        { 0.25f, 0.52f, 0.96f, 0.6f },    // mnemonic
+        { 0.64f, 0.82f, 1,     0.6f },    // label
+        { 0.7f,  0.7f,  0.7f,  0.6f },    // default ('[', '+', '*', ',')
+        { 0.25f, 0.74f, 0.38f, 0.6f },    // dword/xmmword 'ptr'
+        { 0.78f, 0.46f, 0.75f, 0.6f  },    // register
+        { 0.81f, 0.6f,  0.91f, 0.6f },    // literal
+};
+
 
 [[maybe_unused]] static inline float GetScale()
 {

--- a/server/TracySourceTokenizer.hpp
+++ b/server/TracySourceTokenizer.hpp
@@ -2,7 +2,9 @@
 #define __TRACYSOURCETOKENIZER_HPP__
 
 #include <stdint.h>
+#include <cstdint>
 #include <vector>
+#include <string>
 
 namespace tracy
 {
@@ -24,11 +26,28 @@ public:
         Special
     };
 
+    enum class AsmTokenColor : uint8_t
+    {
+        Mnemonic,       // no-op, padding
+        Label,          // no-op, padding
+        Default,        // '+', '[', '*', etc
+        SizeDirective,   // byte, word, dword, etc
+        Register,       // rax, rip, etc
+        Literal,        // 0x04, etc
+    };
+
     struct Token
     {
         const char* begin;
         const char* end;
         TokenColor color;
+    };
+
+    struct AsmToken
+    {
+        uint8_t beginIdx;
+        uint8_t endIdx;
+        AsmTokenColor color;
     };
 
     struct Line
@@ -38,9 +57,16 @@ public:
         std::vector<Token> tokens;
     };
 
+    struct AsmOperand
+    {
+        std::string string;
+        std::vector<AsmToken> tokens;
+    };
+
     Tokenizer();
 
     std::vector<Token> Tokenize( const char* begin, const char* end );
+    AsmOperand TokenizeAsmOperand( const char assemblyText[160] );
 
 private:
     TokenColor IdentifyToken( const char*& begin, const char* end );

--- a/server/TracySourceView.hpp
+++ b/server/TracySourceView.hpp
@@ -82,7 +82,7 @@ private:
         uint64_t addr;
         uint64_t jumpAddr;
         std::string mnemonic;
-        std::string operands;
+        Tokenizer::AsmOperand operands;
         uint8_t len;
         LeaData leaData;
         bool jumpConditional;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48577820/187176237-d3f18f5d-d2eb-4be0-8d92-e45233ecf6d9.png)

Makes the asm view a little easier (or harder) on the eyes. I bear no attachment to the chosen colours - This is a pretty simple change, just adds some basic syntax highlighting for the asm, splitting registers/directives/opcodes.

There is still some work to be done in:
- [x] Formatting
- [x] Renaming `Tokenizer::AsmOperandString` to something more to the point
- [x] Implementing any feedback
- [x] Support for ARM assembly
- [x] Fix bug wherein the 'click' to select an element is currently the last token rendered. Entire group should be clickable

I also suspect there may be a desire to move the storage of all the assembly information into its own struct similar to `TracySourceContents.hpp`, however I am not planning to do this in this change.

Would like to hear any opinions you have regarding the implementation / suggestions regarding alternate approaches.

I'm also interested in any feedback regarding ideas for reducing the amount of space taken up in the margins for both the source / assembly views for things like hardware counters / src -> assembly line count.