### PR TITLE
Don't error on frame end without start

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -5077,13 +5077,12 @@ void Worker::ProcessFrameMarkEnd( const QueueFrameMark& ev )
     } );
 
     assert( fd->continuous == 0 );
-    const auto time = TscTime( ev.time );
     if( fd->frames.empty() )
     {
-        if ( !m_ignoreFrameEndFaults )
-            FrameEndFailure();
+        if( !m_ignoreFrameEndFaults ) FrameEndFailure();
         return;
     }
+    const auto time = TscTime( ev.time );
     assert( fd->frames.back().end == -1 );
     fd->frames.back().end = time;
     if( m_data.lastTime < time ) m_data.lastTime = time;

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -2756,6 +2756,7 @@ void Worker::Exec()
         m_captureTime = welcome.epoch;
         m_executableTime = welcome.exectime;
         m_ignoreMemFreeFaults = ( welcome.flags & WelcomeFlag::OnDemand ) || ( welcome.flags & WelcomeFlag::IsApple );
+        m_ignoreFrameEndFaults = welcome.flags & WelcomeFlag::OnDemand;
         m_data.cpuArch = (CpuArchitecture)welcome.cpuArch;
         m_codeTransfer = welcome.flags & WelcomeFlag::CodeTransfer;
         m_combineSamples = welcome.flags & WelcomeFlag::CombineSamples;
@@ -5079,7 +5080,8 @@ void Worker::ProcessFrameMarkEnd( const QueueFrameMark& ev )
     const auto time = TscTime( ev.time );
     if( fd->frames.empty() )
     {
-        FrameEndFailure();
+        if ( !m_ignoreFrameEndFaults )
+            FrameEndFailure();
         return;
     }
     assert( fd->frames.back().end == -1 );

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -980,6 +980,7 @@ private:
     int m_bufferOffset;
     bool m_onDemand;
     bool m_ignoreMemFreeFaults;
+    bool m_ignoreFrameEndFaults;
     bool m_codeTransfer;
     bool m_combineSamples;
     bool m_identifySamples = false;


### PR DESCRIPTION
With on-demand profiling we're very likely to connect in the middle of a discontinuous frame and thus receive a frame end without any preceding frame start. So don't error out in this case.

This makes on-demand profiling usable with discontinuous frames.

If this is the right approach here, I can also remove the `FrameEnd` failure stuff altogether as it seems otherwise unused.