### PR TITLE
CMake: Add option to explicitly set lib type 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,19 @@ cmake_minimum_required(VERSION 3.10)
 
 project(Tracy LANGUAGES CXX)
 
+option(TRACY_STATIC "Whether to build Tracy as a static library" NOT ${BUILD_SHARED_LIBS})
+
 find_package(Threads REQUIRED)
 
 set(TRACY_PUBLIC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/public)
 
-add_library(TracyClient "${TRACY_PUBLIC_DIR}/TracyClient.cpp")
+if(TRACY_STATIC)
+	set(TRACY_VISIBILITY "STATIC")
+else()
+	set(TRACY_VISIBILITY "SHARED")
+endif()
+
+add_library(TracyClient ${TRACY_VISIBILITY} "${TRACY_PUBLIC_DIR}/TracyClient.cpp")
 target_compile_features(TracyClient PUBLIC cxx_std_11)
 target_include_directories(TracyClient SYSTEM PUBLIC
     $<BUILD_INTERFACE:${TRACY_PUBLIC_DIR}>
@@ -62,7 +70,7 @@ set_option(TRACY_FIBERS "Enable fibers support" OFF)
 set_option(TRACY_NO_CRASH_HANDLER "Disable crash handling" OFF)
 set_option(TRACY_TIMER_FALLBACK "Use lower resolution timers" OFF)
 
-if(BUILD_SHARED_LIBS)
+if(NOT TRACY_STATIC)
     target_compile_definitions(TracyClient PRIVATE TRACY_EXPORTS)
     target_compile_definitions(TracyClient PUBLIC TRACY_IMPORTS)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(Threads REQUIRED)
 
 set(TRACY_PUBLIC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/public)
 
-add_library(TracyClient public/TracyClient.cpp)
+add_library(TracyClient "${TRACY_PUBLIC_DIR}/TracyClient.cpp")
 target_compile_features(TracyClient PUBLIC cxx_std_11)
 target_include_directories(TracyClient SYSTEM PUBLIC
     $<BUILD_INTERFACE:${TRACY_PUBLIC_DIR}>


### PR DESCRIPTION
With this new option, it is now possible to explicitly build Tracy as a
shared or static library independent from the BUILD_SHARED_LIBS
variable, which always acts on a global scope (thus, affecting all CMake
targets).

If the options is not explicitly given, it will default to whatever
BUILD_SHARED_LIBS would indicate, leaving the default behavior
unchanged.