### PR TITLE
Add tracy client address complile flag

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -503,7 +503,7 @@ The program name that is sent out in the broadcast messages can be customized by
 
 By default, the Tracy client will listen on all network interfaces. If you want to restrict it to only listening on the localhost interface, define the \texttt{TRACY\_ONLY\_LOCALHOST} macro at compile-time, or set the \texttt{TRACY\_ONLY\_LOCALHOST} environment variable to $1$ at runtime.
 
-If you need to use a specific Tracy client address, such as QNX requires, define the \texttt{TRACY\_CLIENT\_ADDRESS} macro at compile-time as the desired string address, or set the \texttt{TRACY\_ONLY\_LOCALHOST} environment variable to the desired string address at runtime.
+If you need to use a specific Tracy client address, such as QNX requires, define the \texttt{TRACY\_CLIENT\_ADDRESS} macro at compile-time as the desired string address.
 
 By default, the Tracy client will listen on IPv6 interfaces, falling back to IPv4 only if IPv6 is unavailable. If you want to restrict it to only listening on IPv4 interfaces, define the \texttt{TRACY\_ONLY\_IPV4} macro at compile-time, or set the \texttt{TRACY\_ONLY\_IPV4} environment variable to $1$ at runtime.
 

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -503,6 +503,8 @@ The program name that is sent out in the broadcast messages can be customized by
 
 By default, the Tracy client will listen on all network interfaces. If you want to restrict it to only listening on the localhost interface, define the \texttt{TRACY\_ONLY\_LOCALHOST} macro at compile-time, or set the \texttt{TRACY\_ONLY\_LOCALHOST} environment variable to $1$ at runtime.
 
+If you need to use a specific Tracy client address, such as QNX requires, define the \texttt{TRACY\_CLIENT\_ADDRESS} macro at compile-time as the desired string address, or set the \texttt{TRACY\_ONLY\_LOCALHOST} environment variable to the desired string address at runtime.
+
 By default, the Tracy client will listen on IPv6 interfaces, falling back to IPv4 only if IPv6 is unavailable. If you want to restrict it to only listening on IPv4 interfaces, define the \texttt{TRACY\_ONLY\_IPV4} macro at compile-time, or set the \texttt{TRACY\_ONLY\_IPV4} environment variable to $1$ at runtime.
 
 \subsubsection{Setup for multi-DLL projects}

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1731,6 +1731,8 @@ void Profiler::Worker()
     new(m_broadcast) UdpBroadcast();
 #  ifdef TRACY_ONLY_LOCALHOST
     const char* addr = "127.255.255.255";
+#  elif defined TRACY_CLIENT_ADDRESS
+    const char* addr = TRACY_CLIENT_ADDRESS;
 #  elif defined __QNX__
      // global broadcast address of 255.255.255.255 is not well-supported by QNX,
      // use the interface broadcast address instead, e.g. "const char* addr = 192.168.1.255;"

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1736,7 +1736,7 @@ void Profiler::Worker()
 #  elif defined __QNX__
      // global broadcast address of 255.255.255.255 is not well-supported by QNX,
      // use the interface broadcast address instead, e.g. "const char* addr = 192.168.1.255;"
-#    error Need to set an appropriate broadcast address for a QNX target.
+#    error Need to specify TRACY_CLIENT_ADDRESS for a QNX target.
 #  else
     const char* addr = "255.255.255.255";
 #  endif


### PR DESCRIPTION
Support passing tracy client address via compile flag. Adds convenience for compiling tracy on multiple targets that have different network requirements. (In this case using QNX so can't use the default 255.255.255.255 as @michaeldleslie helped point out). 

Can add documentation in the appropriate spot.