### PR TITLE
Linux compilation fixes

### DIFF
--- a/public/client/TracyScoped.hpp
+++ b/public/client/TracyScoped.hpp
@@ -166,7 +166,7 @@ private:
     const bool m_active;
 
 #ifdef TRACY_ON_DEMAND
-    uint64_t m_connectionId;
+    uint64_t m_connectionId = 0;
 #endif
 };
 

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -1265,8 +1265,7 @@ void SysTraceWorker( void* ptr )
                             type = QueueType::HwSampleBranchMiss;
                             break;
                         default:
-                            assert( false );
-                            break;
+                            abort();
                         }
 
                         TracyLfqPrepare( type );


### PR DESCRIPTION
Two commits which fixes compilation on linux:

1. ```public/tracy/../client/../common/TracyAlign.hpp:22:11: error: ‘type’ may be used uninitialized in this function [-Werror=maybe-uninitialized]```
2. ```public/tracy/../client/TracyScoped.hpp:102:9: error: ‘___tracy_scoped_zone.tracy::ScopedZone::m_connectionId’ may be used uninitialized in this function [-Werror=maybe-uninitialized]```
