### PR TITLE
Adding ctrl-r as a hotkey for reconnecting from the main profiler view.

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -2391,6 +2391,8 @@ The \emph{discovered clients} list is only displayed if clients are broadcasting
 
 Both connecting to a client and opening a saved trace will present you with the main profiler view, which you can use to analyze the data (see section~\ref{analyzingdata}).
 
+Once connected to a client \keys{\ctrl + \shift + \Alt + R} can be used to quickly discard any captured data and reconnect to a client at the same address.
+
 \subsubsection{Connection information pop-up}
 \label{connectionpopup}
 

--- a/server/TracyView.cpp
+++ b/server/TracyView.cpp
@@ -648,6 +648,16 @@ bool View::Draw()
         ImGui::EndPopup();
     }
 
+    if( !m_staticView &&
+        ( ImGui::IsModKey( ImGuiKey_LeftCtrl ) || ImGui::IsModKey( ImGuiKey_RightCtrl ) ) &&
+        ( ImGui::IsModKey( ImGuiKey_LeftShift ) || ImGui::IsModKey( ImGuiKey_RightShift ) ) &&
+        ( ImGui::IsModKey( ImGuiKey_LeftAlt ) || ImGui::IsModKey( ImGuiKey_RightAlt ) ) &&
+        ImGui::IsKeyPressed( ImGuiKey_R ) )
+    {
+        m_reconnectRequested = true;
+        return false;
+    }
+
     s_time += ImGui::GetIO().DeltaTime;
     return DrawImpl();
 }


### PR DESCRIPTION
This is effectively the same as clicking on the connection status button, clicking discard, and then clicking reconnect.