### PR TITLE
C++20 co_await support prototype

### DIFF
--- a/public/client/TracyAsyncEvents.hpp
+++ b/public/client/TracyAsyncEvents.hpp
@@ -2,126 +2,78 @@
 
 #include "TracyProfiler.hpp"
 
-#define DEBUG_TEMP 1
-#if DEBUG_TEMP
-#include <syncstream>
-#include <iostream>
-#include <string>
+#if 0
+    #define ASSERT(x)
+#else
+    #define ASSERT(x) if(!(x)) __debugbreak();
 #endif
 
 namespace tracy
 {
     class AsyncScopedZone;
     struct SourceLocationData;
-    inline thread_local tracy::AsyncScopedZone* g_pCurrentZone = nullptr;
+    inline thread_local AsyncScopedZone* g_pCurrentZone = nullptr;
 
-    void StartAsyncEvent(const AsyncScopedZone* pAsyncScopedZone
-#if DEBUG_TEMP
-        , size_t nFiber
-#endif
-    );
-    void StopAsyncEvent();
+    void StartAsyncEvent(AsyncScopedZone* pAsyncScopedZone);
+    void StopAsyncEvent(AsyncScopedZone* pAsyncScopedZone);
 
     class AsyncScopedZone
     {
     public:
-        AsyncScopedZone(const SourceLocationData* pSourceLocation
-#if DEBUG_TEMP
-            , size_t nFiber
-#endif
-        );
+        AsyncScopedZone(const SourceLocationData* pSourceLocation);
         ~AsyncScopedZone();
 
         // private:
         const SourceLocationData* const m_pSourceLocation = nullptr;
-#if DEBUG_TEMP
-        const size_t m_nFiber = -1;
-#endif
         AsyncScopedZone* m_pParent = nullptr;
+        // std::thread::id m_LockThreadId;
     };
 }
 
-
-tracy_force_inline void tracy::StartAsyncEvent(const AsyncScopedZone* pAsyncScopedZone
-#if DEBUG_TEMP
-    , size_t nFiber
-#endif
-)
+inline void tracy::StartAsyncEvent(AsyncScopedZone* pAsyncScopedZone)
 {
+    ASSERT(pAsyncScopedZone);
+    ASSERT(!g_pCurrentZone);
+    // pAsyncScopedZone->m_LockThreadId = std::this_thread::get_id();
+    g_pCurrentZone = pAsyncScopedZone;
+
     TracyQueuePrepare( QueueType::ZoneBegin );
     MemWrite( &item->zoneBegin.time, Profiler::GetTime() );
     MemWrite( &item->zoneBegin.srcloc, (uint64_t)pAsyncScopedZone->m_pSourceLocation );
     TracyQueueCommit( zoneBeginThread );
-
-#if DEBUG_TEMP
-    if (nFiber == 0)
-    {
-        const std::string sMessage = "fiber: " + std::to_string(nFiber);
-        tracy::Profiler::Message(sMessage.c_str(), sMessage.size(), 0);
-    }
-#endif
 }
 
-tracy_force_inline void tracy::StopAsyncEvent()
+inline void tracy::StopAsyncEvent(AsyncScopedZone* pAsyncScopedZone)
 {
+    ASSERT(pAsyncScopedZone);
+    ASSERT(pAsyncScopedZone == g_pCurrentZone);
+    // ASSERT(pAsyncScopedZone->m_LockThreadId == std::this_thread::get_id());
+    g_pCurrentZone = nullptr;
+
     TracyQueuePrepare(QueueType::ZoneEnd);
     MemWrite(&item->zoneEnd.time, Profiler::GetTime());
     TracyQueueCommit(zoneEndThread);
 }
 
-tracy_force_inline tracy::AsyncScopedZone::AsyncScopedZone(const SourceLocationData* pSourceLocation
-#if DEBUG_TEMP
-    , size_t nFiber
-#endif
-)
+inline tracy::AsyncScopedZone::AsyncScopedZone(const SourceLocationData* pSourceLocation)
     : m_pSourceLocation(pSourceLocation)
