### PR TITLE
Fix: Don't let make_unique initialise data unnecessarily

### DIFF
--- a/server/TracyUserData.cpp
+++ b/server/TracyUserData.cpp
@@ -40,7 +40,7 @@ UserData::UserData( const char* program, uint64_t time )
         fseek( f, 0, SEEK_END );
         const auto sz = ftell( f );
         fseek( f, 0, SEEK_SET );
-        auto buf = std::unique_ptr<char[]>(new char[sz]);
+        auto buf = std::unique_ptr<char[]>( new char[sz] );
         fread( buf.get(), 1, sz, f );
         fclose( f );
         m_description.assign( buf.get(), buf.get() + sz );

--- a/server/TracyUserData.cpp
+++ b/server/TracyUserData.cpp
@@ -40,7 +40,7 @@ UserData::UserData( const char* program, uint64_t time )
         fseek( f, 0, SEEK_END );
         const auto sz = ftell( f );
         fseek( f, 0, SEEK_SET );
-        auto buf = std::make_unique<char[]>( sz );
+        auto buf = std::unique_ptr<char[]>(new char[sz]);
         fread( buf.get(), 1, sz, f );
         fclose( f );
         m_description.assign( buf.get(), buf.get() + sz );

--- a/server/TracyView_ZoneInfo.cpp
+++ b/server/TracyView_ZoneInfo.cpp
@@ -1239,8 +1239,8 @@ void View::DrawZoneInfoChildren( const V& children, int64_t ztime )
             ImGui::NextColumn();
             if( expandGroup )
             {
-                auto ctt = std::make_unique<uint64_t[]>( cgr.v.size() );
-                auto cti = std::make_unique<uint32_t[]>( cgr.v.size() );
+                auto ctt = std::unique_ptr<uint64_t[]>( new uint64_t[cgr.v.size()] );
+                auto cti = std::unique_ptr<uint32_t[]>( new uint32_t[cgr.v.size()] );
                 for( size_t i=0; i<cgr.v.size(); i++ )
                 {
                     const auto& child = a(children[cgr.v[i]]);
@@ -1293,8 +1293,8 @@ void View::DrawZoneInfoChildren( const V& children, int64_t ztime )
     }
     else
     {
-        auto ctt = std::make_unique<uint64_t[]>( children.size() );
-        auto cti = std::make_unique<uint32_t[]>( children.size() );
+        auto ctt = std::unique_ptr<uint64_t[]>( new uint64_t[children.size()] );
+        auto cti = std::unique_ptr<uint32_t[]>( new uint32_t[children.size()] );
         uint64_t ctime = 0;
         for( size_t i=0; i<children.size(); i++ )
         {
@@ -1691,8 +1691,8 @@ void View::DrawGpuInfoChildren( const V& children, int64_t ztime )
             ImGui::NextColumn();
             if( expandGroup )
             {
-                auto ctt = std::make_unique<uint64_t[]>( cgr.v.size() );
-                auto cti = std::make_unique<uint32_t[]>( cgr.v.size() );
+                auto ctt = std::unique_ptr<uint64_t[]>( new uint64_t[cgr.v.size()] );
+                auto cti = std::unique_ptr<uint32_t[]>( new uint32_t[cgr.v.size()] );
                 for( size_t i=0; i<cgr.v.size(); i++ )
                 {
                     const auto& child = a(children[cgr.v[i]]);
@@ -1740,8 +1740,8 @@ void View::DrawGpuInfoChildren( const V& children, int64_t ztime )
     }
     else
     {
-        auto ctt = std::make_unique<uint64_t[]>( children.size() );
-        auto cti = std::make_unique<uint32_t[]>( children.size() );
+        auto ctt = std::unique_ptr<uint64_t[]>( new uint64_t[children.size()] );
+        auto cti = std::unique_ptr<uint32_t[]>( new uint32_t[children.size()] );
         uint64_t ctime = 0;
         for( size_t i=0; i<children.size(); i++ )
         {

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -2722,7 +2722,7 @@ const unordered_flat_map<CallstackFrameId, uint32_t, Worker::CallstackFrameIdHas
 void Worker::Network()
 {
     auto ShouldExit = [this] { return m_shutdown.load( std::memory_order_relaxed ); };
-    auto lz4buf = std::make_unique<char[]>( LZ4Size );
+    auto lz4buf = std::unique_ptr<char[]>( new char[LZ4Size] );
 
     for(;;)
     {


### PR DESCRIPTION
None of the changed functions rely on the memory being zero-initialised because its initially only written to, which is why we can safely have the memory be garbage at creation. The C++ spec guarantees that `std::make_unique(std::size_t size)` with an array type always value-initialises the array/object (from cppreference):
> 2) Constructs an array of the given dynamic size. The array elements are [value-initialized](https://en.cppreference.com/w/cpp/language/value_initialization). This overload participates in overload resolution only if T is an array of unknown bound. The function is equivalent to:
`unique_ptr<T>(new std::remove_extent_t[size]())`