### PR TITLE
Add basic QNX support

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -373,6 +373,7 @@ Tracy Profiler supports  MSVC, GCC, and clang. You will need to use a reasonably
 \item WSL (x64)
 \item OSX (x64)
 \item iOS (ARM, ARM64)
+\item QNX (x64)
 \end{itemize}
 
 Moreover, the following platforms are not supported due to how secretive their owners are but were reported to be working after extending the system integration layer:
@@ -864,26 +865,26 @@ Some features of the profiler are only available on selected platforms. Please r
 
 \begin{table}[h]
 \centering
-\begin{tabular}[h]{c|c|c|c|c|c|c}
-\textbf{Feature} & \textbf{Windows} & \textbf{Linux} & \textbf{Android} & \textbf{OSX} & \textbf{iOS} & \textbf{BSD} \\ \hline
-Profiling program init & \faCheck & \faCheck & \faCheck & \faPoo & \faPoo & \faCheck \\
-CPU zones & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
-Locks & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
-Plots & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
-Messages & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
-Memory & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
-GPU zones (OpenGL) & \faCheck & \faCheck & \faCheck & \faPoo & \faPoo & \\
-GPU zones (Vulkan) & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \\
-Call stacks & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
-Symbol resolution & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
-Crash handling & \faCheck & \faCheck & \faCheck & \faTimes & \faTimes & \faTimes \\
-CPU usage probing & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
-Context switches & \faCheck & \faCheck & \faCheck & \faTimes & \faPoo & \faTimes \\
-Wait stacks & \faCheck & \faCheck & \faCheck & \faTimes & \faPoo & \faTimes \\
-CPU topology information & \faCheck & \faCheck & \faCheck & \faTimes & \faTimes & \faTimes \\
-Call stack sampling & \faCheck & \faCheck & \faCheck & \faTimes & \faPoo & \faTimes \\
-Hardware sampling & \faCheck{}\textsuperscript{\emph{a}} & \faCheck & \faCheck & \faTimes & \faPoo & \faTimes \\
-VSync capture & \faCheck & \faCheck & \faTimes & \faTimes & \faTimes & \faTimes \\
+\begin{tabular}[h]{c|c|c|c|c|c|c|c}
+\textbf{Feature} & \textbf{Windows} & \textbf{Linux} & \textbf{Android} & \textbf{OSX} & \textbf{iOS} & \textbf{BSD} & \textbf{QNX} \\ \hline
+Profiling program init & \faCheck & \faCheck & \faCheck & \faPoo & \faPoo & \faCheck & \faCheck \\
+CPU zones & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
+Locks & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
+Plots & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
+Messages & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
+Memory & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faTimes \\
+GPU zones (OpenGL) & \faCheck & \faCheck & \faCheck & \faPoo & \faPoo & \faTimes & \faTimes \\
+GPU zones (Vulkan) & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faTimes & \faTimes \\
+Call stacks & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faTimes \\
+Symbol resolution & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
+Crash handling & \faCheck & \faCheck & \faCheck & \faTimes & \faTimes & \faTimes & \faTimes \\
+CPU usage probing & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faTimes \\
+Context switches & \faCheck & \faCheck & \faCheck & \faTimes & \faPoo & \faTimes & \faTimes \\
+Wait stacks & \faCheck & \faCheck & \faCheck & \faTimes & \faPoo & \faTimes & \faTimes \\
+CPU topology information & \faCheck & \faCheck & \faCheck & \faTimes & \faTimes & \faTimes & \faTimes \\
+Call stack sampling & \faCheck & \faCheck & \faCheck & \faTimes & \faPoo & \faTimes & \faTimes \\
+Hardware sampling & \faCheck{}\textsuperscript{\emph{a}} & \faCheck & \faCheck & \faTimes & \faPoo & \faTimes & \faTimes \\
+VSync capture & \faCheck & \faCheck & \faTimes & \faTimes & \faTimes & \faTimes & \faTimes \\
 \end{tabular}
 
 \vspace{1em}

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -873,8 +873,9 @@ Locks & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faChe
 Plots & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
 Messages & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
 Memory & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faTimes \\
-GPU zones (OpenGL) & \faCheck & \faCheck & \faCheck & \faPoo & \faPoo & \faTimes & \faTimes \\
-GPU zones (Vulkan) & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faTimes & \faTimes \\
+% GPU zones fields intentionally left blank for BSDs
+GPU zones (OpenGL) & \faCheck & \faCheck & \faCheck & \faPoo & \faPoo & & \faTimes \\
+GPU zones (Vulkan) & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & & \faTimes \\
 Call stacks & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faTimes \\
 Symbol resolution & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck & \faCheck \\
 Crash handling & \faCheck & \faCheck & \faCheck & \faTimes & \faTimes & \faTimes & \faTimes \\

--- a/profiler/src/HttpRequest.cpp
+++ b/profiler/src/HttpRequest.cpp
@@ -66,6 +66,8 @@ static const char* GetOsInfo()
     sprintf( buf, "BSD (NetBSD)" );
 #elif defined __OpenBSD__
     sprintf( buf, "BSD (OpenBSD)" );
+#elif defined __QNX__
+    sprintf( buf, "QNX" );
 #else
     sprintf( buf, "unknown" );
 #endif

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1713,9 +1713,9 @@ void Profiler::Worker()
 #  ifdef TRACY_ONLY_LOCALHOST
     const char* addr = "127.255.255.255";
 #  elif defined __QNX__
-    // global broadcast address of 255.255.255.255 is not well-supported by QNX,
-    // use the interface broadcast address instead, e.g. "const char* addr = 192.168.1.255;"
-#error Need to set an appropriate broadcast address for a QNX target.
+     // global broadcast address of 255.255.255.255 is not well-supported by QNX,
+     // use the interface broadcast address instead, e.g. "const char* addr = 192.168.1.255;"
+#    error Need to set an appropriate broadcast address for a QNX target.
 #  else
     const char* addr = "255.255.255.255";
 #  endif


### PR DESCRIPTION
This adds a basic level of support for QNX, i.e. only the instrumentation/annotation-based profiling features. Most other features haven't been tested. I've successful used this on QNX 7.0, but I think it should work for QNX 6+ at least.