-#if DEBUG_TEMP
-    , m_nFiber(nFiber)
-#endif
 {
     if (g_pCurrentZone)
     {
-#if DEBUG_TEMP
-        std::osyncstream(std::cout) << "AsyncScopedZone: constructor, StopAsyncEvent"
-            << ", location: " << g_pCurrentZone->m_pSourceLocation->function
-            << ", fiber: " << nFiber
-            << ", thread id: " << std::this_thread::get_id()
-            << ", frame: " << GetProfiler().GetFrame()
-            << std::endl;
-#endif
-
         m_pParent = g_pCurrentZone;
-        StopAsyncEvent();
+        StopAsyncEvent(g_pCurrentZone);
     }
 
-#if DEBUG_TEMP
-    std::osyncstream(std::cout) << "AsyncScopedZone: constructor, StartAsyncEvent"
-        << ", location: " << pSourceLocation->function
-        << ", fiber: " << nFiber
-        << ", thread id: " << std::this_thread::get_id()
-        << ", frame: " << GetProfiler().GetFrame()
-        << std::endl;
-#endif
-
-    g_pCurrentZone = this;
-    StartAsyncEvent(this
-#if DEBUG_TEMP
-        , nFiber
-#endif
-    );
+    StartAsyncEvent(this);
 }
 
-tracy_force_inline tracy::AsyncScopedZone::~AsyncScopedZone()
+inline tracy::AsyncScopedZone::~AsyncScopedZone()
 {
     if (g_pCurrentZone)
     {
-        StopAsyncEvent();
-        g_pCurrentZone = g_pCurrentZone->m_pParent;
-        if (g_pCurrentZone)
-            StartAsyncEvent(g_pCurrentZone
-#if DEBUG_TEMP
-                , g_pCurrentZone->m_nFiber
-#endif
-            );
+        auto pZoneToContinue = g_pCurrentZone->m_pParent;
+        StopAsyncEvent(g_pCurrentZone);
+        if (pZoneToContinue)
+            StartAsyncEvent(pZoneToContinue);
     }
 }

--- a/public/client/TracyAsyncEvents.hpp
+++ b/public/client/TracyAsyncEvents.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+#include "TracyProfiler.hpp"
+
+#define DEBUG_TEMP 1
+#if DEBUG_TEMP
+#include <syncstream>
+#include <iostream>
+#include <string>
+#endif
+
+namespace tracy
+{
+    class AsyncScopedZone;
+    struct SourceLocationData;
+    inline thread_local tracy::AsyncScopedZone* g_pCurrentZone = nullptr;
+
+    void StartAsyncEvent(const AsyncScopedZone* pAsyncScopedZone
+#if DEBUG_TEMP
+        , size_t nFiber
+#endif
+    );
+    void StopAsyncEvent();
+
+    class AsyncScopedZone
+    {
+    public:
+        AsyncScopedZone(const SourceLocationData* pSourceLocation
+#if DEBUG_TEMP
+            , size_t nFiber
+#endif
+        );
+        ~AsyncScopedZone();
+
+        // private:
+        const SourceLocationData* const m_pSourceLocation = nullptr;
+#if DEBUG_TEMP
+        const size_t m_nFiber = -1;
+#endif
+        AsyncScopedZone* m_pParent = nullptr;
+    };
+}
+
+
+tracy_force_inline void tracy::StartAsyncEvent(const AsyncScopedZone* pAsyncScopedZone
+#if DEBUG_TEMP
+    , size_t nFiber
+#endif
+)
+{
+    TracyQueuePrepare( QueueType::ZoneBegin );
+    MemWrite( &item->zoneBegin.time, Profiler::GetTime() );
+    MemWrite( &item->zoneBegin.srcloc, (uint64_t)pAsyncScopedZone->m_pSourceLocation );
+    TracyQueueCommit( zoneBeginThread );
+
+#if DEBUG_TEMP
+    if (nFiber == 0)
+    {
+        const std::string sMessage = "fiber: " + std::to_string(nFiber);
+        tracy::Profiler::Message(sMessage.c_str(), sMessage.size(), 0);
+    }
+#endif
+}
+
+tracy_force_inline void tracy::StopAsyncEvent()
+{
+    TracyQueuePrepare(QueueType::ZoneEnd);
+    MemWrite(&item->zoneEnd.time, Profiler::GetTime());
+    TracyQueueCommit(zoneEndThread);
+}
+
+tracy_force_inline tracy::AsyncScopedZone::AsyncScopedZone(const SourceLocationData* pSourceLocation
+#if DEBUG_TEMP
+    , size_t nFiber
+#endif
+)
+    : m_pSourceLocation(pSourceLocation)
+#if DEBUG_TEMP
+    , m_nFiber(nFiber)
+#endif
+{
+    if (g_pCurrentZone)
+    {
+#if DEBUG_TEMP
+        std::osyncstream(std::cout) << "AsyncScopedZone: constructor, StopAsyncEvent"
+            << ", location: " << g_pCurrentZone->m_pSourceLocation->function
+            << ", fiber: " << nFiber
+            << ", thread id: " << std::this_thread::get_id()
+            << ", frame: " << GetProfiler().GetFrame()
+            << std::endl;
+#endif
+
+        m_pParent = g_pCurrentZone;
+        StopAsyncEvent();
+    }
+
+#if DEBUG_TEMP
+    std::osyncstream(std::cout) << "AsyncScopedZone: constructor, StartAsyncEvent"
+        << ", location: " << pSourceLocation->function
+        << ", fiber: " << nFiber
+        << ", thread id: " << std::this_thread::get_id()
+        << ", frame: " << GetProfiler().GetFrame()
+        << std::endl;
+#endif
+
+    g_pCurrentZone = this;
+    StartAsyncEvent(this
+#if DEBUG_TEMP
+        , nFiber
+#endif
+    );
+}
+
+tracy_force_inline tracy::AsyncScopedZone::~AsyncScopedZone()
+{
+    if (g_pCurrentZone)
+    {
+        StopAsyncEvent();
+        g_pCurrentZone = g_pCurrentZone->m_pParent;
+        if (g_pCurrentZone)
+            StartAsyncEvent(g_pCurrentZone
+#if DEBUG_TEMP
+                , g_pCurrentZone->m_nFiber
+#endif
+            );
+    }
+}

