### PR TITLE
Allow source file modification time to be newer then trace capture time

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3736,6 +3736,8 @@ Let's say we have an Unix-based operating system with program sources in \texttt
 \end{itemize}
 \end{bclogo}
 
+By default, all source file modification times need to be older than the cature time of the trace. This can be disabled using the \emph{Enforce source file modification time older than trace capture time} check box, i.e. when the source files are under source control and the file modification time is not relevant.
+
 In this window, you can view the information about the machine on which the profiled application was running. This includes the operating system, used compiler, CPU name, total available RAM, etc. In addition, if application information was provided (see section~\ref{appinfo}), it will also be displayed here.
 
 If an application should crash during profiling (section~\ref{crashhandling}), the profiler will display the crash information in this window. It provides you information about the thread that has crashed, the crash reason, and the crash call stack (section~\ref{callstackwindow}).

--- a/profiler/src/profiler/TracyFilesystem.cpp
+++ b/profiler/src/profiler/TracyFilesystem.cpp
@@ -10,6 +10,7 @@ bool SourceFileValid( const char* fn, uint64_t olderThan, const View& view, cons
     struct stat buf;
     if( stat( view.SourceSubstitution( fn ), &buf ) == 0 && ( buf.st_mode & S_IFREG ) != 0 )
     {
+        if(!view.ValidateSourceAge()) return true;
         return (uint64_t)buf.st_mtime < olderThan;
     }
     return false;

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -124,6 +124,7 @@ public:
     uint16_t GetPort() const { return m_worker.GetPort(); }
 
     const char* SourceSubstitution( const char* srcFile ) const;
+    bool ValidateSourceAge() const { return m_validateSourceAge; }
 
     void ShowSampleParents( uint64_t symAddr, bool withInlines ) { m_sampleParents.symAddr = symAddr; m_sampleParents.sel = 0; m_sampleParents.withInlines = withInlines; }
 
@@ -585,6 +586,7 @@ private:
 
     std::vector<SourceRegex> m_sourceSubstitutions;
     bool m_sourceRegexValid = true;
+    bool m_validateSourceAge = true;
 
     RangeSlim m_setRangePopup;
     bool m_setRangePopupOpen = false;

--- a/profiler/src/profiler/TracyView_TraceInfo.cpp
+++ b/profiler/src/profiler/TracyView_TraceInfo.cpp
@@ -863,6 +863,8 @@ void View::DrawInfo()
             m_sourceRegexValid = regexValid;
         }
 
+        ImGui::Checkbox("Enforce source file modification time older than trace capture time", &m_validateSourceAge);
+
         ImGui::TreePop();
     }
 


### PR DESCRIPTION
Add a checkbox to allow source files to be newer then the capture

Useful on a Mac if sources are controlled via git