### PR TITLE
Add: Alternative Vulkan context constructor

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -1523,6 +1523,12 @@ In order to maintain synchronization between CPU and GPU time domains, you will 
 
 To enable calibrated context, replace the macro \texttt{TracyVkContext} with \texttt{TracyVkContextCalibrated} and pass the two functions as additional parameters, in the order specified above.
 
+\subparagraph{Using Vulkan 1.2 features}
+
+Vulkan 1.2 and \texttt{VK\_EXT\_host\_query\_reset} provide mechanics to reset the query pool without the need of a command buffer. By using \texttt{TracyVkContextHostCalibrated} you can make use of this feature. It only requires a function pointer to \texttt{vkResetQueryPool} in addition to the ones required for \texttt{TracyVkContextCalibrated} instead of the VkQueue and VkCommandBuffer handles.
+
+However, using this feature requires the physical device to have calibrated device and host time domains. In addition to \texttt{VK\_TIME\_DOMAIN\_DEVICE\_EXT}, \texttt{vkGetPhysicalDeviceCalibrateableTimeDomainsEXT} will have to additionally return either \texttt{VK\_TIME\_DOMAIN\_CLOCK\_MONOTONIC\_RAW\_EXT} or \texttt{VK\_TIME\_DOMAIN\_QUERY\_PERFORMANCE\_COUNTER\_EXT} for Unix and Windows, respectively. If this is not the case, you will need to use \texttt{TracyVkContextCalibrated} or \texttt{TracyVkContext} macro instead.
+
 \subsubsection{Direct3D 11}
 
 To enable Direct3D 11 support, include the \texttt{public/tracy/TracyD3D11.hpp} header file, and create a \texttt{TracyD3D11Ctx} object with the \texttt{TracyD3D11Context(device, devicecontext)} macro. The object should later be cleaned up with the \texttt{TracyD3D11Destroy} macro. Tracy does not support D3D11 command lists. To set a custom name for the context, use the \texttt{TracyGpuContextName(name, size)} macro.


### PR DESCRIPTION
This adds a new constructor to the Vulkan context class that does not require to have a VkCommandBuffer and VkCommandPool created for it. It instead fully relies on host operations that were added with newer versions of Vulkan to completely avoid the use of command buffers. However, there are cases where the physical device does not support host timestamps with `vkGetCalibratedTimestampsEXT` where the command buffer based constructor would need to be used (I've placed an assertion to detect this). The user would need to check for this. (Most modern GPU drivers support this though)

I've tried to stick with the style of the rest of the header, I hope that that looks fine. However, I'm not sure wether I should be moving common code out of the constructors so that their differences are easily spottable and are simpler to read.