### PR TITLE
Updates to address compilation with TRACY_NO_CALLSTACK

### DIFF
--- a/public/TracyClient.cpp
+++ b/public/TracyClient.cpp
@@ -31,20 +31,22 @@
 #include "client/TracyAlloc.cpp"
 #include "client/TracyOverride.cpp"
 
-#if TRACY_HAS_CALLSTACK == 2 || TRACY_HAS_CALLSTACK == 3 || TRACY_HAS_CALLSTACK == 4 || TRACY_HAS_CALLSTACK == 6
-#  include "libbacktrace/alloc.cpp"
-#  include "libbacktrace/dwarf.cpp"
-#  include "libbacktrace/fileline.cpp"
-#  include "libbacktrace/mmapio.cpp"
-#  include "libbacktrace/posix.cpp"
-#  include "libbacktrace/sort.cpp"
-#  include "libbacktrace/state.cpp"
-#  if TRACY_HAS_CALLSTACK == 4
-#    include "libbacktrace/macho.cpp"
-#  else
-#    include "libbacktrace/elf.cpp"
+#if defined(TRACY_HAS_CALLSTACK)
+#  if TRACY_HAS_CALLSTACK == 2 || TRACY_HAS_CALLSTACK == 3 || TRACY_HAS_CALLSTACK == 4 || TRACY_HAS_CALLSTACK == 6
+#    include "libbacktrace/alloc.cpp"
+#    include "libbacktrace/dwarf.cpp"
+#    include "libbacktrace/fileline.cpp"
+#    include "libbacktrace/mmapio.cpp"
+#    include "libbacktrace/posix.cpp"
+#    include "libbacktrace/sort.cpp"
+#    include "libbacktrace/state.cpp"
+#    if TRACY_HAS_CALLSTACK == 4
+#      include "libbacktrace/macho.cpp"
+#    else
+#      include "libbacktrace/elf.cpp"
+#    endif
+#    include "common/TracyStackFrames.cpp"
 #  endif
-#  include "common/TracyStackFrames.cpp"
 #endif
 
 #ifdef _MSC_VER

--- a/public/client/TracyCallstack.hpp
+++ b/public/client/TracyCallstack.hpp
@@ -5,6 +5,15 @@
 #include "../common/TracyForceInline.hpp"
 #include "TracyCallstack.h"
 
+#ifndef TRACY_HAS_CALLSTACK
+
+namespace tracy
+{
+static tracy_force_inline void* Callstack( int /*depth*/ ) { return nullptr; }
+}
+
+#else
+
 #if TRACY_HAS_CALLSTACK == 2 || TRACY_HAS_CALLSTACK == 5
 #  include <unwind.h>
 #elif TRACY_HAS_CALLSTACK >= 3
@@ -16,15 +25,6 @@
 #    include <execinfo.h>
 #  endif
 #endif
-
-#ifndef TRACY_HAS_CALLSTACK
-
-namespace tracy
-{
-static tracy_force_inline void* Callstack( int depth ) { return nullptr; }
-}
-
-#else
 
 #ifdef TRACY_DEBUGINFOD
 #  include <elfutils/debuginfod.h>

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -605,8 +605,7 @@ public:
         profiler.m_serialLock.unlock();
 #else
         static_cast<void>(depth); // unused
-        static_cast<void>(name); // unused
-        MemAlloc( ptr, size, secure );
+        MemAllocNamed( ptr, size, secure, name );
 #endif
     }
 
@@ -629,8 +628,7 @@ public:
         profiler.m_serialLock.unlock();
 #else
         static_cast<void>(depth); // unused
-        static_cast<void>(name); // unused
-        MemFree( ptr, secure );
+        MemFreeNamed( ptr, secure, name );
 #endif
     }
 


### PR DESCRIPTION
Two patches that address compilation with TRACY_NO_CALLSTACK:

- Remove build warnings about an undefined TRACY_HAS_CALLSTACK
- Still name memory pools in "MemAllocCallstackNamed()" when callstacks aren't enabled.