### PR TITLE
respect mesons default_library option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,8 +95,8 @@ if get_option('tracy_no_crash_handler')
 endif
 
 tracy_shared_libs = get_option('default_library') == 'shared'
-if tracy_shared_libs and not get_option('tracy_shared_libs')
-  warning('tracy_shared_libs is set to false, but default_library is set to shared. Building shared library.')
+if not tracy_shared_libs and get_option('tracy_shared_libs')
+  warning('tracy_shared_libs is set to true, but default_library is set to static. Building static library.')
 endif
 
 if tracy_shared_libs

--- a/meson.build
+++ b/meson.build
@@ -1,106 +1,108 @@
-project('tracy', ['cpp'], version: '0.10.0')
+project('tracy', ['cpp'], version: '0.10.0', meson_version: '>=0.60.0')
 
+# internal compiler flags
 tracy_compile_args = []
 
+# compiler flags shared between client and server
+tracy_common_args = []
+
 if get_option('tracy_enable')
-  tracy_compile_args += ['-DTRACY_ENABLE']
+  tracy_common_args += ['-DTRACY_ENABLE']
 endif
 
 if get_option('tracy_on_demand')
-  tracy_compile_args += ['-DTRACY_ON_DEMAND']
+  tracy_common_args += ['-DTRACY_ON_DEMAND']
 endif
 
 if get_option('tracy_callstack')
-  tracy_compile_args += ['-DTRACY_CALLSTACK']
+  tracy_common_args += ['-DTRACY_CALLSTACK']
 endif
 
 if get_option('tracy_no_callstack')
-  tracy_compile_args += ['-DTRACY_NO_CALLSTACK']
+  tracy_common_args += ['-DTRACY_NO_CALLSTACK']
 endif
 
 if get_option('tracy_no_callstack_inlines')
-  tracy_compile_args += ['-DTRACY_NO_CALLSTACK_INLINES']
+  tracy_common_args += ['-DTRACY_NO_CALLSTACK_INLINES']
 endif
 
 if get_option('tracy_only_localhost')
-  tracy_compile_args += ['-DTRACY_ONLY_LOCALHOST']
+  tracy_common_args += ['-DTRACY_ONLY_LOCALHOST']
 endif
 
 if get_option('tracy_no_broadcast')
-  tracy_compile_args += ['-DTRACY_NO_BROADCAST']
+  tracy_common_args += ['-DTRACY_NO_BROADCAST']
 endif
 
 if get_option('tracy_only_ipv4')
-  tracy_compile_args += ['-DTRACY_ONLY_IPV4']
+  tracy_common_args += ['-DTRACY_ONLY_IPV4']
 endif
 
 if get_option('tracy_no_code_transfer')
-  tracy_compile_args += ['-DTRACY_NO_CODE_TRANSFER']
+  tracy_common_args += ['-DTRACY_NO_CODE_TRANSFER']
 endif
 
 if get_option('tracy_no_context_switch')
-  tracy_compile_args += ['-DTRACY_NO_CONTEXT_SWITCH']
+  tracy_common_args += ['-DTRACY_NO_CONTEXT_SWITCH']
 endif
 
 if get_option('tracy_no_exit')
-  tracy_compile_args += ['-DTRACY_NO_EXIT']
+  tracy_common_args += ['-DTRACY_NO_EXIT']
 endif
 
 if get_option('tracy_no_sampling')
-  tracy_compile_args += ['-DTRACY_NO_SAMPLING']
+  tracy_common_args += ['-DTRACY_NO_SAMPLING']
 endif
 
 if get_option('tracy_no_verify')
-  tracy_compile_args += ['-DTRACY_NO_VERIFY']
+  tracy_common_args += ['-DTRACY_NO_VERIFY']
 endif
 
 if get_option('tracy_no_vsync_capture')
-  tracy_compile_args += ['-DTRACY_NO_VSYNC_CAPTURE']
+  tracy_common_args += ['-DTRACY_NO_VSYNC_CAPTURE']
 endif
 
 if get_option('tracy_no_frame_image')
-  tracy_compile_args += ['-DTRACY_NO_FRAME_IMAGE']
+  tracy_common_args += ['-DTRACY_NO_FRAME_IMAGE']
 endif
 
 if get_option('tracy_no_system_tracing')
-  tracy_compile_args += ['-DTRACY_NO_SYSTEM_TRACING']
+  tracy_common_args += ['-DTRACY_NO_SYSTEM_TRACING']
 endif
 
 if get_option('tracy_patchable_nopsleds')
