### PR TITLE
Fix compile error when TRACY_NO_CRASH_HANDLER is enabled

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1520,7 +1520,7 @@ bool Profiler::ShouldExit()
 
 void Profiler::Worker()
 {
-#ifdef __linux__
+#if defined __linux__ && !defined TRACY_NO_CRASH_HANDLER
     s_profilerTid = syscall( SYS_gettid );
 #endif
 


### PR DESCRIPTION
Without this, tracy will fail to compile with the following error:
```
.../external/tracy/public/client/TracyProfiler.cpp:1524:5: error: ‘s_profilerTid’ was not declared in this scope; did you mean ‘s_profiler’?
 1524 |     s_profilerTid = syscall( SYS_gettid );
      |     ^~~~~~~~~~~~~
      |     s_profiler
```