--- a/public/client/TracyAwaitable.hpp
+++ b/public/client/TracyAwaitable.hpp
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "TracyAsyncEvents.hpp"
+
+#include <type_traits>
+
+namespace tracy
+{
+    template<class BaseAwaitableType>
+    class Awaitable : public BaseAwaitableType
+    {
+    public:
+        Awaitable(BaseAwaitableType baseAwaitable);
+#if DEBUG_TEMP
+        ~Awaitable();
+#endif
+        auto await_suspend(auto handle);
+        auto await_resume();
+
+    private:
+        AsyncScopedZone* m_pCurrentZone = nullptr;
+    };
+
+    template<class BaseAwaitableType>
+    Awaitable<BaseAwaitableType>::Awaitable(BaseAwaitableType baseAwaitable)
+        : BaseAwaitableType(std::move(baseAwaitable))
+    {
+#if DEBUG_TEMP
+        std::osyncstream(std::cout) << "Awaitable: constructor"
+            << ", thread id: " << std::this_thread::get_id()
+            << ", frame: " << GetProfiler().GetFrame()
+            << std::endl;
+#endif
+    }
+
+#if DEBUG_TEMP
+    template <class BaseAwaitableType>
+    Awaitable<BaseAwaitableType>::~Awaitable()
+    {
+        std::osyncstream(std::cout) << "Awaitable: destructor"
+            << ", thread id: " << std::this_thread::get_id()
+            << ", frame: " << GetProfiler().GetFrame()
+            << std::endl;
+    }
+#endif
+
+    template<class BaseAwaitableType>
+    auto Awaitable<BaseAwaitableType>::await_suspend(auto handle)
+    {
+#if DEBUG_TEMP
+        std::osyncstream(std::cout) << "Awaitable: await_suspend"
+            << ", thread id: " << std::this_thread::get_id()
+            << ", frame: " << GetProfiler().GetFrame()
+            << std::endl;
+#endif
+
+        if (g_pCurrentZone)
+        {
+#if DEBUG_TEMP
+            std::osyncstream(std::cout) << "Awaitable: await_suspend, StopAsyncEvent"
+                << ", location: " << g_pCurrentZone->m_pSourceLocation->function
+                << ", fiber: " << g_pCurrentZone->m_nFiber
+                << ", thread id: " << std::this_thread::get_id()
+                << ", frame: " << GetProfiler().GetFrame()
+                << std::endl;
+#endif
+
+            m_pCurrentZone = g_pCurrentZone;
+            g_pCurrentZone = nullptr;
+            StopAsyncEvent();
+        }
+
+        return BaseAwaitableType::await_suspend(handle);
+    }
+
+    template<class BaseAwaitableType>
+    auto Awaitable<BaseAwaitableType>::await_resume()
+    {
+#if DEBUG_TEMP
+        std::osyncstream(std::cout) << "Awaitable: await_resume"
+            << ", thread id: " << std::this_thread::get_id()
+            << ", frame: " << GetProfiler().GetFrame()
+            << std::endl;
+#endif
+
+        if (m_pCurrentZone)
+        {
+#if DEBUG_TEMP
+            std::osyncstream(std::cout) << "Awaitable: await_resume, StartAsyncEvent"
+                << ", location: " << m_pCurrentZone->m_pSourceLocation->function
+                << ", fiber: " << m_pCurrentZone->m_nFiber
+                << ", thread id: " << std::this_thread::get_id()
+                << ", frame: " << GetProfiler().GetFrame()
+                << std::endl;
+#endif
+
+            StartAsyncEvent(m_pCurrentZone
+#if DEBUG_TEMP
+                , m_pCurrentZone->m_nFiber
+#endif
+            );
+            g_pCurrentZone = m_pCurrentZone;
+            m_pCurrentZone = nullptr;
+        }
+
+        return BaseAwaitableType::await_resume();
+    }
+}