-  tracy_compile_args += ['-DTRACY_PATCHABLE_NOPSLEDS']
+  tracy_common_args += ['-DTRACY_PATCHABLE_NOPSLEDS']
 endif
 
 if get_option('tracy_delayed_init')
-  tracy_compile_args += ['-DTRACY_DELAYED_INIT']
+  tracy_common_args += ['-DTRACY_DELAYED_INIT']
 endif
 
 if get_option('tracy_manual_lifetime')
-  tracy_compile_args += ['-DTRACY_MANUAL_LIFETIME']
+  tracy_common_args += ['-DTRACY_MANUAL_LIFETIME']
 endif
 
 if get_option('tracy_fibers')
-  tracy_compile_args += ['-DTRACY_FIBERS']
+  tracy_common_args += ['-DTRACY_FIBERS']
 endif
 
 if get_option('tracy_timer_fallback')
-  tracy_compile_args += ['-DTRACY_TIMER_FALLBACK']
-endif
-
-tracy_shared_libs = get_option('tracy_shared_libs')
-if tracy_shared_libs
-  add_project_arguments('-DTRACY_EXPORTS', language : 'cpp')
+  tracy_common_args += ['-DTRACY_TIMER_FALLBACK']
 endif
 
 if get_option('tracy_no_crash_handler')
-  tracy_compile_args += ['-DTRACY_NO_CRASH_HANDLER']
+  tracy_common_args += ['-DTRACY_NO_CRASH_HANDLER']
 endif
 
-add_project_arguments(tracy_compile_args, language : 'cpp')
+tracy_shared_libs = get_option('default_library') == 'shared' or get_option('tracy_shared_libs')
+if tracy_shared_libs
+  tracy_compile_args += ['-DTRACY_EXPORTS']
+endif
 
 threads_dep = dependency('threads')
 
 if host_machine.system() == 'windows'
