### PR TITLE
Fix and test TRACY_DEMANGLE for TracyClient

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -42,3 +42,4 @@ jobs:
         make -j`nproc` -C test TRACYFLAGS=-DTRACY_ON_DEMAND
         make -j`nproc` -C test clean
         make -j`nproc` -C test TRACYFLAGS="-DTRACY_DELAYED_INIT -DTRACY_MANUAL_LIFETIME"
+        make           -C test -B ../public/TracyClient.o DEFINES='-DTRACY_DEMANGLE'

--- a/public/client/TracyCallstack.cpp
+++ b/public/client/TracyCallstack.cpp
@@ -686,7 +686,9 @@ void InitCallstackCritical()
 void InitCallstack()
 {
     cb_bts = backtrace_create_state( nullptr, 0, nullptr, nullptr );
+#ifndef TRACY_DEMANGLE
     ___tracy_init_demangle_buffer();
+#endif
 
 #ifdef __linux
     InitKernelSymbols();
@@ -761,7 +763,9 @@ debuginfod_client* GetDebuginfodClient()
 
 void EndCallstack()
 {
+#ifndef TRACY_DEMANGLE
     ___tracy_free_demangle_buffer();
+#endif
 #ifdef TRACY_DEBUGINFOD
     ClearDebugInfoVector( s_di_known );
     debuginfod_end( s_debuginfod );


### PR DESCRIPTION
The configuration wasn't tested and stopped compiling. This fixes it and adds a test to ensure it doesn't break again.