### PR TITLE
Added relwithdebug build target for unix build of profiler

### DIFF
--- a/profiler/build/unix/Makefile
+++ b/profiler/build/unix/Makefile
@@ -10,6 +10,9 @@ debug:
 release:
 	@$(MAKE) -f release.mk all
 
+relwithdebug:
+	@$(MAKE) -f relwithdebug.mk all
+
 clean:
 	@$(MAKE) -f build.mk clean
 

--- a/profiler/build/unix/relwithdebug.mk
+++ b/profiler/build/unix/relwithdebug.mk
@@ -1,0 +1,14 @@
+CFLAGS := -O3 -g
+ifndef TRACY_NO_LTO
+CFLAGS += -flto
+endif
+DEFINES := -DNDEBUG
+BUILD := release-with-debug
+
+include ../../../common/unix-debug.mk
+
+ifeq ($(LEGACY),1)
+    include legacy.mk
+else
+    include build.mk
+endif


### PR DESCRIPTION
When investigating a crash in Tracy profiler when that was being triggered by my early attempts at VulkaSceneGraph/Tracy integration I found it helpful to have a release with debug info unix build.  

I've resolved these teething problems in the VulkanSceneGraph/Tracy integration so Tracy profiler is now running robustly even with large paged database where multi-threaded loading and Vulkan work is happening so haven't had to come up with any fixes for the Profiler so all good there.  I'm providing this PR as it might still be useful for others to compile the profiler with release with debug info.