### PR TITLE
ci: Update to current versions of actions.

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fix stupidity
       run: |
         cp AUTHORS AUTHORS.
         cp LICENSE LICENSE.
     - name: Compile LaTeX
-      uses: xu-cheng/latex-action@v2
+      uses: xu-cheng/latex-action@v3
       with:
         working_directory: manual
         root_file: tracy.tex
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: manual
         path: manual/tracy.pdf

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     container: archlinux:base-devel
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install linux libraries
       run: pacman -Syu --noconfirm && pacman -S --noconfirm --needed freetype2 capstone tbb debuginfod wayland dbus libxkbcommon libglvnd meson
     - name: Profiler GUI

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install macos libraries
       run: brew install capstone tbb pkg-config glfw meson
     - name: Profiler GUI

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: microsoft/setup-msbuild@v1.0.2
+    - uses: actions/checkout@v4
+    - uses: microsoft/setup-msbuild@v2
     - name: Integrate vcpkg
       run: vcpkg integrate install
     - name: Profiler GUI Debug
@@ -54,7 +54,7 @@ jobs:
         copy library\win32\x64\Release\TracyProfiler.dll bin\dev
         copy library\win32\x64\Release\TracyProfiler.lib bin\dev
         7z a Tracy.7z bin
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         path: Tracy.7z
 
@@ -66,8 +66,8 @@ jobs:
       VCPKG_ROOT: ''
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: microsoft/setup-msbuild@v1.0.2
+    - uses: actions/checkout@v4
+    - uses: microsoft/setup-msbuild@v2
     - name: Install vcpkg dependencies
       run: vcpkg/install_vcpkg_dependencies.bat
     - name: Profiler GUI Release


### PR DESCRIPTION
This should remove the warnings within the GitHub Actions UI about using the deprecated Node 12 and 16 versions.