### PR TITLE
Fix two bugs

### DIFF
--- a/public/common/TracySystem.cpp
+++ b/public/common/TracySystem.cpp
@@ -219,7 +219,7 @@ TRACY_API const char* GetThreadName( uint32_t id )
         if( hnd != 0 )
         {
             PWSTR tmp;
-            if ( SUCCEEDED( _GetThreadDescription( hnd, &tmp ) ) )
+            if( SUCCEEDED( _GetThreadDescription( hnd, &tmp ) ) )
             {
                 auto ret = wcstombs( buf, tmp, 256 );
                 CloseHandle( hnd );

--- a/public/common/TracySystem.cpp
+++ b/public/common/TracySystem.cpp
@@ -213,24 +213,24 @@ TRACY_API const char* GetThreadName( uint32_t id )
 # else
    static auto _GetThreadDescription = (t_GetThreadDescription)GetProcAddress( GetModuleHandleA( "kernel32.dll" ), "GetThreadDescription" );
 # endif
-  if( _GetThreadDescription )
-  {
-      auto hnd = OpenThread( THREAD_QUERY_LIMITED_INFORMATION, FALSE, (DWORD)id );
-      if( hnd != 0 )
-      {
-          PWSTR tmp;
-          if ( SUCCEEDED( _GetThreadDescription( hnd, &tmp ) ) )
-          {
-            auto ret = wcstombs( buf, tmp, 256 );
-            CloseHandle( hnd );
-            LocalFree( tmp );
-            if( ret != static_cast<std::size_t>(-1) )
+    if( _GetThreadDescription )
+    {
+        auto hnd = OpenThread( THREAD_QUERY_LIMITED_INFORMATION, FALSE, (DWORD)id );
+        if( hnd != 0 )
+        {
+            PWSTR tmp;
+            if ( SUCCEEDED( _GetThreadDescription( hnd, &tmp ) ) )
             {
-                return buf;
+                auto ret = wcstombs( buf, tmp, 256 );
+                CloseHandle( hnd );
+                LocalFree( tmp );
+                if( ret != static_cast<std::size_t>( -1 ) )
+                {
+                    return buf;
+                }
             }
-          }
-      }
-  }
+        }
+    }
 #elif defined __linux__
   int cs, fd;
   char path[32];

--- a/public/common/TracySystem.cpp
+++ b/public/common/TracySystem.cpp
@@ -219,12 +219,15 @@ TRACY_API const char* GetThreadName( uint32_t id )
       if( hnd != 0 )
       {
           PWSTR tmp;
-          _GetThreadDescription( hnd, &tmp );
-          auto ret = wcstombs( buf, tmp, 256 );
-          CloseHandle( hnd );
-          if( ret != static_cast<std::size_t>(-1) )
+          if ( SUCCEEDED( _GetThreadDescription( hnd, &tmp ) ) )
           {
-              return buf;
+            auto ret = wcstombs( buf, tmp, 256 );
+            CloseHandle( hnd );
+            LocalFree( tmp );
+            if( ret != static_cast<std::size_t>(-1) )
+            {
+                return buf;
+            }
           }
       }
   }

--- a/public/common/TracySystem.cpp
+++ b/public/common/TracySystem.cpp
@@ -222,7 +222,7 @@ TRACY_API const char* GetThreadName( uint32_t id )
           _GetThreadDescription( hnd, &tmp );
           auto ret = wcstombs( buf, tmp, 256 );
           CloseHandle( hnd );
-          if( ret != 0 )
+          if( ret != static_cast<std::size_t>(-1) )
           {
               return buf;
           }


### PR DESCRIPTION
- wcstombs return (size_t)-1 to indicate error.  [reference](https://[cplusplus.com/reference/cstdlib/wcstombs/](https://cplusplus.com/reference/cstdlib/wcstombs/))
- To free the memory for the thread description, call the [LocalFree](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-localfree) method. [reference](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreaddescription)