### PR TITLE
Clamp scrolling to the difference between the deepest zone near the m…

### DIFF
--- a/server/TracyTimelineController.cpp
+++ b/server/TracyTimelineController.cpp
@@ -160,7 +160,7 @@ void TimelineController::End( double pxns, const ImVec2& wpos, bool hover, bool 
 
     if( const auto scrollY = CalculateScrollPosition() )
     {
-        int clampedScrollY = std::min<int>( *scrollY, yOffset );
+        int clampedScrollY = std::min<int>( *scrollY, std::max<int>( yOffset - ImGui::GetWindowHeight(), 0 ) );
         ImGui::SetScrollY( clampedScrollY );
         int minHeight = ImGui::GetWindowHeight() + clampedScrollY;
         yOffset = std::max( yOffset, minHeight );


### PR DESCRIPTION
…ouse, and the height of the window.

This prevents from unncessary scrolling when the trace does not exceed the size of the screen.

Would be great if @tvoeroes can confirm this does not regress their use.

