### PR TITLE
Added preprocessor checks for Clang on Windows

### DIFF
--- a/public/common/TracySystem.cpp
+++ b/public/common/TracySystem.cpp
@@ -110,7 +110,7 @@ struct ThreadNameData
 std::atomic<ThreadNameData*>& GetThreadNameData();
 #endif
 
-#ifdef _MSC_VER
+#if defined _MSC_VER && !defined __clang__
 #  pragma pack( push, 8 )
 struct THREADNAME_INFO
 {
@@ -149,7 +149,7 @@ TRACY_API void SetThreadName( const char* name )
     }
     else
     {
-#  if defined _MSC_VER
+#  if defined _MSC_VER && !defined __clang__
         THREADNAME_INFO info;
         info.dwType = 0x1000;
         info.szName = name;

--- a/public/common/tracy_lz4.cpp
+++ b/public/common/tracy_lz4.cpp
@@ -128,11 +128,11 @@
 #endif  /* _MSC_VER */
 
 #ifndef LZ4_FORCE_INLINE
-#  ifdef _MSC_VER    /* Visual Studio */
+#  if defined (_MSC_VER) && !defined (__clang__)    /* MSVC */
 #    define LZ4_FORCE_INLINE static __forceinline
 #  else
 #    if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
-#      ifdef __GNUC__
+#      if defined (__GNUC__) || defined (__clang__)
 #        define LZ4_FORCE_INLINE static inline __attribute__((always_inline))
 #      else
 #        define LZ4_FORCE_INLINE static inline


### PR DESCRIPTION
MSVC-specific code is used in some places ([`__try`](https://github.com/wolfpld/tracy/blob/a2dd51ae4ca8fa8495faf739420d3b21f06c440b/public/common/TracySystem.cpp#L126), [`__except`](https://github.com/wolfpld/tracy/blob/a2dd51ae4ca8fa8495faf739420d3b21f06c440b/public/common/TracySystem.cpp#L130) and [`__forceinline`](https://github.com/wolfpld/tracy/blob/a2dd51ae4ca8fa8495faf739420d3b21f06c440b/public/common/tracy_lz4.cpp#L132)) and compiled only if `_MSC_VER` is set; however, Clang under Windows also defines this, which reports errors on this non-standard code if the `-pedantic-errors` compiler flag is set:
```
In file included from tracy/public/TracyClient.cpp:14:
tracy/public/common/TracySystem.cpp:126:5: error: extension used [-Werror,-Wlanguage-extension-token]
    __try
    ^
In file included from tracy/public/TracyClient.cpp:22:
tracy/public/common/tracy_lz4.cpp:445:1: error: extension used [-Werror,-Wlanguage-extension-token]
LZ4_FORCE_INLINE
^
tracy/public/common/tracy_lz4.cpp:132:37: note: expanded from macro 'LZ4_FORCE_INLINE'
#    define LZ4_FORCE_INLINE static __forceinline
                                    ^
```