### PR TITLE
Fix race condition for symbols resolution on windows

### DIFF
--- a/public/client/TracyCallstack.cpp
+++ b/public/client/TracyCallstack.cpp
@@ -227,6 +227,10 @@ void InitCallstack()
                 const auto res = GetModuleFileNameA( mod[i], name, 1021 );
                 if( res > 0 )
                 {
+                    // This may be a new module loaded since our call to SymInitialize.
+                    // Just in case, force DbgHelp to load its pdb !
+                    SymLoadModuleEx(proc, NULL, name, NULL, (DWORD64)info.lpBaseOfDll, info.SizeOfImage, NULL, 0);
+
                     auto ptr = name + res;
                     while( ptr > name && *ptr != '\\' && *ptr != '/' ) ptr--;
                     if( ptr > name ) ptr++;


### PR DESCRIPTION
There might have been new modules loaded by another thread between the `SymInitialize` and `EnumProcessModules` calls. Since we register the enumerated modules into the cache, we need to make sure that symbols for this module are loaded. The only way to do that is to call `SymLoadModuleEx`, just like we do when finding new modules after `InitCallstack`.