### PR TITLE
Fix unstable zone grouping

### DIFF
--- a/server/TracyView_ZoneTimeline.cpp
+++ b/server/TracyView_ZoneTimeline.cpp
@@ -636,7 +636,7 @@ int View::DrawZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx, co
     {
         auto& ev = a(*it);
         const auto end = m_worker.GetZoneEnd( ev );
-        const auto zsz = std::max( (end - ev.Start()) * pxns, pxns * 0.5 );
+        const auto zsz = std::max( ( end - ev.Start() ) * pxns, pxns * 0.5 );
         if( zsz < MinVisSize )
         {
             const auto MinVisNs = MinVisSize * nspx;
@@ -653,13 +653,13 @@ int View::DrawZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx, co
                 num += std::distance( prevIt, it );
                 if( it == zitend ) break;
                 const auto nend = m_worker.GetZoneEnd( a(*it) );
-                if(nend - lastZoneInGroupStart >= MinVisNs * 2 ) break;
+                if( nend - lastZoneInGroupStart >= MinVisNs * 2 ) break;
                 lastZoneInGroupStart = a(*it).Start();
                 nextTime = nend + nspx;
             }
             auto lastZoneInGroupIt = it;
             lastZoneInGroupIt--;
-            auto rend = m_worker.GetZoneEnd(a(*lastZoneInGroupIt));
+            auto rend = m_worker.GetZoneEnd( a(*lastZoneInGroupIt) );
             auto px1ns = rend - m_vd.zvStart;
 
             const auto px1 = px1ns * pxns;


### PR DESCRIPTION
The zone grouping was only taking into account the first zone for both its duration and width, which was wrong and could cause zones to "disappear" if the first zone of the group was really small. 

![image](https://user-images.githubusercontent.com/6024225/221689325-15da0c0c-bb7d-41ea-96a6-7e87e27fbaff.png)
![image](https://user-images.githubusercontent.com/6024225/221689339-f073f2c4-686a-483b-9232-efb73950bcfb.png)

Grouping now works by taking into account the size of the zone and not the clipped to screen size for grouping decisions, to avoid having zone groups popping at the beginning and end of the window. In order to have consistent results and avoid popping, we're using the start of the last zone in a group as reference instead of its end. This means that it now includes the zone width, so that we make the same decisions wether we are in considering new zones in the loop or to start grouping zones.

Altogether, this seems to have fixed any zone popping when panning, at the cost of not grouping the first/last zone if it is clipped, which seems to be less of an issue to me.
