### PR TITLE
Timeline animation tweaks

### DIFF
--- a/server/TracyTimelineController.cpp
+++ b/server/TracyTimelineController.cpp
@@ -7,6 +7,7 @@ namespace tracy
 
 TimelineController::TimelineController( View& view, Worker& worker )
     : m_height( 0 )
+    , m_scroll( 0 )
     , m_firstFrame( true )
     , m_view( view )
     , m_worker( worker )
@@ -30,7 +31,12 @@ void TimelineController::End( double pxns, int offset, const ImVec2& wpos, bool 
         item->Draw( m_firstFrame, pxns, offset, wpos, hover, yMin, yMax );
     }
 
-    m_height = offset;
+    const auto scrollPos = ImGui::GetScrollY();
+    if( ( scrollPos == 0 && m_scroll != 0 ) || offset > m_height )
+    {
+        m_height = offset;
+    }
+    m_scroll = scrollPos;
 }
 
 }

--- a/server/TracyTimelineController.cpp
+++ b/server/TracyTimelineController.cpp
@@ -7,7 +7,6 @@ namespace tracy
 
 TimelineController::TimelineController( View& view, Worker& worker )
     : m_height( 0 )
-    , m_scroll( 0 )
     , m_firstFrame( true )
     , m_view( view )
     , m_worker( worker )
@@ -31,16 +30,7 @@ void TimelineController::End( double pxns, int offset, const ImVec2& wpos, bool 
         item->Draw( m_firstFrame, pxns, offset, wpos, hover, yMin, yMax );
     }
 
-    const auto scrollPos = ImGui::GetScrollY();
-    if( scrollPos == 0 && m_scroll != 0 )
-    {
-        m_height = 0;
-    }
-    else
-    {
-        if( offset > m_height ) m_height = offset;
-    }
-    m_scroll = scrollPos;
+    m_height = offset;
 }
 
 }

--- a/server/TracyTimelineController.hpp
+++ b/server/TracyTimelineController.hpp
@@ -43,7 +43,6 @@ private:
     unordered_flat_map<const void*, std::unique_ptr<TimelineItem>> m_itemMap;
 
     float m_height;
-    float m_scroll;
 
     bool m_firstFrame;
 

--- a/server/TracyTimelineController.hpp
+++ b/server/TracyTimelineController.hpp
@@ -43,6 +43,7 @@ private:
     unordered_flat_map<const void*, std::unique_ptr<TimelineItem>> m_itemMap;
 
     float m_height;
+    float m_scroll;
 
     bool m_firstFrame;
 

--- a/server/TracyTimelineItem.cpp
+++ b/server/TracyTimelineItem.cpp
@@ -121,8 +121,8 @@ void TimelineItem::Draw( bool firstFrame, double pxns, int& offset, const ImVec2
 
 void TimelineItem::AdjustThreadHeight( bool firstFrame, int oldOffset, int& offset )
 {
-    const auto speed = 10.0;
-    const auto minMove = 2.0;
+    const auto speed = 5.0;
+    const auto minMove = 1.0;
 
     const auto h = offset - oldOffset;
     if( firstFrame )

--- a/server/TracyTimelineItem.cpp
+++ b/server/TracyTimelineItem.cpp
@@ -21,8 +21,7 @@ void TimelineItem::Draw( bool firstFrame, double pxns, int& offset, const ImVec2
 {
     if( !IsVisible() )
     {
-        if( m_height != 0 )
-            AdjustThreadHeight( firstFrame, offset, offset );
+        if( m_height != 0 ) AdjustThreadHeight( firstFrame, offset, offset );
         return;
     }
     if( IsEmpty() ) return;

--- a/server/TracyTimelineItem.cpp
+++ b/server/TracyTimelineItem.cpp
@@ -121,8 +121,8 @@ void TimelineItem::Draw( bool firstFrame, double pxns, int& offset, const ImVec2
 
 void TimelineItem::AdjustThreadHeight( bool firstFrame, int oldOffset, int& offset )
 {
-    const auto speed = 5.0;
-    const auto minMove = 1.0;
+    const auto speed = 4.0;
+    const auto baseMove = 1.0;
 
     const auto h = offset - oldOffset;
     if( firstFrame )
@@ -135,12 +135,12 @@ void TimelineItem::AdjustThreadHeight( bool firstFrame, int oldOffset, int& offs
         const auto preClampMove = diff * speed * ImGui::GetIO().DeltaTime;
         if( diff > 0 )
         {
-            const auto move = std::max( minMove, preClampMove );
+            const auto move = preClampMove + baseMove;
             m_height = int( std::min<double>( m_height + move, h ) );
         }
         else
         {
-            const auto move = std::min( -minMove, preClampMove );
+            const auto move = preClampMove - baseMove;
             m_height = int( std::max<double>( m_height + move, h ) );
         }
         s_wasActive = true;

--- a/server/TracyTimelineItem.hpp
+++ b/server/TracyTimelineItem.hpp
@@ -47,10 +47,8 @@ protected:
 
 private:
     void AdjustThreadHeight( bool firstFrame, int oldOffset, int& offset );
-    float AdjustThreadPosition( float wy, int& offset );
 
     int m_height;
-    int m_offset;
 
 protected:
     View& m_view;

--- a/server/TracyView_Timeline.cpp
+++ b/server/TracyView_Timeline.cpp
@@ -333,6 +333,7 @@ void View::DrawTimeline()
 
     const auto wpos = ImGui::GetCursorScreenPos();
     const auto dpos = wpos + ImVec2( 0.5f, 0.5f );
+    // note that m_tc.GetHeight() returns the height from the previous draw
     const auto h = std::max<float>( m_tc.GetHeight(), ImGui::GetContentRegionAvail().y - 4 );    // magic border value
 
     ImGui::ItemSize( ImVec2( w, h ) );


### PR DESCRIPTION
* Changed the resizing logic such that when one `TimelineItem` is shrinking the `TimelineItem`s below it are following at the same speed.
* I also sneaked in a `TimelineController` height calculation fix.
* Reduced the number of lines of code.
* Tested @ 60FPS and 15FPS.
* Removed `TimelineItem::AdjustThreadPosition()` because it became obsolete.

Why:

* With this change, the `TimelineItem` shrinking is more consistent with `TimelineItem` expanding.
* Without the change each `TimelineItem` is moving at a different speed across the screen when resizing. This makes it much harder for the brain to keep track of what is happening.
* Without the change, the animations can take a very long time if a many `TimelineItem`s are resizing at the same time. To the point where in one of my use cases I had to wait multiple seconds for the animation to finish before I could reorient myself.
* With the change the timeline seems more usable to me.