--- a/public/client/TracyAwaitable.hpp
+++ b/public/client/TracyAwaitable.hpp
@@ -11,11 +11,7 @@ namespace tracy
     {
     public:
         Awaitable(BaseAwaitableType baseAwaitable);
-#if DEBUG_TEMP
         ~Awaitable();
-#endif
-        auto await_suspend(auto handle);
-        auto await_resume();
 
     private:
         AsyncScopedZone* m_pCurrentZone = nullptr;
@@ -25,84 +21,17 @@ namespace tracy
     Awaitable<BaseAwaitableType>::Awaitable(BaseAwaitableType baseAwaitable)
         : BaseAwaitableType(std::move(baseAwaitable))
     {
-#if DEBUG_TEMP
-        std::osyncstream(std::cout) << "Awaitable: constructor"
-            << ", thread id: " << std::this_thread::get_id()
-            << ", frame: " << GetProfiler().GetFrame()
-            << std::endl;
-#endif
+        if (g_pCurrentZone)
+        {
+            m_pCurrentZone = g_pCurrentZone;
+            StopAsyncEvent(g_pCurrentZone);
+        }
     }
 
-#if DEBUG_TEMP
     template <class BaseAwaitableType>
     Awaitable<BaseAwaitableType>::~Awaitable()
     {
-        std::osyncstream(std::cout) << "Awaitable: destructor"
-            << ", thread id: " << std::this_thread::get_id()
-            << ", frame: " << GetProfiler().GetFrame()
-            << std::endl;
-    }
-#endif
-
-    template<class BaseAwaitableType>
-    auto Awaitable<BaseAwaitableType>::await_suspend(auto handle)
-    {
-#if DEBUG_TEMP
-        std::osyncstream(std::cout) << "Awaitable: await_suspend"
-            << ", thread id: " << std::this_thread::get_id()
-            << ", frame: " << GetProfiler().GetFrame()
-            << std::endl;
-#endif
-
-        if (g_pCurrentZone)
-        {
-#if DEBUG_TEMP
-            std::osyncstream(std::cout) << "Awaitable: await_suspend, StopAsyncEvent"
-                << ", location: " << g_pCurrentZone->m_pSourceLocation->function
-                << ", fiber: " << g_pCurrentZone->m_nFiber
-                << ", thread id: " << std::this_thread::get_id()
-                << ", frame: " << GetProfiler().GetFrame()
-                << std::endl;
-#endif
-
-            m_pCurrentZone = g_pCurrentZone;
-            g_pCurrentZone = nullptr;
-            StopAsyncEvent();
-        }
-
-        return BaseAwaitableType::await_suspend(handle);
-    }
-
-    template<class BaseAwaitableType>
-    auto Awaitable<BaseAwaitableType>::await_resume()
-    {
-#if DEBUG_TEMP
-        std::osyncstream(std::cout) << "Awaitable: await_resume"
-            << ", thread id: " << std::this_thread::get_id()
-            << ", frame: " << GetProfiler().GetFrame()
-            << std::endl;
-#endif
-
         if (m_pCurrentZone)
-        {
-#if DEBUG_TEMP
-            std::osyncstream(std::cout) << "Awaitable: await_resume, StartAsyncEvent"
-                << ", location: " << m_pCurrentZone->m_pSourceLocation->function
-                << ", fiber: " << m_pCurrentZone->m_nFiber
-                << ", thread id: " << std::this_thread::get_id()
-                << ", frame: " << GetProfiler().GetFrame()
-                << std::endl;
-#endif
-
-            StartAsyncEvent(m_pCurrentZone
-#if DEBUG_TEMP
-                , m_pCurrentZone->m_nFiber
-#endif
-            );
-            g_pCurrentZone = m_pCurrentZone;
-            m_pCurrentZone = nullptr;
-        }
-
-        return BaseAwaitableType::await_resume();
+            StartAsyncEvent(m_pCurrentZone);
     }
 }

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -237,11 +237,6 @@ public:
         return m_zoneId.fetch_add( 1, std::memory_order_relaxed );
     }
 
