### PR TITLE
Fix build when TRACY_HAS_CALLSTACK is not defined

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4172,6 +4172,7 @@ TRACY_API void ___tracy_emit_gpu_zone_begin( const struct ___tracy_gpu_zone_begi
     TracyLfqCommitC;
 }
 
+#ifdef TRACY_HAS_CALLSTACK
 TRACY_API void ___tracy_emit_gpu_zone_begin_callstack( const struct ___tracy_gpu_zone_begin_callstack_data data )
 {
     tracy::GetProfiler().SendCallstack( data.depth );
@@ -4183,6 +4184,7 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_callstack( const struct ___tracy_gpu
     tracy::MemWrite( &item->gpuZoneBegin.srcloc, data.srcloc );
     TracyLfqCommitC;
 }
+#endif
 
 TRACY_API void ___tracy_emit_gpu_zone_begin_alloc( const struct ___tracy_gpu_zone_begin_data data )
 {
@@ -4195,6 +4197,7 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_alloc( const struct ___tracy_gpu_zon
     TracyLfqCommitC;
 }
 
+#ifdef TRACY_HAS_CALLSTACK
 TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_callstack( const struct ___tracy_gpu_zone_begin_callstack_data data )
 {
     tracy::GetProfiler().SendCallstack( data.depth );
@@ -4206,6 +4209,7 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_callstack( const struct ___tra
     tracy::MemWrite( &item->gpuZoneBegin.context, data.context );
     TracyLfqCommitC;
 }
+#endif
 
 TRACY_API void ___tracy_emit_gpu_time( const struct ___tracy_gpu_time_data data )
 {
@@ -4273,6 +4277,7 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_serial( const struct ___tracy_gpu_zo
     tracy::Profiler::QueueSerialFinish();
 }
 
+#ifdef TRACY_HAS_CALLSTACK
 TRACY_API void ___tracy_emit_gpu_zone_begin_callstack_serial( const struct ___tracy_gpu_zone_begin_callstack_data data )
 {
     auto item = tracy::Profiler::QueueSerialCallstack( tracy::Callstack( data.depth ) );
@@ -4284,6 +4289,7 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_callstack_serial( const struct ___tr
     tracy::MemWrite( &item->gpuZoneBegin.context, data.context );
     tracy::Profiler::QueueSerialFinish();
 }
+#endif
 
 TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_serial( const struct ___tracy_gpu_zone_begin_data data )
 {
@@ -4297,6 +4303,7 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_serial( const struct ___tracy_
     tracy::Profiler::QueueSerialFinish();
 }
 
+#ifdef TRACY_HAS_CALLSTACK
 TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_callstack_serial( const struct ___tracy_gpu_zone_begin_callstack_data data )
 {
     auto item = tracy::Profiler::QueueSerialCallstack( tracy::Callstack( data.depth ) );
@@ -4308,6 +4315,7 @@ TRACY_API void ___tracy_emit_gpu_zone_begin_alloc_callstack_serial( const struct
     tracy::MemWrite( &item->gpuZoneBegin.context, data.context );
     tracy::Profiler::QueueSerialFinish();
 }
+#endif
 
 TRACY_API void ___tracy_emit_gpu_time_serial( const struct ___tracy_gpu_time_data data )
 {

--- a/public/tracy/TracyD3D11.hpp
+++ b/public/tracy/TracyD3D11.hpp
@@ -275,6 +275,7 @@ public:
         Profiler::QueueSerialFinish();
     }
 
+#ifdef TRACY_HAS_CALLSTACK
     tracy_force_inline D3D11ZoneScope( D3D11Ctx* ctx, const SourceLocationData* srcloc, int depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
@@ -303,6 +304,7 @@ public:
 
         GetProfiler().SendCallstack( depth );
     }
+#endif
 
     tracy_force_inline D3D11ZoneScope(D3D11Ctx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, bool active)
 #ifdef TRACY_ON_DEMAND
@@ -333,6 +335,7 @@ public:
         Profiler::QueueSerialFinish();
     }
 
+#ifdef TRACY_HAS_CALLSTACK
     tracy_force_inline D3D11ZoneScope(D3D11Ctx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int depth, bool active)
 #ifdef TRACY_ON_DEMAND
         : m_active(active&& GetProfiler().IsConnected())
@@ -361,6 +364,7 @@ public:
 
         Profiler::QueueSerialFinish();
     }
+#endif
 
     tracy_force_inline ~D3D11ZoneScope()
     {

--- a/public/tracy/TracyD3D12.hpp
+++ b/public/tracy/TracyD3D12.hpp
@@ -345,6 +345,7 @@ namespace tracy
 			Profiler::QueueSerialFinish();
 		}
 
+#ifdef TRACY_HAS_CALLSTACK
 		tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, ID3D12GraphicsCommandList* cmdList, const SourceLocationData* srcLocation, int depth, bool active)
 #ifdef TRACY_ON_DEMAND
 			: m_active(active&& GetProfiler().IsConnected())
@@ -370,6 +371,7 @@ namespace tracy
 
 			Profiler::QueueSerialFinish();
 		}
+#endif
 
 		tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, ID3D12GraphicsCommandList* cmdList, bool active)
 #ifdef TRACY_ON_DEMAND
@@ -399,6 +401,7 @@ namespace tracy
 			Profiler::QueueSerialFinish();
 		}
 
+#ifdef TRACY_HAS_CALLSTACK
 		tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, ID3D12GraphicsCommandList* cmdList, int depth, bool active)
 #ifdef TRACY_ON_DEMAND
 			: m_active(active&& GetProfiler().IsConnected())
