### PR TITLE
Added gpu calibration to the C API

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4219,6 +4219,16 @@ TRACY_API void ___tracy_emit_gpu_context_name( const struct ___tracy_gpu_context
     TracyLfqCommitC;
 }
 
+TRACY_API void ___tracy_emit_gpu_calibration( const struct ___tracy_gpu_calibration_data data )
+{
+    TracyLfqPrepareC( tracy::QueueType::GpuCalibration );
+    tracy::MemWrite( &item->gpuCalibration.cpuTime, tracy::Profiler::GetTime() );
+    tracy::MemWrite( &item->gpuCalibration.gpuTime, data.gpuTime );
+    tracy::MemWrite( &item->gpuCalibration.cpuDelta, data.cpuDelta );
+    tracy::MemWrite( &item->gpuCalibration.context, data.context );
+    TracyLfqCommitC;
+}
+
 TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_serial( const struct ___tracy_gpu_zone_begin_data data )
 {
     auto item = tracy::Profiler::QueueSerial();
@@ -4276,6 +4286,17 @@ TRACY_API void ___tracy_emit_gpu_context_name_serial( const struct ___tracy_gpu_
     tracy::MemWrite( &item->gpuContextNameFat.context, data.context );
     tracy::MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)ptr );
     tracy::MemWrite( &item->gpuContextNameFat.size, data.len );
+    tracy::Profiler::QueueSerialFinish();
+}
+
+TRACY_API void ___tracy_emit_gpu_calibration_serial( const struct ___tracy_gpu_calibration_data data )
+{
+    auto item = tracy::Profiler::QueueSerial();
+    tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuCalibration );
+    tracy::MemWrite( &item->gpuCalibration.cpuTime, tracy::Profiler::GetTime() );
+    tracy::MemWrite( &item->gpuCalibration.gpuTime, data.gpuTime );
+    tracy::MemWrite( &item->gpuCalibration.cpuDelta, data.cpuDelta );
+    tracy::MemWrite( &item->gpuCalibration.context, data.context );
     tracy::Profiler::QueueSerialFinish();
 }
 

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -177,7 +177,7 @@ TRACY_API void ___tracy_emit_gpu_zone_end_serial( const struct ___tracy_gpu_zone
 TRACY_API void ___tracy_emit_gpu_time_serial( const struct ___tracy_gpu_time_data );
 TRACY_API void ___tracy_emit_gpu_new_context_serial( const struct ___tracy_gpu_new_context_data );
 TRACY_API void ___tracy_emit_gpu_context_name_serial( const struct ___tracy_gpu_context_name_data );
-TRACY_API void ___tracy_emit_gpu_calibration_serial(const struct ___tracy_gpu_calibration_data );
+TRACY_API void ___tracy_emit_gpu_calibration_serial( const struct ___tracy_gpu_calibration_data );
 
 TRACY_API int ___tracy_connected(void);
 

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -136,6 +136,12 @@ struct ___tracy_gpu_context_name_data {
     uint16_t len;
 };
 
+struct ___tracy_gpu_calibration_data {
+    int64_t gpuTime;
+    int64_t cpuDelta;
+    uint8_t context;
+};
+
 // Some containers don't support storing const types.
 // This struct, as visible to user, is immutable, so treat it as if const was declared here.
 typedef /*const*/ struct ___tracy_c_zone_context TracyCZoneCtx;
@@ -164,12 +170,14 @@ TRACY_API void ___tracy_emit_gpu_zone_end( const struct ___tracy_gpu_zone_end_da
 TRACY_API void ___tracy_emit_gpu_time( const struct ___tracy_gpu_time_data );
 TRACY_API void ___tracy_emit_gpu_new_context( const struct ___tracy_gpu_new_context_data );
 TRACY_API void ___tracy_emit_gpu_context_name( const struct ___tracy_gpu_context_name_data );
+TRACY_API void ___tracy_emit_gpu_calibration( const struct ___tracy_gpu_calibration_data );
 
 TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_serial( const struct ___tracy_gpu_zone_begin_data );
 TRACY_API void ___tracy_emit_gpu_zone_end_serial( const struct ___tracy_gpu_zone_end_data data );
 TRACY_API void ___tracy_emit_gpu_time_serial( const struct ___tracy_gpu_time_data );
 TRACY_API void ___tracy_emit_gpu_new_context_serial( const struct ___tracy_gpu_new_context_data );
 TRACY_API void ___tracy_emit_gpu_context_name_serial( const struct ___tracy_gpu_context_name_data );
+TRACY_API void ___tracy_emit_gpu_calibration_serial(const struct ___tracy_gpu_calibration_data );
 
 TRACY_API int ___tracy_connected(void);
 


### PR DESCRIPTION
I am currently integrating Tracy into a C project. Additionally to the CPU profiling I also wanted to use Tracy for GPU profiling with Vulkan. One thing that was missing compared to the C++ API was the ability to calibrate the GPU timestamps. This PR adds the ___tracy_emit_gpu_calibration and ___tracy_emit_gpu_calibration_serial calls to the C API of Tracy to be able to calibrate GPU timestamps from the C API.