### PR TITLE
Initialize some variables in client

### DIFF
--- a/public/client/TracyCallstack.cpp
+++ b/public/client/TracyCallstack.cpp
@@ -661,7 +661,7 @@ static void InitKernelSymbols()
         while( *ptr != '\t' && *ptr != '\n' ) ptr++;
         const auto nameend = ptr;
         const char* modstart = nullptr;
-        const char* modend;
+        const char* modend = nullptr;
         if( *ptr == '\t' )
         {
             ptr += 2;

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -1241,7 +1241,7 @@ void SysTraceWorker( void* ptr )
 #if defined TRACY_HW_TIMER && ( defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64 )
                         t0 = ring.ConvertTimeToTsc( t0 );
 #endif
-                        QueueType type;
+                        QueueType type{};
                         switch( id )
                         {
                         case EventCpuCycles:
@@ -1313,7 +1313,7 @@ void SysTraceWorker( void* ptr )
                 while( activeNum > 0 )
                 {
                     int sel = -1;
-                    int selPos;
+                    int selPos = -1;
                     int64_t t0 = std::numeric_limits<int64_t>::max();
                     for( int i=0; i<activeNum; i++ )
                     {


### PR DESCRIPTION
I was trying to integrate Tracy in a project that is built using the following flags:
```
-Wno-comment -Wno-reorder -Wno-unused-variable -Wtype-limits -std=c++11 -fno-strict-aliasing -Wno-unused-but-set-variable -march=native -mfpmath=sse -mavx2 -DLV_HAVE_AVX2 -DLV_HAVE_AVX -DLV_HAVE_SSE -fvisibility=hidden -O3 -fno-trapping-math -fno-math-errno -DBUILD_TYPE_RELEASE -finstrument-functions -Werror -O3 -DNDEBUG
```

When doing that, the build procedure was failing due to issues similar to the following:
```
error: ‘<variableName>’ may be used uninitialized [-Werror=maybe-uninitialized]
```
The commit proposed in this pull request solves the issue by initializing some variables in the client.

It is possible to reproduce the issue by setting the flags above in the tracy/test Makefile, and building the test.