-    tracy_force_inline uint64_t GetFrame() const
-    {
-        return m_frameCount.load( std::memory_order_relaxed );
-    }
-
     static tracy_force_inline QueueItem* QueueSerial()
     {
         auto& p = GetProfiler();

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -237,6 +237,11 @@ public:
         return m_zoneId.fetch_add( 1, std::memory_order_relaxed );
     }
 
+    tracy_force_inline uint64_t GetFrame() const
+    {
+        return m_frameCount.load( std::memory_order_relaxed );
+    }
+
     static tracy_force_inline QueueItem* QueueSerial()
     {
         auto& p = GetProfiler();

--- a/public/client/TracyResult.hpp
+++ b/public/client/TracyResult.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "TracyAwaitable.hpp"
+
+#include <coroutine>
+
+namespace tracy
+{
+    template<class BaseResultType>
+    class Result : public BaseResultType
+    {
+    public:
+        Result(BaseResultType&& result);
+#if DEBUG_TEMP
+        ~Result();
+#endif
+        auto operator co_await();
+    };
+
+    template<class BaseResultType>
+    Result<BaseResultType>::Result(BaseResultType&& result)
+        : BaseResultType(std::forward<BaseResultType>(result))
+    {
+#if DEBUG_TEMP
+        std::osyncstream(std::cout) << "Result: constructor"
+            << ", thread id: " << std::this_thread::get_id()
+            << ", frame: " << GetProfiler().GetFrame()
+            << std::endl;
+#endif
+    }
+
+#if DEBUG_TEMP
+    template <class BaseResultType>
+    Result<BaseResultType>::~Result()
+    {
+        std::osyncstream(std::cout) << "Result: destructor"
+            << ", thread id: " << std::this_thread::get_id()
+            << ", frame: " << GetProfiler().GetFrame()
+            << std::endl;
+    }
+#endif
+
+    template<class BaseResultType>
+    auto Result<BaseResultType>::operator co_await()
+    {
+#if DEBUG_TEMP
+        std::osyncstream(std::cout) << "Result: operator co_await"
+            << ", thread id: " << std::this_thread::get_id()
+            << ", frame: " << GetProfiler().GetFrame()
+            << std::endl;
+#endif
+
+        return Awaitable(BaseResultType::operator co_await());
+    }
+}
+
+template<template<class> class original_result, class type, class... arguments>
+struct std::coroutine_traits<tracy::Result<original_result<type>>, arguments...>
+{
+    using promise_type = typename coroutine_traits<original_result<type>, arguments...>::promise_type;
+};

--- a/public/client/TracyResult.hpp
+++ b/public/client/TracyResult.hpp
@@ -11,9 +11,6 @@ namespace tracy
     {
     public:
         Result(BaseResultType&& result);
-#if DEBUG_TEMP
-        ~Result();
-#endif
         auto operator co_await();
     };
 
@@ -21,35 +18,11 @@ namespace tracy
     Result<BaseResultType>::Result(BaseResultType&& result)
         : BaseResultType(std::forward<BaseResultType>(result))
     {
-#if DEBUG_TEMP
-        std::osyncstream(std::cout) << "Result: constructor"
-            << ", thread id: " << std::this_thread::get_id()
-            << ", frame: " << GetProfiler().GetFrame()
-            << std::endl;
-#endif
     }
-
-#if DEBUG_TEMP
-    template <class BaseResultType>
-    Result<BaseResultType>::~Result()
-    {
-        std::osyncstream(std::cout) << "Result: destructor"
-            << ", thread id: " << std::this_thread::get_id()
-            << ", frame: " << GetProfiler().GetFrame()
-            << std::endl;
-    }
-#endif
 
     template<class BaseResultType>
     auto Result<BaseResultType>::operator co_await()
     {
-#if DEBUG_TEMP
-        std::osyncstream(std::cout) << "Result: operator co_await"
-            << ", thread id: " << std::this_thread::get_id()
-            << ", frame: " << GetProfiler().GetFrame()
-            << std::endl;
-#endif
-
         return Awaitable(BaseResultType::operator co_await());
     }
 }

