### PR TITLE
prevent divding by zero `csvexport` when number of zones is 1

### DIFF
--- a/csvexport/src/csvexport.cpp
+++ b/csvexport/src/csvexport.cpp
@@ -337,7 +337,9 @@ int main(int argc, char** argv)
             const auto ss = zone_data.sumSq
                 - 2. * zone_data.total * avg
                 + avg * avg * sz;
-            const auto std = sqrt(ss / (sz - 1));
+            double std = 0;
+            if( sz > 1 )
+                std = sqrt(ss / (sz - 1));
             values[9] = std::to_string(std);
 
             std::string row = join(values, args.separator);


### PR DESCRIPTION
We've noticed segfaults when exporting a tracy file to CSV in cases where one of the zones only has a single entry. The segfault is very "delicate", many things make it go away such as changing optimization level, disabling LTO, etc.

The actual segfault occurs in `std::to_string` in the line below the change in this commit but the fix here solves it, probably by avoiding the undefined behavior in this case.

The GDB backtrace to the segfaults is given below:

<details>
  <summary>GDB backtrace</summary>

```
Thread 1 "tracy-csvexport" received signal SIGSEGV, Segmentation fault.
0x000000000049c2a5 in std::char_traits<char>::copy (__n=4, __s2=0x7fffffffaa70 "-nan", __s1=<optimized out>) at /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/bits/char_traits.h:350
350     /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/bits/char_traits.h: No such file or directory.
(gdb) bt
#0  0x000000000049c2a5 in std::char_traits<char>::copy (__n=4, 
    __s2=0x7fffffffaa70 "-nan", __s1=<optimized out>)
    at /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/bits/char_traits.h:350
#1  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_copy (__n=4, __s=0x7fffffffaa70 "-nan", 
    __d=<optimized out>)
    at /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/bits/basic_string.h:340
#2  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_copy_chars (__k2=0x7fffffffaa74 "", 
    __k1=0x7fffffffaa70 "-nan", __p=<optimized out>)
    at /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/bits/basic_string.h:387
#3  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*> (
    __end=0x7fffffffaa74 "", __beg=0x7fffffffaa70 "-nan", 
    this=0x7fffffffaed0)
    at /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/bits/basic_string.tcc:225
#4  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct_aux<char*> (__end=<optimized out>, 
    __beg=<optimized out>, this=<optimized out>, 
    this=<optimized out>, __beg=<optimized out>, 
    __end=<optimized out>)
    at /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/bits/basic_string.h:236
#5  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*> (__end=<optimized out>, 
    __beg=<optimized out>, this=<optimized out>, 
    this=<optimized out>, __beg=<optimized out>, 
    __end=<optimized out>)
    at /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/bits/basic_string.h:255
#6  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<char*, void> (__a=..., 
    __end=<optimized out>, __beg=<optimized out>, 
    this=<optimized out>, this=<optimized out>, 
    __beg=<optimized out>, __end=<optimized out>, __a=...)
    at /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/bits/basic_string.h:607
#7  __gnu_cxx::__to_xstring<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, char>(int (*)(char*, unsigned long, char const*, __va_list_tag*), unsigned long, char const*, ...) [clone .constprop.15] (__convf=<optimized out>, __n=328, 
    __fmt=0x4d4cf0 "%f", __fmt=0x4d4cf0 "%f", __n=328, 
    __convf=<optimized out>)
    at /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/ext/string_conversions.h:115
#8  0x000000000040546b in std::__cxx11::to_string (
    __val=<optimized out>)
    at /opt/x86_64-linux-gnu/x86_64-linux-gnu/include/c++/8.1.0/bits/basic_string.h:6461
#9  main (argc=<optimized out>, argv=<optimized out>)
    at ../../src/csvexport.cpp:341
```

</summary>