### PR TITLE
give a hint towards `__attribute__((cleanup)` for RAII type behavior in C

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -1880,7 +1880,7 @@ The following macros mark the beginning of a zone:
 
 Refer to sections~\ref{markingzones} and~\ref{multizone} for description of macro variants and parameters. The \texttt{ctx} parameter specifies the name of a data structure, which the macro will create on the stack to hold the internal zone data.
 
-Unlike C++, there's no automatic destruction mechanism in C, so you will need to mark where the zone ends manually. To do so use the \texttt{TracyCZoneEnd(ctx)} macro.
+Unlike C++, there's no automatic destruction mechanism in C, so you will need to mark where the zone ends manually. To do so use the \texttt{TracyCZoneEnd(ctx)} macro.\footnote{GCC and Clang provide \texttt{\_\_attribute\_\_((cleanup))} which can used to run a function when a variable goes out of scope.}
 
 Zone text and name may be set by using the \texttt{TracyCZoneText(ctx, txt, size)}, \texttt{TracyCZoneValue(ctx, value)} and \texttt{TracyCZoneName(ctx, txt, size)} macros. Make sure you are following the zone stack rules, as described in section~\ref{multizone}!
 


### PR DESCRIPTION
I felt like this could be a useful little hint since it can quite significantly simplify using the C api since you don't have to manually insert the zone end function everywhere a function can return.