### PR TITLE
Fix connection check for capturing

### DIFF
--- a/capture/src/capture.cpp
+++ b/capture/src/capture.cpp
@@ -159,7 +159,7 @@ int main( int argc, char** argv )
     printf( "Connecting to %s:%i...", address, port );
     fflush( stdout );
     tracy::Worker worker( address, port );
-    while( !worker.IsConnected() )
+    while( !worker.HasData() )
     {
         const auto handshake = worker.GetHandshakeStatus();
         if( handshake == tracy::HandshakeProtocolMismatch )
@@ -179,7 +179,6 @@ int main( int argc, char** argv )
         }
         std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
     }
-    while( !worker.HasData() ) std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
     printf( "\nQueue delay: %s\nTimer resolution: %s\n", tracy::TimeToString( worker.GetDelay() ), tracy::TimeToString( worker.GetResolution() ) );
 
 #ifdef _WIN32


### PR DESCRIPTION
The tracy worker `Exec` resets the `IsConnected` to false when finishing the capture. If it finishes too quick, the waiting loop in `capture.cpp` might not ever see `IsConnected = true`.

This changes the waiting condition to use `HasData`, which stays as true once the worker receives the data.