### PR TITLE
Fix compilation for the case of using TRACY_NO_CALLSTACK

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1072,7 +1072,9 @@ static void CrashHandler( int signal, siginfo_t* info, void* /*ucontext*/ )
     }
     closedir( dp );
 
+#ifdef TRACY_HAS_CALLSTACK
     if( selfTid == s_symbolTid ) s_symbolThreadGone.store( true, std::memory_order_release );
+#endif
 
     TracyLfqPrepare( QueueType::Crash );
     TracyLfqCommit;


### PR DESCRIPTION
Declaration of `s_symbolThreadGone` [wrapped with macros](https://github.com/wolfpld/tracy/blob/master/public/client/TracyProfiler.cpp#L849-L852), which is missing in the place of usage. So, compilation will fail, if you use `TRACY_NO_CALLSTACK`.