-  add_project_arguments('-DWINVER=0x0601', '-D_WIN32_WINNT=0x0601',  language: 'cpp')
+  tracy_compile_args += ['-DWINVER=0x0601', '-D_WIN32_WINNT=0x0601']
 endif
 
 includes = [
@@ -167,25 +169,20 @@ if compiler.get_id() != 'msvc'
   override_options += 'cpp_std=c++11'
 endif
 
-if tracy_shared_libs
-  tracy = shared_library('tracy', tracy_src, tracy_header_files,
+tracy_compile_args += tracy_common_args
+
+tracy = library('tracy', tracy_src, tracy_header_files,
     dependencies        : [ threads_dep ],
     include_directories : tracy_public_include_dirs,
+    cpp_args            : tracy_compile_args,
     override_options    : override_options,
     install             : true)
-else
-  tracy = static_library('tracy', tracy_src, tracy_header_files,
-    dependencies        : [ threads_dep ],
-    include_directories : tracy_public_include_dirs,
-    override_options    : override_options,
-    install             : true)
-endif
 
 install_headers(includes, subdir : 'tracy')
 install_headers(common_includes, subdir : 'common')
 install_headers(client_includes, subdir : 'client')
 
-tracy_dep_compile_args = tracy_compile_args
+tracy_dep_compile_args = tracy_common_args
 
 if tracy_shared_libs
   tracy_dep_compile_args += [ '-DTRACY_IMPORTS' ]

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('tracy', ['cpp'], version: '0.10.0', meson_version: '>=0.60.0')
+project('tracy', ['cpp'], version: '0.10.0', meson_version: '>=0.54.0')
 
 # internal compiler flags
 tracy_compile_args = []

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('tracy', ['cpp'], version: '0.10.0', meson_version: '>=0.54.0')
+project('tracy', ['cpp'], version: '0.10.0', meson_version: '>=0.63.0')
 
 # internal compiler flags
 tracy_compile_args = []
@@ -94,7 +94,11 @@ if get_option('tracy_no_crash_handler')
   tracy_common_args += ['-DTRACY_NO_CRASH_HANDLER']
 endif
 
-tracy_shared_libs = get_option('default_library') == 'shared' or get_option('tracy_shared_libs')
+tracy_shared_libs = get_option('default_library') == 'shared'
+if tracy_shared_libs and not get_option('tracy_shared_libs')
+  warning('tracy_shared_libs is set to false, but default_library is set to shared. Building shared library.')
+endif
+
 if tracy_shared_libs
   tracy_compile_args += ['-DTRACY_EXPORTS']
 endif

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('tracy', ['cpp'], version: '0.10.0', meson_version: '>=0.54.0')
 # internal compiler flags
 tracy_compile_args = []
 
-# compiler flags shared between client and server
+# compiler flags shared between the capture library itself and the code using it
 tracy_common_args = []
 
 if get_option('tracy_enable')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,5 +19,5 @@ option('tracy_timer_fallback', type : 'boolean', value : false, description : 'U
 option('tracy_delayed_init', type : 'boolean', value : false, description : 'Enable delayed initialization of the library (init on first call)')
 option('tracy_manual_lifetime', type : 'boolean', value : false, description : 'Enable the manual lifetime management of the profile')
 option('tracy_fibers', type : 'boolean', value : false, description : 'Enable fibers support')
-option('tracy_shared_libs', type : 'boolean', value : false, description : 'Builds Tracy as a shared object', deprecated : 'default_library')
+option('tracy_shared_libs', type : 'boolean', value : false, description : 'Builds Tracy as a shared object (deprecated in favour of default_library=shared)', deprecated : true)
 option('tracy_no_crash_handler', type : 'boolean', value : false, description : 'Disable crash handling')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,5 +19,5 @@ option('tracy_timer_fallback', type : 'boolean', value : false, description : 'U
 option('tracy_delayed_init', type : 'boolean', value : false, description : 'Enable delayed initialization of the library (init on first call)')
 option('tracy_manual_lifetime', type : 'boolean', value : false, description : 'Enable the manual lifetime management of the profile')
 option('tracy_fibers', type : 'boolean', value : false, description : 'Enable fibers support')
-option('tracy_shared_libs', type : 'boolean', value : false, description : 'Builds Tracy as a shared object (deprecated: please specify default_library=shared)', deprecated : true)
+option('tracy_shared_libs', type : 'boolean', value : false, description : 'Builds Tracy as a shared object')
 option('tracy_no_crash_handler', type : 'boolean', value : false, description : 'Disable crash handling')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,5 +19,5 @@ option('tracy_timer_fallback', type : 'boolean', value : false, description : 'U
 option('tracy_delayed_init', type : 'boolean', value : false, description : 'Enable delayed initialization of the library (init on first call)')
 option('tracy_manual_lifetime', type : 'boolean', value : false, description : 'Enable the manual lifetime management of the profile')
 option('tracy_fibers', type : 'boolean', value : false, description : 'Enable fibers support')
-option('tracy_shared_libs', type : 'boolean', value : false, description : 'Builds Tracy as a shared object', deprecated : 'use default_library=shared instead')
+option('tracy_shared_libs', type : 'boolean', value : false, description : 'Builds Tracy as a shared object', deprecated : 'default_library')
 option('tracy_no_crash_handler', type : 'boolean', value : false, description : 'Disable crash handling')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,5 +19,5 @@ option('tracy_timer_fallback', type : 'boolean', value : false, description : 'U
 option('tracy_delayed_init', type : 'boolean', value : false, description : 'Enable delayed initialization of the library (init on first call)')
 option('tracy_manual_lifetime', type : 'boolean', value : false, description : 'Enable the manual lifetime management of the profile')
 option('tracy_fibers', type : 'boolean', value : false, description : 'Enable fibers support')
-option('tracy_shared_libs', type : 'boolean', value : false, description : 'Builds Tracy as a shared object')
+option('tracy_shared_libs', type : 'boolean', value : false, description : 'Builds Tracy as a shared object (deprecated: please specify default_library=shared)', deprecated : true)
 option('tracy_no_crash_handler', type : 'boolean', value : false, description : 'Disable crash handling')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,5 +19,5 @@ option('tracy_timer_fallback', type : 'boolean', value : false, description : 'U
 option('tracy_delayed_init', type : 'boolean', value : false, description : 'Enable delayed initialization of the library (init on first call)')
 option('tracy_manual_lifetime', type : 'boolean', value : false, description : 'Enable the manual lifetime management of the profile')
 option('tracy_fibers', type : 'boolean', value : false, description : 'Enable fibers support')
-option('tracy_shared_libs', type : 'boolean', value : false, description : 'Builds Tracy as a shared object')
+option('tracy_shared_libs', type : 'boolean', value : false, description : 'Builds Tracy as a shared object', deprecated : 'use default_library=shared instead')
 option('tracy_no_crash_handler', type : 'boolean', value : false, description : 'Disable crash handling')


### PR DESCRIPTION
Meson provides a build flag called `default_library` which is the standard way to specify the type of library to build. I left `tracy_shared_libs` in to prevent a breaking change.