### PR TITLE
move ___tracy_fiber* declarations to under ifdef

### DIFF
--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -341,10 +341,10 @@ TRACY_API void ___tracy_emit_message_appinfo( const char* txt, size_t size );
 
 #define TracyCIsConnected ___tracy_connected()
 
+#ifdef TRACY_FIBERS
 TRACY_API void ___tracy_fiber_enter( const char* fiber );
 TRACY_API void ___tracy_fiber_leave( void );
 
-#ifdef TRACY_FIBERS
 #  define TracyCFiberEnter( fiber ) ___tracy_fiber_enter( fiber );
 #  define TracyCFiberLeave ___tracy_fiber_leave();
 #endif


### PR DESCRIPTION
These functions are only defined when -DTRACY_FIBERS is set. However, the function is declared regardless of this def, which seems like it could lead to obscure linking errors. I haven’t encountered any of these specifically, but in my case, this difference makes it more difficult to produce correctly auto-generated bindings.