### PR TITLE
This change makes the crash handler only install when tracy is connected.

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1459,6 +1459,10 @@ void Profiler::InstallCrashHandler()
     sigaction( SIGABRT, &crashHandler, &m_prevSignal.abrt );
 #endif
 
+#if defined _WIN32 && !defined TRACY_UWP && !defined TRACY_NO_CRASH_HANDLER
+    m_exceptionHandler = AddVectoredExceptionHandler( 1, CrashFilter );
+#endif
+
 #ifndef TRACY_NO_CRASH_HANDLER
     m_crashHandlerInstalled = true;
 #endif
@@ -1523,7 +1527,6 @@ void Profiler::SpawnWorkerThreads()
 #  ifdef TRACY_HAS_CALLSTACK
     s_symbolThreadId = GetThreadId( s_symbolThread->Handle() );
 #  endif
-    m_exceptionHandler = AddVectoredExceptionHandler( 1, CrashFilter );
 #endif
 
 #ifdef TRACY_HAS_CALLSTACK

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -798,6 +798,9 @@ private:
     void HandleSymbolQueueItem( const SymbolQueueItem& si );
 #endif
 
+    void InstallCrashHandler();
+    void RemoveCrashHandler();
+    
     void ClearQueues( tracy::moodycamel::ConsumerToken& token );
     void ClearSerial();
     DequeueStatus Dequeue( tracy::moodycamel::ConsumerToken& token );


### PR DESCRIPTION

This avoids the issue that an end user has their own crash handler which gets ignored when tracy is compiled in, even if tracy isn't connected to capture the crash.