### PR TITLE
Miscellaneous emscripten fixes

### DIFF
--- a/profiler/build/wasm/build.mk
+++ b/profiler/build/wasm/build.mk
@@ -5,7 +5,7 @@ CFLAGS += -sUSE_FREETYPE=1 -pthread
 CXXFLAGS := $(CFLAGS) -std=c++17
 DEFINES += -DIMGUI_ENABLE_FREETYPE -DIMGUI_IMPL_OPENGL_ES2
 INCLUDES := -I../../../imgui -I$(HOME)/.emscripten_cache/sysroot/include/capstone
-LIBS += -lpthread -ldl $(HOME)/.emscripten_cache/sysroot/lib/libcapstone.a -sUSE_GLFW=3 -sINITIAL_MEMORY=384mb -sALLOW_MEMORY_GROWTH=1 -sMAXIMUM_MEMORY=4gb -sWASM_BIGINT=1 -sPTHREAD_POOL_SIZE=4 -sEXPORTED_FUNCTIONS=_main,_nativeResize,_nativeOpenFile -sEXPORTED_RUNTIME_METHODS=ccall -sENVIRONMENT=web,worker -sSTACK_SIZE=131072 -sDEFAULT_PTHREAD_STACK_SIZE=131072 --preload-file embed.tracy
+LIBS += -lpthread -ldl $(HOME)/.emscripten_cache/sysroot/lib/libcapstone.a -sUSE_GLFW=3 -sINITIAL_MEMORY=384mb -sALLOW_MEMORY_GROWTH=1 -sMAXIMUM_MEMORY=4gb -sWASM_BIGINT=1 -sPTHREAD_POOL_SIZE=8 -sEXPORTED_FUNCTIONS=_main,_nativeResize,_nativeOpenFile -sEXPORTED_RUNTIME_METHODS=ccall -sENVIRONMENT=web,worker -sSTACK_SIZE=131072 -sDEFAULT_PTHREAD_STACK_SIZE=131072 --preload-file embed.tracy
 
 PROJECT := Tracy
 IMAGE := $(PROJECT)-$(BUILD).html

--- a/profiler/build/wasm/build.mk
+++ b/profiler/build/wasm/build.mk
@@ -5,7 +5,7 @@ CFLAGS += -sUSE_FREETYPE=1 -pthread
 CXXFLAGS := $(CFLAGS) -std=c++17
 DEFINES += -DIMGUI_ENABLE_FREETYPE -DIMGUI_IMPL_OPENGL_ES2
 INCLUDES := -I../../../imgui -I$(HOME)/.emscripten_cache/sysroot/include/capstone
-LIBS += -lpthread -ldl $(HOME)/.emscripten_cache/sysroot/lib/libcapstone.a -sUSE_GLFW=3 -sINITIAL_MEMORY=384mb -sALLOW_MEMORY_GROWTH=1 -sMAXIMUM_MEMORY=4gb -sWASM_BIGINT=1 -sPTHREAD_POOL_SIZE=4 -sEXPORTED_FUNCTIONS=_main,_nativeResize,_nativeOpenFile -sEXPORTED_RUNTIME_METHODS=ccall -sENVIRONMENT=web,worker --preload-file embed.tracy
+LIBS += -lpthread -ldl $(HOME)/.emscripten_cache/sysroot/lib/libcapstone.a -sUSE_GLFW=3 -sINITIAL_MEMORY=384mb -sALLOW_MEMORY_GROWTH=1 -sMAXIMUM_MEMORY=4gb -sWASM_BIGINT=1 -sPTHREAD_POOL_SIZE=4 -sEXPORTED_FUNCTIONS=_main,_nativeResize,_nativeOpenFile -sEXPORTED_RUNTIME_METHODS=ccall -sENVIRONMENT=web,worker -sSTACK_SIZE=131072 -sDEFAULT_PTHREAD_STACK_SIZE=131072 --preload-file embed.tracy
 
 PROJECT := Tracy
 IMAGE := $(PROJECT)-$(BUILD).html

--- a/profiler/src/imgui/imgui_impl_glfw.cpp
+++ b/profiler/src/imgui/imgui_impl_glfw.cpp
@@ -765,6 +765,11 @@ static void ImGui_ImplGlfw_UpdateMonitors()
         int x, y;
         glfwGetMonitorPos(glfw_monitors[n], &x, &y);
         const GLFWvidmode* vid_mode = glfwGetVideoMode(glfw_monitors[n]);
+        if (vid_mode == NULL) { // Failed to get Video mode (e.g. Emscripten does not support this function)
+            bd->WantUpdateMonitors = false;
+            platform_io.Monitors.resize(0);
+            return;
+        }
         monitor.MainPos = monitor.WorkPos = ImVec2((float)x, (float)y);
         monitor.MainSize = monitor.WorkSize = ImVec2((float)vid_mode->width, (float)vid_mode->height);
 #if GLFW_HAS_MONITOR_WORK_AREA

--- a/profiler/src/imgui/imgui_impl_glfw.cpp
+++ b/profiler/src/imgui/imgui_impl_glfw.cpp
@@ -313,6 +313,11 @@ void ImGui_ImplGlfw_MouseButtonCallback(GLFWwindow* window, int button, int acti
 
 void ImGui_ImplGlfw_ScrollCallback(GLFWwindow* window, double xoffset, double yoffset)
 {
+#if defined(__EMSCRIPTEN__)
+    // Running under Emscripten, GLFW reports grossly mis-scaled scroll events and even flips the X axis.
+    xoffset /= -20.0f;
+#endif
+
     ImGui_ImplGlfw_Data* bd = ImGui_ImplGlfw_GetBackendData();
     if (bd->PrevUserCallbackScroll != nullptr && window == bd->Window)
         bd->PrevUserCallbackScroll(window, xoffset, yoffset);


### PR DESCRIPTION
Series of emscripten-specific fixes:
- Increase `STACK_SIZE` to 128 kB from 64 kB (was causing crashes, especially on startup)
- Re-scale horizontal scroll values so that scroll speed (approximately) matches desktop
- Fix NULL pointer dereference
- Increase `PTHREAD_POOL_SIZE` from 4 to 8 (may be unnecessary)