### PR TITLE
Fix Fedora 36 compilation issue.

### DIFF
--- a/server/tracy_robin_hood.h
+++ b/server/tracy_robin_hood.h
@@ -47,6 +47,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <limits>
 #if __cplusplus >= 201703L
 #    include <string_view>
 #endif


### PR DESCRIPTION
```
error: ‘numeric_limits’ is not a member of ‘std’.
```