### PR TITLE
(Do not submit) - draft for adapting to capstone arm64 renaming

### DIFF
--- a/server/TracySourceView.cpp
+++ b/server/TracySourceView.cpp
@@ -711,7 +711,7 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
         rval = cs_open( CS_ARCH_ARM, CS_MODE_ARM, &handle );
         break;
     case CpuArchArm64:
-        rval = cs_open( CS_ARCH_ARM64, CS_MODE_ARM, &handle );
+        rval = cs_open( CS_AARCH64pre(CS_ARCH_), CS_MODE_ARM, &handle );
         break;
     default:
         assert( false );
@@ -776,9 +776,9 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
                     }
                     break;
                 case CpuArchArm64:
-                    if( detail.arm64.op_count == 1 && detail.arm64.operands[0].type == ARM64_OP_IMM )
+                    if( detail.CS_aarch64().op_count == 1 && detail.CS_aarch64().operands[0].type == CS_AARCH64(_OP_IMM) )
                     {
-                        jumpAddr = (uint64_t)detail.arm64.operands[0].imm;
+                        jumpAddr = (uint64_t)detail.CS_aarch64().operands[0].imm;
                     }
                     break;
                 default:
@@ -863,18 +863,18 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
                 }
                 break;
             case CpuArchArm64:
-                for( uint8_t i=0; i<detail.arm64.op_count; i++ )
+                for( uint8_t i=0; i<detail.CS_aarch64().op_count; i++ )
                 {
                     uint8_t type = 0;
-                    switch( detail.arm64.operands[i].type )
+                    switch( detail.CS_aarch64().operands[i].type )
                     {
-                    case ARM64_OP_IMM:
+                    case CS_AARCH64(_OP_IMM):
                         type = 0;
                         break;
-                    case ARM64_OP_REG:
+                    case CS_AARCH64(_OP_REG):
                         type = 1;
                         break;
-                    case ARM64_OP_MEM:
+                    case CS_AARCH64(_OP_MEM):
                         type = 2;
                         break;
                     default:

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -3840,7 +3840,7 @@ void Worker::AddSymbolCode( uint64_t ptr, const char* data, size_t sz )
         rval = cs_open( CS_ARCH_ARM, CS_MODE_ARM, &handle );
         break;
     case CpuArchArm64:
-        rval = cs_open( CS_ARCH_ARM64, CS_MODE_ARM, &handle );
+        rval = cs_open( CS_AARCH64pre(CS_ARCH_), CS_MODE_ARM, &handle );
         break;
     default:
         assert( false );
@@ -3884,9 +3884,9 @@ void Worker::AddSymbolCode( uint64_t ptr, const char* data, size_t sz )
                         }
                         break;
                     case CpuArchArm64:
-                        if( detail.arm64.op_count == 1 && detail.arm64.operands[0].type == ARM64_OP_IMM )
+                        if( detail.CS_aarch64().op_count == 1 && detail.CS_aarch64().operands[0].type == CS_AARCH64(_OP_IMM) )
                         {
-                            callAddr = (uint64_t)detail.arm64.operands[0].imm;
+                            callAddr = (uint64_t)detail.CS_aarch64().operands[0].imm;
                         }
                         break;
                     default:


### PR DESCRIPTION
FYI @wolfpld: Capstone has just done a breaking renaming: ARM64 --> AArch64 (https://github.com/capstone-engine/capstone/pull/2026)

This PR is a good-enough local patch for anyone trying to build against latest Capstone. It uses Capstone's own provided compatibility macros to resolve to either the old or the new identifiers.

The problem which IIUC makes this PR not good to merge is that by relying on these Capstone macros... it probably doesn't actually support older Capstone versions, which presumably don't have these macros.

You probably need to resolve that by forking these macros on the Tracy side...