### PR TITLE
Added cmake versioning and removed hardcoded share dir path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(Tracy LANGUAGES CXX)
+# Run version helper script
+include(version.cmake)
+
+set(TRACY_VERSION_MAJOR ${major})
+set(TRACY_VERSION_MINOR ${minor})
+set(TRACY_VERSION_PATCH ${patch})
+set(TRACY_VERSION_STRING "${TRACY_VERSION_MAJOR}.${TRACY_VERSION_MINOR}.${TRACY_VERSION_PATCH}")
+
+project(Tracy LANGUAGES CXX VERSION ${TRACY_VERSION_STRING})
 
 if(${BUILD_SHARED_LIBS})
 	set(DEFAULT_STATIC OFF)
@@ -84,6 +92,8 @@ endif()
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
+set_target_properties(TracyClient PROPERTIES VERSION ${PROJECT_VERSION})
+
 set(tracy_includes
     ${TRACY_PUBLIC_DIR}/tracy/TracyC.h
     ${TRACY_PUBLIC_DIR}/tracy/Tracy.hpp
@@ -146,10 +156,10 @@ install(FILES ${common_includes}
 install(EXPORT TracyConfig
         NAMESPACE Tracy::
         FILE TracyTargets.cmake
-        DESTINATION share/Tracy)
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/Tracy)
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
         "${CMAKE_CURRENT_BINARY_DIR}/TracyConfig.cmake"
-        INSTALL_DESTINATION share/Tracy)
+        INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/Tracy)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/TracyConfig.cmake
-        DESTINATION share/Tracy)
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/Tracy)

--- a/version.cmake
+++ b/version.cmake
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.10)
+
+message("Parsing public/common/TracyVersion.hpp file")
+
+file(READ "public/common/TracyVersion.hpp" version)
+
+# Note: This looks for a specific pattern in TracyVersion.hpp, if it changes
+# this needs updating.
+string(REGEX MATCH "Major = ([0-9]+)" _ ${version})
+
+# This works do to the above () subexpression selection. See
+# https://cmake.org/cmake/help/latest/command/string.html#regex-match for more
+# details
+set(major ${CMAKE_MATCH_1})
+
+string(REGEX MATCH "Minor = ([0-9]+)" _ ${version})
+set(minor ${CMAKE_MATCH_1})
+
+string(REGEX MATCH "Patch = ([0-9]+)" _ ${version})
+set(patch ${CMAKE_MATCH_1})
+
+message("VERSION ${major}.${minor}.${patch}")


### PR DESCRIPTION
### Changes and Reason
Added a version string to the cmake to allow the shared library to be set up with correct version number and symlink. This is particularity important when incorporating Tracy into a [Yocto](https://www.yoctoproject.org/) recipe. The outcome of this change is a .so file and symlink as follows 
```
lrwxrwxrwx  1 christian christian     19 Jul 11 16:29 libTracyClient.so -> libTracyClient.so.0
lrwxrwxrwx  1 christian christian     23 Jul 11 16:29 libTracyClient.so.0 -> libTracyClient.so.0.9.1
-rwxrwxr-x  1 christian christian 829344 Jul 11 16:29 libTracyClient.so.0.9.1
```
Also replaced the hard coded share dir with the built in [cmake variable](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html) for the share dir to match the rest of the cmake.

Hopefully you find these acceptable.

### Testing 
Able to build and use the library just as before and if used in Yocto image successfully adds library to image. 
