### PR TITLE
Defer GPU context creation from the C API

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4258,6 +4258,11 @@ TRACY_API void ___tracy_emit_gpu_new_context( ___tracy_gpu_new_context_data data
     tracy::MemWrite( &item->gpuNewContext.context, data.context );
     tracy::MemWrite( &item->gpuNewContext.flags, data.flags );
     tracy::MemWrite( &item->gpuNewContext.type, data.type );
+
+#ifdef TRACY_ON_DEMAND
+    tracy::GetProfiler().DeferItem( *item );
+#endif
+
     TracyLfqCommitC;
 }
 
@@ -4270,6 +4275,11 @@ TRACY_API void ___tracy_emit_gpu_context_name( const struct ___tracy_gpu_context
     tracy::MemWrite( &item->gpuContextNameFat.context, data.context );
     tracy::MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)ptr );
     tracy::MemWrite( &item->gpuContextNameFat.size, data.len );
+
+#ifdef TRACY_ON_DEMAND
+    tracy::GetProfiler().DeferItem( *item );
+#endif
+
     TracyLfqCommitC;
 }
 


### PR DESCRIPTION
Same as how the C++ API does it. Otherwise with on demand mode the profiler never receives the GPU context info.

This makes things not crash, but there seems to be a different issue where GPU zones always start close to timestamp 0, rather than after the on-demand connection.

![image](https://github.com/wolfpld/tracy/assets/1794388/9f000902-7ba7-4959-ada0-c41f7a829ea4)

And if I connect again later, the GPU zones will still appear at the very beginning.

I'm not sure after glancing through the code what is at fault here. Moreover, even without on-demand, the GPU zones appear earlier than they should, so there might be two separate issues at play. Some of them are also overlapping weirdly. I am on AMD RX 6700M on Linux 6.5.6 and using OpenGL timestamp queries.