@@ -426,6 +429,7 @@ namespace tracy
 
 			Profiler::QueueSerialFinish();
 		}
+#endif
 
 		tracy_force_inline ~D3D12ZoneScope()
 		{

--- a/public/tracy/TracyOpenCL.hpp
+++ b/public/tracy/TracyOpenCL.hpp
@@ -255,6 +255,7 @@ namespace tracy {
             Profiler::QueueSerialFinish();
         }
 
+#ifdef TRACY_HAS_CALLSTACK
         tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, const SourceLocationData* srcLoc, int depth, bool is_active)
 #ifdef TRACY_ON_DEMAND
             : m_active(is_active&& GetProfiler().IsConnected())
@@ -279,6 +280,7 @@ namespace tracy {
             MemWrite(&item->gpuZoneBegin.context, ctx->GetId());
             Profiler::QueueSerialFinish();
         }
+#endif
 
         tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, bool is_active)
 #ifdef TRACY_ON_DEMAND
@@ -304,6 +306,7 @@ namespace tracy {
             Profiler::QueueSerialFinish();
         }
 
+#ifdef TRACY_HAS_CALLSTACK
         tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int depth, bool is_active)
 #ifdef TRACY_ON_DEMAND
             : m_active(is_active && GetProfiler().IsConnected())
@@ -327,6 +330,7 @@ namespace tracy {
             MemWrite(&item->gpuZoneBegin.context, ctx->GetId());
             Profiler::QueueSerialFinish();
         }
+#endif
 
         tracy_force_inline void SetEvent(cl_event event)
         {

--- a/public/tracy/TracyVulkan.hpp
+++ b/public/tracy/TracyVulkan.hpp
@@ -360,6 +360,7 @@ public:
         Profiler::QueueSerialFinish();
     }
 
+#ifdef TRACY_HAS_CALLSTACK
     tracy_force_inline VkCtxScope( VkCtx* ctx, const SourceLocationData* srcloc, VkCommandBuffer cmdbuf, int depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
@@ -383,6 +384,7 @@ public:
         MemWrite( &item->gpuZoneBegin.context, ctx->GetId() );
         Profiler::QueueSerialFinish();
     }
+#endif
 
     tracy_force_inline VkCtxScope( VkCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, VkCommandBuffer cmdbuf, bool is_active )
 #ifdef TRACY_ON_DEMAND
@@ -409,6 +411,7 @@ public:
         Profiler::QueueSerialFinish();
     }
 
+#ifdef TRACY_HAS_CALLSTACK
     tracy_force_inline VkCtxScope( VkCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, VkCommandBuffer cmdbuf, int depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
@@ -433,6 +436,7 @@ public:
         MemWrite( &item->gpuZoneBegin.context, ctx->GetId() );
         Profiler::QueueSerialFinish();
     }
+#endif
 
     tracy_force_inline ~VkCtxScope()
     {


### PR DESCRIPTION
The function `tracy::Callstack()` is unknown when `TRACY_HAS_CALLSTACK` macro is not defined, causing compile errors in platforms without callstack support (e.g. Universal Windows Platform in our case). Added guards around affected methods.

Another working alternative could be to introduce a dummy implementation in `TracyCallstack.hpp`: 
```cpp
#ifndef TRACY_HAS_CALLSTACK
namespace tracy
{
static tracy_force_inline void* Callstack( int depth )
{
    return nullptr;
}
}
#else 
// ...
```
Guarding seemed to be the more common practice in the codebase, please tell if you prefer the dummy option or any other alternative.  