### PR TITLE
Fix and update Wayland scale handling

### DIFF
--- a/profiler/src/Backend.hpp
+++ b/profiler/src/Backend.hpp
@@ -11,7 +11,7 @@ class RunQueue;
 class Backend
 {
 public:
-    Backend( const char* title, const std::function<void()>& redraw, RunQueue* mainThreadTasks );
+    Backend( const char* title, const std::function<void()>& redraw, const std::function<void(float)>& scaleChanged, RunQueue* mainThreadTasks );
     ~Backend();
 
     void Show();

--- a/profiler/src/BackendGlfw.cpp
+++ b/profiler/src/BackendGlfw.cpp
@@ -60,7 +60,7 @@ static void glfw_window_iconify_callback( GLFWwindow*, int iconified )
 }
 
 
-Backend::Backend( const char* title, const std::function<void()>& redraw, RunQueue* mainThreadTasks )
+Backend::Backend( const char* title, const std::function<void()>& redraw, const std::function<void(float)>& scaleChanged, RunQueue* mainThreadTasks )
 {
     glfwSetErrorCallback( glfw_error_callback );
     if( !glfwInit() ) exit( 1 );

--- a/profiler/src/BackendWayland.cpp
+++ b/profiler/src/BackendWayland.cpp
@@ -160,6 +160,7 @@ constexpr ImGuiKey s_keyTable[] = {
 };
 
 static std::function<void()> s_redraw;
+static std::function<void(float)> s_scaleChanged;
 static RunQueue* s_mainThreadTasks;
 
 static struct wl_display* s_dpy;
@@ -662,9 +663,10 @@ static void SetupCursor()
     s_cursorY = cursor->images[0]->hotspot_y / s_maxScale;
 }
 
-Backend::Backend( const char* title, const std::function<void()>& redraw, RunQueue* mainThreadTasks )
+Backend::Backend( const char* title, const std::function<void()>& redraw, const std::function<void(float)>& scaleChanged, RunQueue* mainThreadTasks )
 {
     s_redraw = redraw;
+    s_scaleChanged = scaleChanged;
     s_mainThreadTasks = mainThreadTasks;
     s_w = m_winPos.w;
     s_h = m_winPos.h;
@@ -820,6 +822,7 @@ void Backend::NewFrame( int& w, int& h )
 {
     if( s_prevScale != s_maxScale )
     {
+        s_scaleChanged( s_maxScale );
         SetupCursor();
         wl_surface_set_buffer_scale( s_surf, s_maxScale );
         s_prevScale = s_maxScale;


### PR DESCRIPTION
Right now Tracy uses the maximum scale across all advertised outputs. If you're on a mixed-DPI system, you get 2x-scaled Tracy on your 1x-scaled monitor, which looks a bit blurry.

This PR fixes and updates the scale handling:

1. Changes Tracy to use the maximum scale across all outputs that the Tracy surface is actually displaying on, rather than all advertised outputs.
    - This necessitated adding a way to dynamically change the scale, since the surface can move between differently-scaled outputs.
    - Behavior with `TRACY_DPI_SCALE` set was preserved.
2. With wl_compositor v6, instead of the output scale guesswork, Tracy will use the scale explicitly requested for the surface by the compositor. The compositor can generally make a better decision here, and this also makes the scale correct right from the very first frame drawn by Tracy, if the compositor sends the preferred scale before the surface is mapped.

I tested it on:
- sway for wl_compositor < 6
- mutter for wl_compositor < 6
- [my own compositor](https://github.com/YaLTeR/niri) for wl_compositor = 6 which sends the preferred scale right away

There's still an issue that Tracy doesn't ensure that its buffer is divisible by the scale, which results in it getting killed if that happens. However, it was already present before this PR, so nothing really changes here.