### PR TITLE
Fix compilation error on linux when TRACY_NO_CRASH_HANDLER defined

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -854,7 +854,7 @@ std::atomic<bool> s_symbolThreadGone { false };
 static Thread* s_sysTraceThread = nullptr;
 #endif
 
-#if defined __linux__ && !defined TRACY_NO_CRASH_HANDLER
+#if defined __linux__
 #  ifndef TRACY_CRASH_SIGNAL
 #    define TRACY_CRASH_SIGNAL SIGPWR
 #  endif


### PR DESCRIPTION
On Linux, when `TRACY_NO_CRASH_HANDLER` is defined, there is a compilation error here: https://github.com/threespace/tracy/blob/fix/compile_on_linux_without_crash_handlers/public/client/TracyProfiler.cpp#L1460 due to `TRACY_CRASH_SIGNAL` not being defined. This PR just makes sure that `TRACY_CRASH_SIGNAL` is defined no matter what.