### PR TITLE
Add ZLib dependency into profiler

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -159,6 +159,9 @@ endif()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE TracyServer TracyImGui)
 
+find_package(ZLIB REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE TracyServer ZLIB::ZLIB)
+
 if(NOT EMSCRIPTEN)
     target_link_libraries(${PROJECT_NAME} PRIVATE TracyNfd)
     if (NOT USE_WAYLAND)


### PR DESCRIPTION
This fixes missing dependencies when compiling tracy-profiler with LEGACY=ON:


```
[100%] Linking CXX executable tracy-profiler
lto-wrapper: warning: using serial compilation of 6 LTRANS jobs

/usr/bin/ld: /usr/local/lib/libfreetype.a(ftgzip.c.o): in function `ft_gzip_file_fill_output':
/homes/sb2743/2024-borrowing/tracy/build/profiler/_deps/freetype-src/src/gzip/ftgzip.c:439: undefined reference to `inflate'
/usr/bin/ld: /usr/local/lib/libfreetype.a(ftgzip.c.o): in function `ft_gzip_file_reset':
/homes/sb2743/2024-borrowing/tracy/build/profiler/_deps/freetype-src/src/gzip/ftgzip.c:359: undefined reference to `inflateReset'
/usr/bin/ld: /usr/local/lib/libfreetype.a(ftgzip.c.o): in function `ft_gzip_file_done':
/homes/sb2743/2024-borrowing/tracy/build/profiler/_deps/freetype-src/src/gzip/ftgzip.c:330: undefined reference to `inflateEnd'
/usr/bin/ld: /usr/local/lib/libfreetype.a(ftgzip.c.o): in function `ft_gzip_file_init':
/homes/sb2743/2024-borrowing/tracy/build/profiler/_deps/freetype-src/src/gzip/ftgzip.c:315: undefined reference to `inflateInit2_'
/usr/bin/ld: /usr/local/lib/libfreetype.a(ftgzip.c.o): in function `ft_gzip_file_done':
/homes/sb2743/2024-borrowing/tracy/build/profiler/_deps/freetype-src/src/gzip/ftgzip.c:330: undefined reference to `inflateEnd'
/usr/bin/ld: /usr/local/lib/libfreetype.a(ftgzip.c.o): in function `FT_Gzip_Uncompress':
/homes/sb2743/2024-borrowing/tracy/build/profiler/_deps/freetype-src/src/gzip/ftgzip.c:749: undefined reference to `inflateInit2_'
/usr/bin/ld: /homes/sb2743/2024-borrowing/tracy/build/profiler/_deps/freetype-src/src/gzip/ftgzip.c:753: undefined reference to `inflate'
/usr/bin/ld: /homes/sb2743/2024-borrowing/tracy/build/profiler/_deps/freetype-src/src/gzip/ftgzip.c:756: undefined reference to `inflateEnd'
/usr/bin/ld: /homes/sb2743/2024-borrowing/tracy/build/profiler/_deps/freetype-src/src/gzip/ftgzip.c:764: undefined reference to `inflateEnd'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/tracy-profiler.dir/build.make:1165: tracy-profiler] Error 1
make[1]: *** [CMakeFiles/Makefile2:280: CMakeFiles/tracy-profiler.dir/all] Error 2
```