### PR TITLE
Adding a copy button to the source view.

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3681,7 +3681,7 @@ This window can operate in one of the two modes. The first one is quite simple, 
 
 \subsubsection{Source file view}
 
-In source view mode, you can view the source code of the profiled application to take a quick glance at the context of the function behavior you are analyzing. The profiler will highlight the selected line (for example, a location of a profiling zone) both in the source code listing and on the scroll bar.
+In source view mode, you can view the source code of the profiled application to take a quick glance at the context of the function behavior you are analyzing. The profiler will highlight the selected line (for example, a location of a profiling zone) both in the source code listing and on the scroll bar. The contents of the file displayed in the source view can be copied to the clipboard using the button adjacent to the file name.
 
 \begin{bclogo}[
 noborder=true,

--- a/server/TracySourceContents.cpp
+++ b/server/TracySourceContents.cpp
@@ -33,6 +33,7 @@ void SourceContents::Parse( const char* fileName, const Worker& worker, const Vi
         if( srcCache.data != nullptr )
         {
             m_data = srcCache.data;
+            m_dataSize = srcCache.len;
             sz = srcCache.len;
         }
         else

--- a/server/TracySourceContents.hpp
+++ b/server/TracySourceContents.hpp
@@ -27,6 +27,8 @@ public:
     const char* filename() const { return m_file; }
     uint32_t idx() const { return m_fileStringIdx; }
     bool is_cached() const { return m_data != m_dataBuf; }
+    const char* data() const { return m_data; }
+    size_t data_size() const { return m_dataSize; }
 
 private:
     const char* m_file;

--- a/server/TracySourceView.cpp
+++ b/server/TracySourceView.cpp
@@ -1,5 +1,6 @@
 #include <ctype.h>
 #include <inttypes.h>
+#include <sstream>
 #include <stdio.h>
 
 #include <capstone.h>
@@ -1058,6 +1059,17 @@ void SourceView::Render( Worker& worker, View& view )
 
     if( m_symAddr == 0 )
     {
+        ImGui::PushFont( m_bigFont );
+        if( ClipboardButton() )
+        {
+            std::ostringstream stream;
+            stream.write( m_source.data(), m_source.data_size() );
+            ImGui::SetClipboardText( stream.str().c_str() );
+        }
+        ImGui::PopFont();
+        ImGui::SameLine();
+        ImGui::Spacing();
+        ImGui::SameLine();
         if( m_source.filename() )
         {
             ImGui::PushFont( m_bigFont );


### PR DESCRIPTION
This matches the button in the call stack view:
![image](https://github.com/wolfpld/tracy/assets/75337/74990cf8-9ada-486c-9561-120d1b943c0e)

The source content data is not guaranteed to have a NUL terminator but the ImGui clipboard API requires one so a copy is performed from the source data on-demand.