### PR TITLE
add version to meson.build 'project()'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('tracy', ['cpp'])
+project('tracy', ['cpp'], version: '0.9.1')
 
 if get_option('tracy_enable')
   add_project_arguments('-DTRACY_ENABLE', language : 'cpp')


### PR DESCRIPTION
Meson projects which use tracy as a subproject and specify a version for the dependency will fail due to an undefined version number.

A new tag would be helpful as well so I can submit a new version to the Meson WrapDB, maybe '0.9.1.1'.