### PR TITLE
adapt libbacktrace to musl

### DIFF
--- a/public/libbacktrace/config.h
+++ b/public/libbacktrace/config.h
@@ -1,4 +1,8 @@
 #include <limits.h>
+#if defined(__linux__) && !defined(__GLIBC__) && !defined(__WORDSIZE)
+// include __WORDSIZE headers for musl
+#  include <bits/reg.h>
+#endif
 #if __WORDSIZE == 64
 #  define BACKTRACE_ELF_SIZE 64
 #else


### PR DESCRIPTION
__WORDSIZE is not defined on MUSL by including limits.h only