### PR TITLE
Adding a copy to CSV button to the statistics view.

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3204,6 +3204,16 @@ The last column, \emph{Code size}, displays the size of the symbol in the execut
 
 Finally, the list can be filtered using the \emph{\faFilter{}~Filter symbols} entry field, just like in the instrumentation mode case. Additionally, you can also filter results by the originating image name of the symbol. You may disable the display of kernel symbols with the \emph{\faHatWizard{}~Include kernel} switch. The exclusive/inclusive time counting mode can be switched using the \emph{~Timing} menu (non-reentrant timing is not available in the Sampling view). Limiting the time range is also available but is restricted to self-time. If the \emph{\faPuzzlePiece{}~Show all} option is selected, the list will include not only the call stack samples but also all other symbols collected during the profiling process (this is enabled by default if no sampling was performed).
 
+A simple CSV document containing the visible zones after filtering and limiting can be copied to the clipboard with the button adjacent to the visible zones count. The document contains the following columns:
+
+\begin{itemize}
+  \item \texttt{name} -- Zone name
+  \item \texttt{src\_file} -- Source file where the zone was set
+  \item \texttt{src\_line} -- Line in the source file where the zone was set
+  \item \texttt{total\_ns} -- Total zone time in nanoseconds
+  \item \texttt{counts} -- Zone count
+\end{itemize}
+
 \subsubsection{GPU zones mode}
 
 This is an analog of the instrumentation mode, but for the GPU zones. Note that the available options may be limited here.

--- a/server/TracyView_Statistics.cpp
+++ b/server/TracyView_Statistics.cpp
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include "TracyFilesystem.hpp"
 #include "TracyImGui.hpp"
 #include "TracyPrint.hpp"
@@ -85,6 +87,7 @@ void View::DrawStatistics()
 
     Vector<SrcLocZonesSlim> srcloc;
 
+    bool copySrclocsToClipboard = false;
     if( m_statMode == 0 )
     {
         if( !m_worker.AreSourceLocationZonesReady() )
@@ -258,6 +261,8 @@ void View::DrawStatistics()
         ImGui::Spacing();
         ImGui::SameLine();
         TextFocused( "Visible zones:", RealToString( srcloc.size() ) );
+        ImGui::SameLine();
+        copySrclocsToClipboard = ClipboardButton();
         ImGui::SameLine();
         ImGui::Spacing();
         ImGui::SameLine();
@@ -440,6 +445,8 @@ void View::DrawStatistics()
         ImGui::Spacing();
         ImGui::SameLine();
         TextFocused( "Visible zones:", RealToString( srcloc.size() ) );
+        ImGui::SameLine();
+        copySrclocsToClipboard = ClipboardButton();
     }
 
     ImGui::Separator();
@@ -650,6 +657,12 @@ void View::DrawStatistics()
                     break;
                 }
 
+                std::ostringstream clipboardCSV;
+                if( copySrclocsToClipboard )
+                {
+                    clipboardCSV << "name" << ',' << "src_file" << ',' << "src_line" << ',' << "total_ns" << ',' << "counts" << "\n";
+                }
+
                 for( auto& v : srcloc )
                 {
                     ImGui::TableNextRow();
@@ -718,8 +731,19 @@ void View::DrawStatistics()
                         ImGui::TextUnformatted( RealToString( v.numThreads ) );
                     }
                     ImGui::PopID();
+
+                    if( copySrclocsToClipboard )
+                    {
+                        clipboardCSV << name << ',' << file << ',' << srcloc.line << ',' << v.total << ',' << v.numZones << '\n';
+                    }
                 }
                 ImGui::EndTable();
+
+                if( copySrclocsToClipboard )
+                {
+                    std::string clipboardCSVString = clipboardCSV.str();
+                    ImGui::SetClipboardText( clipboardCSVString.c_str() );
+                }
             }
             ImGui::EndChild();
         }


### PR DESCRIPTION
This copies the visible rows of either the instrumentation or GPU statistics view to a CSV string matching a subset of the csvexport format:
![image](https://github.com/wolfpld/tracy/assets/75337/5a47ed1a-cbd3-49a8-8916-b1f198ede942)

I noticed us sharing screenshots of the statistics view since being able the use the filter/limits of the statistics view to narrow down the zones of interest in the UI is really speedy - but screenshots aren't super usable :)