### PR TITLE
Windows exception handler allows other handlers to be called.

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -843,8 +843,6 @@ LONG WINAPI CrashFilter( PEXCEPTION_POINTERS pExp )
     GetProfiler().RequestShutdown();
     while( !GetProfiler().HasShutdownFinished() ) { std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) ); };
 
-    TerminateProcess( GetCurrentProcess(), 1 );
-
     return EXCEPTION_CONTINUE_SEARCH;
 }
 #endif


### PR DESCRIPTION
The profiled app might install handlers to track crashes, write minidumps, etc. - this patch makes sure the app's exception handler is called when a crash happens while profiling with Tracy.