### PR TITLE
Fix warning: Cast thread id to uint32_t

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -3442,7 +3442,7 @@ bool Profiler::HandleServerQuery()
         }
         else
         {
-            SendString( ptr, GetThreadName( ptr ), QueueType::ThreadName );
+            SendString( ptr, GetThreadName( (uint32_t)ptr ), QueueType::ThreadName );
         }
         break;
     case ServerQuerySourceLocation:


### PR DESCRIPTION
Fix MSVC Warning C4244: 'argument': conversion from 'uint64_t' to 'uint32_t', possible loss of data

Since public\client\TracyProfiler.cpp is included in client code, it'd be nice to clean up this warning. It's the only warning I saw compiling v0.10 with VS2022.

We only store 32 bit thread ids in ThreadNameData. Looks like Windows threadids (`DWORD`) and Linux process ids (`pid_t`) are 32 bits so it seems fine.

Trying to follow existing style instead of static_cast.