### PR TITLE
wayland: Fix use of xdg-decoration protocol

### DIFF
--- a/profiler/src/BackendWayland.cpp
+++ b/profiler/src/BackendWayland.cpp
@@ -537,12 +537,6 @@ static void RegistryGlobal( void*, struct wl_registry* reg, uint32_t name, const
     {
         s_decoration = (zxdg_decoration_manager_v1*)wl_registry_bind( reg, name, &zxdg_decoration_manager_v1_interface, 1 );
     }
-    else if( strcmp( interface, zxdg_toplevel_decoration_v1_interface.name ) == 0 )
-    {
-        s_tldec = (zxdg_toplevel_decoration_v1*)wl_registry_bind( reg, name, &zxdg_toplevel_decoration_v1_interface, 1 );
-        zxdg_toplevel_decoration_v1_add_listener( s_tldec, &decorationListener, nullptr );
-        zxdg_toplevel_decoration_v1_set_mode( s_tldec, ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE );
-    }
 }
 
 static void RegistryGlobalRemove( void*, struct wl_registry* reg, uint32_t name )
@@ -703,7 +697,9 @@ Backend::Backend( const char* title, const std::function<void()>& redraw, RunQue
 
     if( s_decoration )
     {
-        zxdg_decoration_manager_v1_get_toplevel_decoration( s_decoration, s_toplevel );
+        s_tldec = zxdg_decoration_manager_v1_get_toplevel_decoration( s_decoration, s_toplevel );
+        zxdg_toplevel_decoration_v1_add_listener( s_tldec, &decorationListener, nullptr );
+        zxdg_toplevel_decoration_v1_set_mode( s_tldec, ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE );
         wl_display_roundtrip( s_dpy );
     }
 


### PR DESCRIPTION
`zxdg_toplevel_decoration_v1` isn't a global, so the code handling it as one wasn't doing anything. Instead,
`zxdg_decoration_manager_v1_get_toplevel_decoration` returns it.

This fixes the behavior for compositors that support server-side decoration, but do not default to it until explicitly requested by the client.