### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/public/client/tracy_concurrentqueue.h
+++ b/public/client/tracy_concurrentqueue.h
@@ -210,19 +210,13 @@ namespace details
 		}
 	};
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4554)
-#endif
 	template<typename T>
 	static inline bool circular_less_than(T a, T b)
 	{
 		static_assert(std::is_integral<T>::value && !std::numeric_limits<T>::is_signed, "circular_less_than is intended to be used only with unsigned integer types");
-		return static_cast<T>(a - b) > (static_cast<T>(static_cast<T>(1) << static_cast<T>(sizeof(T) * CHAR_BIT - 1)));
+		const T shift = static_cast<T>(sizeof(T) * CHAR_BIT - 1);
+		return a - b > (static_cast<T>(1) << shift);
 	}
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 	template<typename U>
 	static inline char* align_for(char* ptr)


### PR DESCRIPTION
The existing way to disable MSVC warning 4554 is not a good solution as the warning will still be triggered whenever the template is instantiated. It is better to change the code in a way that doesn't trigger the (false) warning at all.