### PR TITLE
Moved methods into public scope and add GetQueryPool() method to enable use of the VkCtx directly rather than just from VkCtxScope

### DIFF
--- a/public/tracy/TracyVulkan.hpp
+++ b/public/tracy/TracyVulkan.hpp
@@ -323,7 +323,6 @@ public:
         m_tail += cnt;
     }
 
-private:
     tracy_force_inline unsigned int NextQueryId()
     {
         const uint64_t id = m_head.fetch_add(1, std::memory_order_relaxed);
@@ -334,6 +333,13 @@ private:
     {
         return m_context;
     }
+
+    tracy_force_inline VkQueryPool GetQueryPool() const
+    {
+         return m_query;
+    }
+
+private:
 
     tracy_force_inline void Calibrate( VkDevice device, int64_t& tCpu, int64_t& tGpu )
     {

--- a/public/tracy/TracyVulkan.hpp
+++ b/public/tracy/TracyVulkan.hpp
@@ -340,7 +340,6 @@ public:
     }
 
 private:
-
     tracy_force_inline void Calibrate( VkDevice device, int64_t& tCpu, int64_t& tGpu )
     {
         assert( m_timeDomain != VK_TIME_DOMAIN_DEVICE_EXT );


### PR DESCRIPTION
To support loosely coupled integration of the [VulkanSceneGraph](https://github.com/vsg-dev/VulkanSceneGraph) with Tracy I had to move the VkCtx::NextQueryId() and GetId() from private to public scope, and add a VkCtx::GetQueryPool().  This change makes it possible to use the VkCtx without going via VkCtxScope and associated macros.

If these changes are deemed suitable and are merged then I can tell the VulkanSceneGraph community to just use tracy master rather than my fork's [VkCtx_public_methods](https://github.com/robertosfield/tracy/tree/VkCtx_public_methods) branch.