### PR TITLE
Update meson_options.txt to allow overriding of tracy_enable

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('tracy_enable', type : 'boolean', value : true, description : 'Enable profiling')
+option('tracy_enable', type : 'boolean', value : true, description : 'Enable profiling', yield: true)
 option('tracy_on_demand', type : 'boolean', value : false, description : 'On-demand profiling')
 option('tracy_callstack', type : 'boolean', value : false, description : 'Enfore callstack collection for tracy regions')
 option('tracy_no_callstack', type : 'boolean', value : false, description : 'Disable all callstack related functionality')


### PR DESCRIPTION
This allows superprojects to override the tracy_enable option. This solves a problem where toggling tracy_enable only does so in the subproject itself, adding TRACY_ENABLE definition to just the client library. Including the header in the superproject we can't use the macros as TRACY_ENABLE isn't defined.

This change allows superprojects to create a tracy_enable option that can control the subprojects option (of the same name), that way we can enable/disable profiling for everything at once, and the superproject can add the TRACY_ENABLE define itself