--- a/public/tracy/TracyAsync.hpp
+++ b/public/tracy/TracyAsync.hpp
@@ -2,12 +2,6 @@
 
 #include "../client/TracyResult.hpp"
 
-#if DEBUG_TEMP
-#define ZoneAsyncC(color, fiber) \
-	static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction, TracyFile, (uint32_t)TracyLine, color }; \
-	tracy::AsyncScopedZone ___tracy_async_scoped_zone( &TracyConcat(__tracy_source_location, TracyLine), fiber );
-#else
-#define ZoneAsyncC(color, fiber) \
+#define ZoneAsyncC(color) \
 	static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction, TracyFile, (uint32_t)TracyLine, color }; \
 	tracy::AsyncScopedZone ___tracy_async_scoped_zone( &TracyConcat(__tracy_source_location, TracyLine) );
-#endif

--- a/public/tracy/TracyAsync.hpp
+++ b/public/tracy/TracyAsync.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../client/TracyResult.hpp"
+
+#if DEBUG_TEMP
+#define ZoneAsyncC(color, fiber) \
+	static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction, TracyFile, (uint32_t)TracyLine, color }; \
+	tracy::AsyncScopedZone ___tracy_async_scoped_zone( &TracyConcat(__tracy_source_location, TracyLine), fiber );
+#else
+#define ZoneAsyncC(color, fiber) \
+	static constexpr tracy::SourceLocationData TracyConcat(__tracy_source_location,TracyLine) { nullptr, TracyFunction, TracyFile, (uint32_t)TracyLine, color }; \
+	tracy::AsyncScopedZone ___tracy_async_scoped_zone( &TracyConcat(__tracy_source_location, TracyLine) );
+#endif


### PR DESCRIPTION
Hi!
I haven't seen coroutine support in any profiler so far, however it would be an incredibly handy feature. Now to profile coroutines I have to use zone macros only for synchronous sections. I created wrappers for awaitable objects in which I overloaded `await_suspend`, `await_resume` and `operator co_await`, and spesial macro for async zone.

Here is a brief example of what it looks like:
```cpp
tracy::Result<concurrencpp::result<void>> LoadChunk()
{
    ZoneAsyncC(tracy::Color::Azure);

    co_await tracy::Awaitable(concurrencpp::resume_on(g_pThreadPoolExecutor));
    co_await PrepareChunk();

    SimulateWork(50, 250);

    co_await LoadChunkResources();

    {
        ZoneScopedN("Sync work");
        SimulateWork(50, 250);
    }

    co_await ProceedChunkResources();
    SimulateWork(50, 250);
}
```

The limitations are:
* awaitable and result (aka task) classes must have move constructor
* user must always use tracy wrappers
* zone macro must be at the very beginning of a coroutine

Here's what it looks like at the moment. I added messages for the first "fiber" to make it easier to track.
![image](https://github.com/wolfpld/tracy/assets/30406125/c264f7dc-cd3c-46c0-b020-4a72e8a04de5)
![image](https://github.com/wolfpld/tracy/assets/30406125/70f6d55c-0b81-4870-a42e-26437caf3001)

I used concurrencpp for this example, but I had to modify it and make its move constructors available. You can see the example in this project:
https://mega.nz/file/h9liTSgJ#-93vlP01T77oE7cKOG35VqnspuW7c3bay-u37YwgxhY

What I would like to add on the tracy side to support this feature:
* "CPU data"-like lines between those scopes would be really helpful
* Special `QueueType` for async zones
* Inner "scopes" have same name. I wasn't able to fix it without macros, because co_await operator can't have any arguments, even if it's `std::source_location`. However, something like CO_AWAIT(...) should help

I was also unable to fix one bug that I believe is on the tracy side. There is a lot of logging in the code now, which I had planned to turn off before opening the request. However, after removing it, the code started crashing somewhere inside tracy. After some research it turned out that the TracyAsyncEvents.hpp::84 and TracyAsyncEvents.hpp::97 zones are to blame. Since there are no state changes there, I assume that something does not have time to happen inside tracy. I request you to help me with this problem as I don't have enough knowledge in this library.
