### PR TITLE
Fix color red and blue byte swap

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -3725,7 +3725,7 @@ void Worker::AddSourceLocation( const QueueSourceLocation& srcloc )
         }
     }
     CheckString( srcloc.function );
-    const uint32_t color = ( srcloc.r << 16 ) | ( srcloc.g << 8 ) | srcloc.b;
+    const uint32_t color = srcloc.r | ( srcloc.g << 8 ) | ( srcloc.b << 16 );
     it->second = SourceLocation {{ srcloc.name == 0 ? StringRef() : StringRef( StringRef::Ptr, srcloc.name ), StringRef( StringRef::Ptr, srcloc.function ), StringRef( StringRef::Ptr, srcloc.file ), srcloc.line, color }};
 }
 
@@ -5331,7 +5331,7 @@ void Worker::ProcessZoneColor( const QueueZoneColor& ev )
     auto& stack = td->stack;
     auto zone = stack.back();
     auto& extra = RequestZoneExtra( *zone );
-    const uint32_t color = ( ev.r << 16 ) | ( ev.g << 8 ) | ev.b;
+    const uint32_t color = ev.r | ( ev.g << 8 ) | ( ev.b << 16);
     extra.color = color;
 }
 
@@ -5625,7 +5625,7 @@ void Worker::ProcessMessageColor( const QueueMessageColor& ev )
     msg->time = time;
     msg->ref = StringRef( StringRef::Type::Idx, GetSingleStringIdx() );
     msg->thread = CompressThread( td->id );
-    msg->color = 0xFF000000 | ( ev.r << 16 ) | ( ev.g << 8 ) | ev.b;
+    msg->color = 0xFF000000 | ev.r | ( ev.g << 8 ) | ( ev.b << 16 );
     msg->callstack.SetVal( 0 );
     if( m_data.lastTime < time ) m_data.lastTime = time;
     InsertMessageData( msg );
@@ -5640,7 +5640,7 @@ void Worker::ProcessMessageLiteralColor( const QueueMessageColorLiteral& ev )
     msg->time = time;
     msg->ref = StringRef( StringRef::Type::Ptr, ev.text );
     msg->thread = CompressThread( td->id );
-    msg->color = 0xFF000000 | ( ev.r << 16 ) | ( ev.g << 8 ) | ev.b;
+    msg->color = 0xFF000000 | ev.r | ( ev.g << 8 ) | ( ev.b << 16 );
     msg->callstack.SetVal( 0 );
     if( m_data.lastTime < time ) m_data.lastTime = time;
     InsertMessageData( msg );


### PR DESCRIPTION
I noticed this strange bug. When sending a message with the color `Red` to the profiler(for example using `TracyMessageLC`) the color being sent is displayed in Profiler such that the R byte gets swapped with the G byte and will be displayed as `Blue`

Please note that I have tested these changes only on my windows machine. I do not have other platforms to test this on.

Below is the screenshot of `QueueMessageColor` that is being enqueued from `TracyClient`
<img width="431" alt="image" src="https://user-images.githubusercontent.com/22360874/213923169-40f3e941-0190-4549-b5a4-f9b496d93411.png">

Below is the screenshot of the `Profiler in master`
<img width="626" alt="image" src="https://user-images.githubusercontent.com/22360874/213923230-e3534178-c813-47ce-999c-34912741d0cf.png">

Below is the screenshot of the `Profiler in Fixed PR`
<img width="623" alt="image" src="https://user-images.githubusercontent.com/22360874/213923252-29adf81f-fe7b-4153-9fb3-0da34df4de5b.png">

### Change in functions
* Worker::AddSourceLocation
* Worker::ProcessZoneColor
* Worker::ProcessMessageColor
* Worker::ProcessMessageLiteralColor