### PR TITLE
Add left/right counts to histogram tooltip

### DIFF
--- a/server/TracyView_FindZone.cpp
+++ b/server/TracyView_FindZone.cpp
@@ -1249,15 +1249,19 @@ void View::DrawFindZone()
                             }
 
                             int64_t tBefore = 0;
+                            int64_t cntBefore = 0;
                             for( int i=0; i<bin; i++ )
                             {
                                 tBefore += binTime[i];
+                                cntBefore += bins[i];
                             }
 
                             int64_t tAfter = 0;
+                            int64_t cntAfter = 0;
                             for( int i=bin+1; i<numBins; i++ )
                             {
                                 tAfter += binTime[i];
+                                cntAfter += bins[i];
                             }
 
                             ImGui::BeginTooltip();
@@ -1265,6 +1269,8 @@ void View::DrawFindZone()
                             ImGui::SameLine();
                             ImGui::Text( "%s - %s", TimeToString( t0 ), TimeToString( t1 ) );
                             TextFocused( "Count:", RealToString( bins[bin] ) );
+                            TextFocused( "Count in the left bins:", RealToString( cntBefore ) );
+                            TextFocused( "Count in the right bins:", RealToString( cntAfter ) );
                             TextFocused( "Time spent in bin:", TimeToString( binTime[bin] ) );
                             TextFocused( "Time spent in the left bins:", TimeToString( tBefore ) );
                             TextFocused( "Time spent in the right bins:", TimeToString( tAfter ) );


### PR DESCRIPTION
First PR to Tracy, so I hope this is on the right track (big fan of the project)

Updates the tooltip in FindZone to include counts left/right of the selected bin:

<img width="400" alt="Screenshot 2023-01-06 at 9 32 16 PM" src="https://user-images.githubusercontent.com/84105208/211131317-fd8573b2-b959-4e0f-b3d9-5de3e521a6f8.png">

The thinking here is that it when total time becomes heavily dominated by long-running calls, it can be difficult to see how many calls account for, e.g., >90% of the zone time.