### PR TITLE
Prefer internal imgui

### DIFF
--- a/profiler/build/unix/build.mk
+++ b/profiler/build/unix/build.mk
@@ -1,7 +1,7 @@
 CFLAGS +=
 CXXFLAGS := $(CFLAGS) -std=c++17
 DEFINES += -DIMGUI_ENABLE_FREETYPE
-INCLUDES := $(shell pkg-config --cflags freetype2 capstone wayland-egl egl wayland-cursor xkbcommon) -I../../../imgui
+INCLUDES := -I../../../imgui $(shell pkg-config --cflags freetype2 capstone wayland-egl egl wayland-cursor xkbcommon)
 LIBS := $(shell pkg-config --libs freetype2 capstone wayland-egl egl wayland-cursor xkbcommon) -lpthread -ldl
 
 PROJECT := Tracy

--- a/profiler/build/unix/legacy.mk
+++ b/profiler/build/unix/legacy.mk
@@ -1,7 +1,7 @@
 CFLAGS +=
 CXXFLAGS := $(CFLAGS) -std=c++17
 DEFINES += -DIMGUI_ENABLE_FREETYPE
-INCLUDES := $(shell pkg-config --cflags glfw3 freetype2 capstone) -I../../../imgui
+INCLUDES := -I../../../imgui $(shell pkg-config --cflags glfw3 freetype2 capstone)
 LIBS := $(shell pkg-config --libs glfw3 freetype2 capstone) -lpthread -ldl
 
 PROJECT := Tracy


### PR DESCRIPTION
This PR sets the imgui include path before to pkg-config include paths to give the internal imgui include directory a higher priority. In cases imgui is installed system wide may the wrong headers are included otherwise. This may happen when using vcpkg to install dependencies and also imgui is installed with vcpkg.