### PR TITLE
Add TracyIsStarted

### DIFF
--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -51,6 +51,10 @@ namespace tracy
 #if defined(TRACY_DELAYED_INIT) && defined(TRACY_MANUAL_LIFETIME)
 TRACY_API void StartupProfiler();
 TRACY_API void ShutdownProfiler();
+TRACY_API bool IsProfilerStarted();
+#  define TracyIsStarted tracy::IsProfilerStarted()
+#else
+#  define TracyIsStarted true
 #endif
 
 class GpuCtx;

--- a/public/tracy/Tracy.hpp
+++ b/public/tracy/Tracy.hpp
@@ -109,6 +109,7 @@
 #define TracyParameterRegister(x,y)
 #define TracyParameterSetup(x,y,z,w)
 #define TracyIsConnected false
+#define TracyIsStarted false
 #define TracySetProgramName(x)
 
 #define TracyFiberEnter(x)

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -97,6 +97,7 @@ typedef const void* TracyCZoneCtx;
 #define TracyCMessageLCS(x,y,z)
 
 #define TracyCIsConnected 0
+#define TracyCIsStarted 0
 
 #ifdef TRACY_FIBERS
 #  define TracyCFiberEnter(fiber)
@@ -185,6 +186,11 @@ typedef /*const*/ struct ___tracy_c_zone_context TracyCZoneCtx;
 #ifdef TRACY_MANUAL_LIFETIME
 TRACY_API void ___tracy_startup_profiler(void);
 TRACY_API void ___tracy_shutdown_profiler(void);
+TRACY_API int ___tracy_profiler_started(void);
+
+#  define TracyCIsStarted ___tracy_profiler_started()
+#else
+#  define TracyCIsStarted 1
 #endif
 
 TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz );


### PR DESCRIPTION
When using TRACY_MANUAL_LIFETIME, calling most Tracy functions before starting the profiler results in an assertion. Notably, even TracyIsConnected is affected. There is, however, no function to check if the profiler had already started. This PR adds such a function.

Related: #637. This PR doesn't add any automatic checks, just allows application code to do them manually.