### PR TITLE
CMake: Fix invalid syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,13 @@ cmake_minimum_required(VERSION 3.10)
 
 project(Tracy LANGUAGES CXX)
 
-option(TRACY_STATIC "Whether to build Tracy as a static library" NOT ${BUILD_SHARED_LIBS})
+if(${BUILD_SHARED_LIBS})
+	set(DEFAULT_STATIC OFF)
+else()
+	set(DEFAULT_STATIC ON)
+endif()
+
+option(TRACY_STATIC "Whether to build Tracy as a static library" ${DEFAULT_STATIC})
 
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
In 1f7656e8454ae96f1657cf91abe8b01dc667689c I introduced a new option
but for setting its default value, I accidentally introduced invalid
cmake syntax that blows off as soon as BUILD_SHARED_LIBS is actually
defined to be non-empty.