### PR TITLE
Vertical timeline centering

### DIFF
--- a/server/TracyTimelineController.cpp
+++ b/server/TracyTimelineController.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "imgui.h"
 
 #include "TracyTimelineController.hpp"
@@ -8,6 +10,8 @@ namespace tracy
 TimelineController::TimelineController( View& view, Worker& worker )
     : m_height( 0 )
     , m_scroll( 0 )
+    , m_centerItemkey( nullptr )
+    , m_centerItemOffsetY( 0 )
     , m_firstFrame( true )
     , m_view( view )
     , m_worker( worker )
@@ -24,8 +28,83 @@ void TimelineController::Begin()
     m_items.clear();
 }
 
-void TimelineController::End( double pxns, const ImVec2& wpos, bool hover, float yMin, float yMax )
+void TimelineController::UpdateCenterItem()
 {
+    ImVec2 mousePos = ImGui::GetMousePos();
+
+    m_centerItemkey = nullptr;
+    m_centerItemOffsetY = 0;
+
+    if( m_firstFrame || !ImGui::IsMousePosValid( &mousePos ) ) return;
+
+    const auto timelineMousePosY = mousePos.y - ImGui::GetWindowPos().y;
+    int centerY = timelineMousePosY + ImGui::GetScrollY();
+
+    int yBegin = 0;
+    int yEnd = 0;
+    for( auto& item : m_items )
+    {
+        m_centerItemkey = item->GetKey();
+        yBegin = yEnd;
+        yEnd += item->GetNextFrameHeight();
+
+        const auto inLowerBounds = m_centerItemkey == m_items.front()->GetKey() || yBegin <= centerY;
+        const auto inUpperBounds = m_centerItemkey == m_items.back()->GetKey() || centerY < yEnd;
+
+        if( inLowerBounds && inUpperBounds )
+        {
+            m_centerItemOffsetY = centerY - yBegin;
+            break;
+        }
+    }
+}
+
+std::optional<int> TimelineController::CalculateScrollPosition() const
+{
+    if( !m_centerItemkey ) return std::nullopt;
+
+    ImVec2 mousePos = ImGui::GetMousePos();
+
+    if( !ImGui::IsMousePosValid( &mousePos ) ) return std::nullopt;
+
+    const auto timelineMousePosY = mousePos.y - ImGui::GetWindowPos().y;
+
+    int yBegin = 0;
+    int yEnd = 0;
+    for( auto& item : m_items )
+    {
+        yBegin = yEnd;
+        yEnd += item->GetNextFrameHeight();
+
+        if( item->GetKey() != m_centerItemkey ) continue;
+
+        int scrollY = yBegin + m_centerItemOffsetY - timelineMousePosY;
+
+        return scrollY;
+    }
+
+    return std::nullopt;
+}
+
+void TimelineController::End( double pxns, const ImVec2& wpos, bool hover,  bool vcenter, float yMin, float yMax )
+{
+    auto shouldUpdateCenterItem = [&] () {
+        const auto& mouseDelta = ImGui::GetIO().MouseDelta;
+        const auto mouseMoved = mouseDelta.x != 0.0f || mouseDelta.y != 0.0f;
+        const auto imguiChangedScroll = m_scroll != ImGui::GetScrollY();
+        return ( ( imguiChangedScroll || mouseMoved ) && !ImGui::IsMouseDown( 1 ) ) || !m_centerItemkey;
+    };
+
+    if( !vcenter )
+    {
+        m_centerItemkey = nullptr;
+        m_centerItemOffsetY = 0;
+    }
+    else if( shouldUpdateCenterItem() )
+    {
+        UpdateCenterItem();
+    }
+
     int yOffset = 0;
 
     for( auto& item : m_items )
@@ -34,6 +113,14 @@ void TimelineController::End( double pxns, const ImVec2& wpos, bool hover, float
         item->Draw( m_firstFrame, pxns, yOffset, wpos, hover, yMin, yMax );
         if( m_firstFrame ) currentFrameItemHeight = item->GetNextFrameHeight();
         yOffset += currentFrameItemHeight;
+    }
+
+    if( const auto scrollY = CalculateScrollPosition() )
+    {
+        int clampedScrollY = std::min<int>( *scrollY, yOffset );
+        ImGui::SetScrollY( clampedScrollY );
+        int minHeight = ImGui::GetWindowHeight() + clampedScrollY;
+        yOffset = std::max( yOffset, minHeight );
     }
 
     const auto scrollPos = ImGui::GetScrollY();

--- a/server/TracyTimelineController.cpp
+++ b/server/TracyTimelineController.cpp
@@ -89,10 +89,12 @@ std::optional<int> TimelineController::CalculateScrollPosition() const
 void TimelineController::End( double pxns, const ImVec2& wpos, bool hover,  bool vcenter, float yMin, float yMax )
 {
     auto shouldUpdateCenterItem = [&] () {
+        const auto imguiChangedScroll = m_scroll != ImGui::GetScrollY();
         const auto& mouseDelta = ImGui::GetIO().MouseDelta;
         const auto mouseMoved = mouseDelta.x != 0.0f || mouseDelta.y != 0.0f;
-        const auto imguiChangedScroll = m_scroll != ImGui::GetScrollY();
-        return ( ( imguiChangedScroll || mouseMoved ) && !ImGui::IsMouseDown( 1 ) ) || !m_centerItemkey;
+        const auto& mousePos = ImGui::GetIO().MousePos;
+        const auto mouseVisible = ImGui::IsMousePosValid( &mousePos );
+        return ( ( imguiChangedScroll || mouseMoved || !mouseVisible ) && !ImGui::IsMouseDown( 1 ) ) || !m_centerItemkey;
     };
 
     if( !vcenter )

--- a/server/TracyTimelineController.cpp
+++ b/server/TracyTimelineController.cpp
@@ -30,8 +30,10 @@ void TimelineController::End( double pxns, const ImVec2& wpos, bool hover, float
 
     for( auto& item : m_items )
     {
+        auto currentFrameItemHeight = item->GetNextFrameHeight();
         item->Draw( m_firstFrame, pxns, yOffset, wpos, hover, yMin, yMax );
-        yOffset += item->GetNextFrameHeight();
+        if( m_firstFrame ) currentFrameItemHeight = item->GetNextFrameHeight();
+        yOffset += currentFrameItemHeight;
     }
 
     const auto scrollPos = ImGui::GetScrollY();

--- a/server/TracyTimelineController.cpp
+++ b/server/TracyTimelineController.cpp
@@ -24,17 +24,20 @@ void TimelineController::Begin()
     m_items.clear();
 }
 
-void TimelineController::End( double pxns, int offset, const ImVec2& wpos, bool hover, float yMin, float yMax )
+void TimelineController::End( double pxns, const ImVec2& wpos, bool hover, float yMin, float yMax )
 {
+    int yOffset = 0;
+
     for( auto& item : m_items )
     {
-        item->Draw( m_firstFrame, pxns, offset, wpos, hover, yMin, yMax );
+        item->Draw( m_firstFrame, pxns, yOffset, wpos, hover, yMin, yMax );
+        yOffset += item->GetNextFrameHeight();
     }
 
     const auto scrollPos = ImGui::GetScrollY();
-    if( ( scrollPos == 0 && m_scroll != 0 ) || offset > m_height )
+    if( ( scrollPos == 0 && m_scroll != 0 ) || yOffset > m_height )
     {
-        m_height = offset;
+        m_height = yOffset;
     }
     m_scroll = scrollPos;
 }

--- a/server/TracyTimelineController.hpp
+++ b/server/TracyTimelineController.hpp
@@ -18,7 +18,7 @@ public:
 
     void FirstFrameExpired();
     void Begin();
-    void End( double pxns, int offset, const ImVec2& wpos, bool hover, float yMin, float yMax );
+    void End( double pxns, const ImVec2& wpos, bool hover, float yMin, float yMax );
 
     template<class T, class U>
     void AddItem( U* data )

--- a/server/TracyTimelineController.hpp
+++ b/server/TracyTimelineController.hpp
@@ -2,6 +2,7 @@
 #define __TRACYTIMELINECONTROLLER_HPP__
 
 #include <assert.h>
+#include <optional>
 #include <vector>
 
 #include "../public/common/TracyForceInline.hpp"
@@ -18,7 +19,7 @@ public:
 
     void FirstFrameExpired();
     void Begin();
-    void End( double pxns, const ImVec2& wpos, bool hover, float yMin, float yMax );
+    void End( double pxns, const ImVec2& wpos, bool hover, bool vcenter, float yMin, float yMax );
 
     template<class T, class U>
     void AddItem( U* data )
@@ -39,11 +40,17 @@ public:
     }
 
 private:
+    void UpdateCenterItem();
+    std::optional<int> CalculateScrollPosition() const;
+
     std::vector<TimelineItem*> m_items;
     unordered_flat_map<const void*, std::unique_ptr<TimelineItem>> m_itemMap;
 
     float m_height;
     float m_scroll;
+
+    const void* m_centerItemkey;
+    int m_centerItemOffsetY;
 
     bool m_firstFrame;
 

--- a/server/TracyTimelineItem.cpp
+++ b/server/TracyTimelineItem.cpp
@@ -8,10 +8,11 @@
 namespace tracy
 {
 
-TimelineItem::TimelineItem( View& view, Worker& worker )
+TimelineItem::TimelineItem( View& view, Worker& worker, const void* key )
     : m_visible( true )
     , m_showFull( true )
     , m_height( 0 )
+    , m_key( key )
     , m_view( view )
     , m_worker( worker )
 {

--- a/server/TracyTimelineItem.cpp
+++ b/server/TracyTimelineItem.cpp
@@ -17,11 +17,14 @@ TimelineItem::TimelineItem( View& view, Worker& worker )
 {
 }
 
-void TimelineItem::Draw( bool firstFrame, double pxns, int& offset, const ImVec2& wpos, bool hover, float yMin, float yMax )
+void TimelineItem::Draw( bool firstFrame, double pxns, int yOffset, const ImVec2& wpos, bool hover, float yMin, float yMax )
 {
+    const auto yBegin = yOffset;
+    auto yEnd = yOffset;
+
     if( !IsVisible() )
     {
-        if( m_height != 0 ) AdjustThreadHeight( firstFrame, offset, offset );
+        if( m_height != 0 ) AdjustThreadHeight( firstFrame, yBegin, yEnd );
         return;
     }
     if( IsEmpty() ) return;
@@ -29,32 +32,31 @@ void TimelineItem::Draw( bool firstFrame, double pxns, int& offset, const ImVec2
     const auto w = ImGui::GetContentRegionAvail().x - 1;
     const auto ty = ImGui::GetTextLineHeight();
     const auto ostep = ty + 1;
-    const auto yPos = wpos.y + offset;
+    const auto yPos = wpos.y + yBegin;
     const auto dpos = wpos + ImVec2( 0.5f, 0.5f );
-    const auto oldOffset = offset;
     auto draw = ImGui::GetWindowDrawList();
 
     ImGui::PushID( this );
-    ImGui::PushClipRect( wpos + ImVec2( 0, offset ), wpos + ImVec2( w, offset + m_height ), true );
+    ImGui::PushClipRect( wpos + ImVec2( 0, yBegin ), wpos + ImVec2( w, yBegin + m_height ), true );
 
-    offset += ostep;
+    yEnd += ostep;
     if( m_showFull )
     {
-        if( !DrawContents( pxns, offset, wpos, hover, yMin, yMax ) && !m_view.GetViewData().drawEmptyLabels )
+        if( !DrawContents( pxns, yEnd, wpos, hover, yMin, yMax ) && !m_view.GetViewData().drawEmptyLabels )
         {
-            offset = oldOffset;
-            AdjustThreadHeight( firstFrame, oldOffset, offset );
+            yEnd = yBegin;
+            AdjustThreadHeight( firstFrame, yBegin, yEnd );
             ImGui::PopClipRect();
             ImGui::PopID();
             return;
         }
     }
 
-    DrawOverlay( wpos + ImVec2( 0, oldOffset ), wpos + ImVec2( w, offset ) );
+    DrawOverlay( wpos + ImVec2( 0, yBegin ), wpos + ImVec2( w, yEnd ) );
     ImGui::PopClipRect();
 
     float labelWidth;
-    const auto hdrOffset = oldOffset;
+    const auto hdrOffset = yBegin;
     const bool drawHeader = yPos + ty >= yMin && yPos <= yMax;
     if( drawHeader )
     {
@@ -112,39 +114,38 @@ void TimelineItem::Draw( bool firstFrame, double pxns, int& offset, const ImVec2
         ImGui::EndPopup();
     }
 
-    offset += 0.2f * ostep;
-    AdjustThreadHeight( firstFrame, oldOffset, offset );
+    yEnd += 0.2f * ostep;
+    AdjustThreadHeight( firstFrame, yBegin, yEnd );
 
     ImGui::PopID();
 }
 
-void TimelineItem::AdjustThreadHeight( bool firstFrame, int oldOffset, int& offset )
+void TimelineItem::AdjustThreadHeight( bool firstFrame, int yBegin, int yEnd )
 {
     const auto speed = 4.0;
     const auto baseMove = 1.0;
 
-    const auto h = offset - oldOffset;
+    const auto newHeight = yEnd - yBegin;
     if( firstFrame )
     {
-        m_height = h;
+        m_height = newHeight;
     }
-    else if( m_height != h )
+    else if( m_height != newHeight )
     {
-        const auto diff = h - m_height;
+        const auto diff = newHeight - m_height;
         const auto preClampMove = diff * speed * ImGui::GetIO().DeltaTime;
         if( diff > 0 )
         {
             const auto move = preClampMove + baseMove;
-            m_height = int( std::min<double>( m_height + move, h ) );
+            m_height = int( std::min<double>( m_height + move, newHeight ) );
         }
         else
         {
             const auto move = preClampMove - baseMove;
-            m_height = int( std::max<double>( m_height + move, h ) );
+            m_height = int( std::max<double>( m_height + move, newHeight ) );
         }
         s_wasActive = true;
     }
-    offset = oldOffset + m_height;
 }
 
 void TimelineItem::VisibilityCheckbox()

--- a/server/TracyTimelineItem.hpp
+++ b/server/TracyTimelineItem.hpp
@@ -14,7 +14,7 @@ class Worker;
 class TimelineItem
 {
 public:
-    TimelineItem( View& view, Worker& worker );
+    TimelineItem( View& view, Worker& worker, const void* key );
     virtual ~TimelineItem() = default;
 
     // draws the timeilne item and also updates the next frame height value
@@ -28,6 +28,8 @@ public:
 
     // returns 0 instead of the correct value for the first frame
     int GetNextFrameHeight() const { return m_height; }
+
+    const void* GetKey() const { return m_key; }
 
 protected:
     virtual uint32_t HeaderColor() const = 0;
@@ -53,6 +55,8 @@ private:
     void AdjustThreadHeight( bool firstFrame, int yBegin, int yEnd );
 
     int m_height;
+
+    const void* m_key;
 
 protected:
     View& m_view;

--- a/server/TracyTimelineItem.hpp
+++ b/server/TracyTimelineItem.hpp
@@ -17,13 +17,17 @@ public:
     TimelineItem( View& view, Worker& worker );
     virtual ~TimelineItem() = default;
 
-    void Draw( bool firstFrame, double pxns, int& offset, const ImVec2& wpos, bool hover, float yMin, float yMax );
+    // draws the timeilne item and also updates the next frame height value
+    void Draw( bool firstFrame, double pxns, int yOffset, const ImVec2& wpos, bool hover, float yMin, float yMax );
 
     void VisibilityCheckbox();
     virtual void SetVisible( bool visible ) { m_visible = visible; }
     virtual bool IsVisible() const { return m_visible; }
 
     void SetShowFull( bool showFull ) { m_showFull = showFull; }
+
+    // returns 0 instead of the correct value for the first frame
+    int GetNextFrameHeight() const { return m_height; }
 
 protected:
     virtual uint32_t HeaderColor() const = 0;
@@ -46,7 +50,7 @@ protected:
     bool m_showFull;
 
 private:
-    void AdjustThreadHeight( bool firstFrame, int oldOffset, int& offset );
+    void AdjustThreadHeight( bool firstFrame, int yBegin, int yEnd );
 
     int m_height;
 

--- a/server/TracyTimelineItemCpuData.cpp
+++ b/server/TracyTimelineItemCpuData.cpp
@@ -8,8 +8,8 @@
 namespace tracy
 {
 
-TimelineItemCpuData::TimelineItemCpuData( View& view, Worker& worker, void* )
-    : TimelineItem( view, worker )
+TimelineItemCpuData::TimelineItemCpuData( View& view, Worker& worker, void* key )
+    : TimelineItem( view, worker, key )
 {
 }
 

--- a/server/TracyTimelineItemCpuData.hpp
+++ b/server/TracyTimelineItemCpuData.hpp
@@ -10,7 +10,7 @@ namespace tracy
 class TimelineItemCpuData final : public TimelineItem
 {
 public:
-    TimelineItemCpuData( View& view, Worker& worker, void* );
+    TimelineItemCpuData( View& view, Worker& worker, void* key );
 
     void SetVisible( bool visible ) override;
     bool IsVisible() const override;

--- a/server/TracyTimelineItemGpu.cpp
+++ b/server/TracyTimelineItemGpu.cpp
@@ -10,7 +10,7 @@ namespace tracy
 {
 
 TimelineItemGpu::TimelineItemGpu( View& view, Worker& worker, GpuCtxData* gpu )
-    : TimelineItem( view, worker )
+    : TimelineItem( view, worker, gpu )
     , m_gpu( gpu )
     , m_idx( view.GetNextGpuIdx() )
 {

--- a/server/TracyTimelineItemPlot.cpp
+++ b/server/TracyTimelineItemPlot.cpp
@@ -9,7 +9,7 @@ namespace tracy
 {
 
 TimelineItemPlot::TimelineItemPlot( View& view, Worker& worker, PlotData* plot )
-    : TimelineItem( view, worker )
+    : TimelineItem( view, worker, plot )
     , m_plot( plot )
 {
 }

--- a/server/TracyTimelineItemThread.cpp
+++ b/server/TracyTimelineItemThread.cpp
@@ -12,7 +12,7 @@ namespace tracy
 {
 
 TimelineItemThread::TimelineItemThread( View& view, Worker& worker, const ThreadData* thread )
-    : TimelineItem( view, worker )
+    : TimelineItem( view, worker, thread )
     , m_thread( thread )
     , m_ghost( false )
 {

--- a/server/TracyView_Timeline.cpp
+++ b/server/TracyView_Timeline.cpp
@@ -321,6 +321,7 @@ void View::DrawTimeline()
     const auto yMin = ImGui::GetCursorScreenPos().y;
     const auto yMax = linepos.y + lineh;
 
+    ImGui::SetNextWindowContentSize( ImVec2( 0, m_tc.GetHeight() ) );
     ImGui::BeginChild( "##zoneWin", ImVec2( ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y ), false, ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_NoScrollWithMouse );
 
     if( m_yDelta != 0 )
@@ -333,7 +334,6 @@ void View::DrawTimeline()
 
     const auto wpos = ImGui::GetCursorScreenPos();
     const auto dpos = wpos + ImVec2( 0.5f, 0.5f );
-    // note that m_tc.GetHeight() returns the height from the previous draw
     const auto h = std::max<float>( m_tc.GetHeight(), ImGui::GetContentRegionAvail().y - 4 );    // magic border value
 
     ImGui::ItemSize( ImVec2( w, h ) );

--- a/server/TracyView_Timeline.cpp
+++ b/server/TracyView_Timeline.cpp
@@ -341,7 +341,6 @@ void View::DrawTimeline()
     draw = ImGui::GetWindowDrawList();
 
     const auto ty = ImGui::GetTextLineHeight();
-    int offset = 0;
     const auto to = 9.f;
     const auto th = ( ty - to ) * sqrt( 3 ) * 0.5;
 
@@ -381,7 +380,7 @@ void View::DrawTimeline()
         }
     }
 
-    m_tc.End( pxns, offset, wpos, hover, yMin, yMax );
+    m_tc.End( pxns, wpos, hover, yMin, yMax );
     ImGui::EndChild();
 
     m_lockHighlight = m_nextLockHighlight;

--- a/server/TracyView_Timeline.cpp
+++ b/server/TracyView_Timeline.cpp
@@ -324,9 +324,16 @@ void View::DrawTimeline()
     ImGui::SetNextWindowContentSize( ImVec2( 0, m_tc.GetHeight() ) );
     ImGui::BeginChild( "##zoneWin", ImVec2( ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y ), false, ImGuiWindowFlags_AlwaysVerticalScrollbar | ImGuiWindowFlags_NoScrollWithMouse );
 
+    const auto verticallyCenterTimeline = true;
+
     if( m_yDelta != 0 )
     {
         auto& io = ImGui::GetIO();
+        if( !verticallyCenterTimeline )
+        {
+            auto y = ImGui::GetScrollY();
+            ImGui::SetScrollY( y - m_yDelta );
+        }
         io.MouseClickedPos[1].y = io.MousePos.y;
     }
 
@@ -378,7 +385,8 @@ void View::DrawTimeline()
         }
     }
 
-    m_tc.End( pxns, wpos, hover, drawMouseLine && m_viewMode == ViewMode::Paused, yMin, yMax );
+    const auto vcenter = verticallyCenterTimeline && drawMouseLine && m_viewMode == ViewMode::Paused;
+    m_tc.End( pxns, wpos, hover, vcenter, yMin, yMax );
     ImGui::EndChild();
 
     m_lockHighlight = m_nextLockHighlight;

--- a/server/TracyView_Timeline.cpp
+++ b/server/TracyView_Timeline.cpp
@@ -327,8 +327,6 @@ void View::DrawTimeline()
     if( m_yDelta != 0 )
     {
         auto& io = ImGui::GetIO();
-        auto y = ImGui::GetScrollY();
-        ImGui::SetScrollY( y - m_yDelta );
         io.MouseClickedPos[1].y = io.MousePos.y;
     }
 
@@ -380,7 +378,7 @@ void View::DrawTimeline()
         }
     }
 
-    m_tc.End( pxns, wpos, hover, yMin, yMax );
+    m_tc.End( pxns, wpos, hover, drawMouseLine && m_viewMode == ViewMode::Paused, yMin, yMax );
     ImGui::EndChild();
 
     m_lockHighlight = m_nextLockHighlight;


### PR DESCRIPTION
This feature, when enabled in the UI (under options), changes the behavior of the timeline view when the `TimelineItem`s are resizing. The timeline view keeps the `TimelineItem` that the mouse is hovering over in its location in the view. I have made the old behavior the default because I am not confident that everybody will prefer the new behavior but I still think its ready to be included. The first two commits make sense to be merged even if the rest is not approved. I would consider #286 to be fixed with this change.

* 1st commit refactors `offset` calculation in `TimelineItem`. There should be no observable changes.
* 2nd commit fixes a off-by-one-frame error in content height calculation. The fix is needed for the feature.
* 3rd commit adds the key to the `TimelineItem`. Also needed for the feature.
* 4th commit implements vertically centering the timeline on the mouse pointer.
* 5th commit makes the feature a run-time opt-in. The default is the old behavior.
