### PR TITLE
Metal (Apple) GPU back-end for Tracy

### DIFF
--- a/profiler/src/profiler/TracyTimelineItemGpu.cpp
+++ b/profiler/src/profiler/TracyTimelineItemGpu.cpp
@@ -42,7 +42,8 @@ void TimelineItemGpu::HeaderTooltip( const char* label ) const
     const bool isMultithreaded =
         ( m_gpu->type == GpuContextType::Vulkan ) ||
         ( m_gpu->type == GpuContextType::OpenCL ) ||
-        ( m_gpu->type == GpuContextType::Direct3D12 );
+        ( m_gpu->type == GpuContextType::Direct3D12 ) ||
+        ( m_gpu->type == GpuContextType::Metal );
 
     char buf[64];
     sprintf( buf, "%s context %i", GpuContextNames[(int)m_gpu->type], m_idx );

--- a/public/common/TracyQueue.hpp
+++ b/public/common/TracyQueue.hpp
@@ -399,7 +399,8 @@ enum class GpuContextType : uint8_t
     Vulkan,
     OpenCL,
     Direct3D12,
-    Direct3D11
+    Direct3D11,
+    Metal
 };
 
 enum GpuContextFlags : uint8_t

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -1,0 +1,364 @@
+#ifndef __TRACYMETAL_HMM__
+#define __TRACYMETAL_HMM__
+
+#ifndef TRACY_ENABLE
+
+#define TracyMetalContext(device,queue) nullptr
+#define TracyMetalDestroy(ctx)
+#define TracyMetalContextName(ctx, name, size)
+
+#define TracyMetalZone(ctx, name)
+#define TracyMetalZoneC(ctx, name, color)
+#define TracyMetalNamedZone(ctx, varname, name, active)
+#define TracyMetalNamedZoneC(ctx, varname, name, color, active)
+#define TracyMetalZoneTransient(ctx, varname, name, active)
+
+#define TracyMetalZoneS(ctx, name, depth)
+#define TracyMetalZoneCS(ctx, name, color, depth)
+#define TracyMetalNamedZoneS(ctx, varname, name, depth, active)
+#define TracyMetalNamedZoneCS(ctx, varname, name, color, depth, active)
+#define TracyMetalZoneTransientS(ctx, varname, name, depth, active)
+
+#define TracyMetalCollect(ctx)
+
+namespace tracy
+{
+class MetalZoneScope {};
+}
+
+using TracyMetalCtx = void*;
+
+#else
+
+#include <atomic>
+#include <assert.h>
+#include <stdlib.h>
+
+#include "Tracy.hpp"
+#include "../client/TracyProfiler.hpp"
+#include "../client/TracyCallstack.hpp"
+#include "../common/TracyAlign.hpp"
+#include "../common/TracyAlloc.hpp"
+
+// ok to import if in obj-c code
+#import <Metal/Metal.h>
+
+#define TracyMetalPanic(msg, ...) do { assert(false && "TracyMetal: " msg); TracyMessageLC("TracyMetal: " msg, tracy::Color::Red4); fprintf(stderr, "TracyMetal: %s\n", msg); __VA_ARGS__; } while(false);
+
+
+namespace tracy
+{
+
+class MetalCtx
+{
+    friend class MetalZoneScope;
+
+    enum { MaxQueries = 4 * 1024 };    // Metal: between 8 and 32768 _BYTES_...
+
+public:
+    MetalCtx(id<MTLDevice> device)
+        : m_device(device)
+    {
+        if (m_device == nil)
+        {
+            TracyMetalPanic("device is nil.", return);
+        }
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtDispatchBoundary])
+        {
+            TracyMetalPanic("timestamp sampling at compute dispatch boundary is not supported.", return);
+        }
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtDrawBoundary])
+        {
+            TracyMetalPanic("timestamp sampling at draw boundary is not supported.", return);
+        }
+        id<MTLCounterSet> timestampCounterSet = nil;
+        for (id<MTLCounterSet> counterSet in m_device.counterSets)
+        {
+            if ([counterSet.name isEqualToString:MTLCommonCounterSetTimestamp])
+            {
+                timestampCounterSet = counterSet;
+                break;
+            }
+        }
+        if (timestampCounterSet == nil)
+        {
+            TracyMetalPanic("timestamp counters are not supported on the platform.", return);
+        }
+        
+        MTLCounterSampleBufferDescriptor* sampleDescriptor = [[MTLCounterSampleBufferDescriptor alloc] init];
+        sampleDescriptor.counterSet = timestampCounterSet;
+        sampleDescriptor.sampleCount = MaxQueries;
+        sampleDescriptor.storageMode = MTLStorageModeShared;
+        sampleDescriptor.label = @"TracyMetalTimestampPool";
+        
+        NSError* error = nil;
+        id<MTLCounterSampleBuffer> counterSampleBuffer = [m_device newCounterSampleBufferWithDescriptor:sampleDescriptor error:&error];
+        if (error != nil)
+        {
+            NSLog(error.localizedDescription);
+            NSLog(error.localizedFailureReason);
+            TracyMetalPanic("unable to create sample buffer for timestamp counters.", return);
+        }
+        m_counterSampleBuffer = counterSampleBuffer;
+
+        MTLTimestamp cpuTimestamp = 0;
+        MTLTimestamp gpuTimestamp = 0;
+        float period = 1.0f;
+        [m_device sampleTimestamps:&cpuTimestamp gpuTimestamp:&gpuTimestamp];
+        
+        m_contextId = GetGpuCtxCounter().fetch_add(1);
+        
+        auto* item = Profiler::QueueSerial();
+        MemWrite(&item->hdr.type, QueueType::GpuNewContext);
+        MemWrite(&item->gpuNewContext.cpuTime, int64_t(cpuTimestamp));
+        MemWrite(&item->gpuNewContext.gpuTime, int64_t(gpuTimestamp));
+        MemWrite(&item->gpuNewContext.thread, uint32_t(0)); // #TODO: why not GetThreadHandle()?
+        MemWrite(&item->gpuNewContext.period, period);
+        MemWrite(&item->gpuNewContext.context, m_contextId);
+        MemWrite(&item->gpuNewContext.flags, GpuContextCalibration);
+        MemWrite(&item->gpuNewContext.type, GpuContextType::Metal);
+        Profiler::QueueSerialFinish();  // TODO: DeferItem() for TRACY_ON_DEMAND
+    }
+
+    ~MetalCtx()
+    {
+    }
+
+    void Name( const char* name, uint16_t len )
+    {
+        auto ptr = (char*)tracy_malloc( len );
+        memcpy( ptr, name, len );
+
+        auto item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuContextName );
+        MemWrite( &item->gpuContextNameFat.context, m_contextId );
+        MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)ptr );
+        MemWrite( &item->gpuContextNameFat.size, len );
+#ifdef TRACY_ON_DEMAND
+        GetProfiler().DeferItem( *item );
+#endif
+        Profiler::QueueSerialFinish();
+    }
+
+    bool Collect()
+    {
+        ZoneScopedC(Color::Red4);
+
+#ifdef TRACY_ON_DEMAND
+        if (!GetProfiler().IsConnected())
+        {
+            return true;
+        }
+#endif
+
+        // Only one thread is allowed to collect timestamps at any given time
+        // but there's no need to block contending threads
+        if (!m_collectionMutex.try_lock())
+        {
+            return true;
+        }
+
+        std::unique_lock lock (m_collectionMutex, std::adopt_lock);
+
+        uintptr_t begin = m_previousCheckpoint.load();
+        uintptr_t latestCheckpoint = m_queryCounter.load(); // TODO: MTLEvent? MTLFence?;
+        uint32_t count = RingCount(begin, latestCheckpoint);
+
+        if (count == 0)   // no pending timestamp queries
+        {
+            uintptr_t nextCheckpoint = m_queryCounter.load();
+            if (nextCheckpoint != latestCheckpoint)
+            {
+                // TODO: signal event / fence now?
+            }
+            return true;
+        }
+
+        if (count >= MaxQueries)
+        {
+            TracyMetalPanic("too many pending timestamp queries.", return false;);
+        }
+
+        NSRange range = { };
+        NSData* data = [m_counterSampleBuffer resolveCounterRange:range];
+        NSUInteger numResolvedTimestamps = data.length / sizeof(MTLCounterResultTimestamp);
+        MTLCounterResultTimestamp* timestamps = (MTLCounterResultTimestamp *)(data.bytes);
+        if (timestamps == nil)
+        {
+            TracyMetalPanic("unable to resolve timestamps.", return false;);
+        }
+
+        for (auto i = begin; i != latestCheckpoint; ++i)
+        {
+            uint32_t k = RingIndex(i);
+            MTLTimestamp& timestamp = timestamps[k].timestamp;
+            // TODO: check the value of timestamp: MTLCounterErrorValue, zero, or valid
+            if (timestamp == MTLCounterErrorValue)
+            {
+                break;
+            }
+            m_previousCheckpoint += 1;
+            auto* item = Profiler::QueueSerial();
+            MemWrite(&item->hdr.type, QueueType::GpuTime);
+            MemWrite(&item->gpuTime.gpuTime, timestamp);
+            MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k));
+            MemWrite(&item->gpuTime.context, m_contextId);
+            Profiler::QueueSerialFinish();
+            timestamp = MTLCounterErrorValue;  // "reset" timestamp
+        }
+
+        //RecalibrateClocks();    // to account for drift
+
+        return true;
+    }
+
+private:
+    tracy_force_inline uint32_t RingIndex(uintptr_t index)
+    {
+        index %= MaxQueries;
+        return static_cast<uint32_t>(index);
+    }
+
+    tracy_force_inline uint32_t RingCount(uintptr_t begin, uintptr_t end)
+    {
+        // wrap-around safe: all unsigned
+        uintptr_t count = end - begin;
+        return static_cast<uint32_t>(count);
+    }
+
+    tracy_force_inline unsigned int NextQueryId()
+    {
+        auto id = m_queryCounter.fetch_add(1);
+        if (RingCount(m_previousCheckpoint, id) >= MaxQueries)
+        {
+            TracyMetalPanic("too many pending timestamp queries.");
+            // #TODO: return some sentinel value; ideally a "hidden" query index
+        }
+        return RingIndex(id);
+    }
+
+    tracy_force_inline uint8_t GetContextId() const
+    {
+        return m_contextId;
+    }
+
+    uint8_t m_contextId = 255;
+
+    id<MTLDevice> m_device = nil;
+    id<MTLCounterSampleBuffer> m_counterSampleBuffer = nil;
+    
+    using atomic_counter = std::atomic<uintptr_t>;
+    static_assert(atomic_counter::is_always_lock_free);
+    atomic_counter m_queryCounter = 0;
+
+    atomic_counter m_previousCheckpoint = 0;
+    atomic_counter::value_type m_nextCheckpoint = 0;
+    
+    std::mutex m_collectionMutex;
+};
+
+class MetalZoneScope
+{
+public:
+    tracy_force_inline MetalZoneScope( MetalCtx* ctx, id<MTLComputeCommandEncoder> cmdEncoder, const SourceLocationData* srcloc, bool is_active )
+#ifdef TRACY_ON_DEMAND
+        : m_active( is_active && GetProfiler().IsConnected() )
+#else
+        : m_active( is_active )
+#endif
+    {
+        if( !m_active ) return;
+        m_ctx = ctx;
+        m_cmdEncoder = cmdEncoder;
+
+        const auto queryId = ctx->NextQueryId();
+        [m_cmdEncoder sampleCountersInBuffer:m_ctx->m_counterSampleBuffer atSampleIndex:queryId withBarrier:YES];
+
+        auto* item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
+        MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
+        MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
+        MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
+        MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
+        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
+
+        Profiler::QueueSerialFinish();
+    }
+
+    tracy_force_inline ~MetalZoneScope()
+    {
+        if( !m_active ) return;
+
+        const auto queryId = m_ctx->NextQueryId();
+        [m_cmdEncoder sampleCountersInBuffer:m_ctx->m_counterSampleBuffer atSampleIndex:queryId withBarrier:YES];
+
+        auto* item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuZoneEndSerial );
+        MemWrite( &item->gpuZoneEnd.cpuTime, Profiler::GetTime() );
+        MemWrite( &item->gpuZoneEnd.thread, GetThreadHandle() );
+        MemWrite( &item->gpuZoneEnd.queryId, uint16_t( queryId ) );
+        MemWrite( &item->gpuZoneEnd.context, m_ctx->GetContextId() );
+
+        Profiler::QueueSerialFinish();
+    }
+
+private:
+    const bool m_active;
+
+    MetalCtx* m_ctx;
+    id<MTLComputeCommandEncoder> m_cmdEncoder;
+};
+
+static inline MetalCtx* CreateMetalContext(id<MTLDevice> device)
+{
+    auto ctx = (MetalCtx*)tracy_malloc( sizeof( MetalCtx ) );
+    new (ctx) MetalCtx( device );
+    return ctx;
+}
+
+static inline void DestroyMetalContext( MetalCtx* ctx )
+{
+    ctx->~MetalCtx();
+    tracy_free( ctx );
+}
+}
+
+using TracyMetalCtx = tracy::MetalCtx*;
+
+#define TracyMetalContext(device) tracy::CreateMetalContext(device);
+#define TracyMetalDestroy(ctx) tracy::DestroyMetalContext(ctx);
+#define TracyMetalContextName(ctx, name, size) ctx->Name(name, size);
+
+#if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK
+#  define TracyMetalZone( ctx, name ) TracyMetalNamedZoneS( ctx, ___tracy_gpu_zone, name, TRACY_CALLSTACK, true )
+#  define TracyMetalZoneC( ctx, name, color ) TracyMetalNamedZoneCS( ctx, ___tracy_gpu_zone, name, color, TRACY_CALLSTACK, true )
+#  define TracyMetalNamedZone( ctx, varname, name, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_gpu_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::MetalZoneScope varname( ctx, &TracyConcat(__tracy_gpu_source_location,TracyLine), TRACY_CALLSTACK, active );
+#  define TracyMetalNamedZoneC( ctx, varname, name, color, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_gpu_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::MetalZoneScope varname( ctx, &TracyConcat(__tracy_gpu_source_location,TracyLine), TRACY_CALLSTACK, active );
+#  define TracyMetalZoneTransient(ctx, varname, name, active) TracyMetalZoneTransientS(ctx, varname, cmdList, name, TRACY_CALLSTACK, active)
+#else
+#  define TracyMetalZone( ctx, cmdEnc, name ) TracyMetalNamedZone( ctx, ___tracy_gpu_zone, cmdEnc, name, true )
+#  define TracyMetalZoneC( ctx, name, color ) TracyMetalNamedZoneC( ctx, ___tracy_gpu_zone, name, color, true )
+#  define TracyMetalNamedZone( ctx, varname, cmdEnc, name, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_gpu_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::MetalZoneScope varname( ctx, cmdEnc, &TracyConcat(__tracy_gpu_source_location,TracyLine), active );
+#  define TracyMetalNamedZoneC( ctx, varname, name, color, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_gpu_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::MetalZoneScope varname( ctx, &TracyConcat(__tracy_gpu_source_location,TracyLine), active );
+#  define TracyMetalZoneTransient(ctx, varname, name, active) tracy::MetalZoneScope varname{ ctx, TracyLine, TracyFile, strlen(TracyFile), TracyFunction, strlen(TracyFunction), name, strlen(name), active };
+#endif
+
+#ifdef TRACY_HAS_CALLSTACK
+#  define TracyMetalZoneS( ctx, name, depth ) TracyMetalNamedZoneS( ctx, ___tracy_gpu_zone, name, depth, true )
+#  define TracyMetalZoneCS( ctx, name, color, depth ) TracyMetalNamedZoneCS( ctx, ___tracy_gpu_zone, name, color, depth, true )
+#  define TracyMetalNamedZoneS( ctx, varname, name, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_gpu_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, 0 }; tracy::MetalZoneScope varname( ctx, &TracyConcat(__tracy_gpu_source_location,TracyLine), depth, active );
+#  define TracyMetalNamedZoneCS( ctx, varname, name, color, depth, active ) static constexpr tracy::SourceLocationData TracyConcat(__tracy_gpu_source_location,TracyLine) { name, TracyFunction,  TracyFile, (uint32_t)TracyLine, color }; tracy::MetalZoneScope varname( ctx, &TracyConcat(__tracy_gpu_source_location,TracyLine), depth, active );
+#  define TracyMetalZoneTransientS(ctx, varname, name, depth, active) tracy::MetalZoneScope varname{ ctx, TracyLine, TracyFile, strlen(TracyFile), TracyFunction, strlen(TracyFunction), name, strlen(name), depth, active };
+#else
+#  define TracyMetalZoneS( ctx, name, depth, active ) TracyMetalZone( ctx, name )
+#  define TracyMetalZoneCS( ctx, name, color, depth, active ) TracyMetalZoneC( name, color )
+#  define TracyMetalNamedZoneS( ctx, varname, name, depth, active ) TracyMetalNamedZone( ctx, varname, name, active )
+#  define TracyMetalNamedZoneCS( ctx, varname, name, color, depth, active ) TracyMetalNamedZoneC( ctx, varname, name, color, active )
+#  define TracyMetalZoneTransientS(ctx, varname, name, depth, active) TracyMetalZoneTransient(ctx, varname, name, active)
+#endif
+
+#define TracyMetalCollect( ctx ) ctx->Collect();
+
+#endif
+
+#endif//__TRACYMETAL_HMM__

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -176,7 +176,7 @@ public:
 
     bool Collect()
     {
-        ZoneScopedC(Color::Red4);
+        ZoneScopedNC("TracyMetal::Collect", Color::Red4);
 
 #ifdef TRACY_ON_DEMAND
         if (!GetProfiler().IsConnected())
@@ -197,14 +197,16 @@ public:
         uintptr_t begin = m_previousCheckpoint.load();
         uintptr_t latestCheckpoint = m_queryCounter.load(); // TODO: MTLEvent? MTLFence?;
         uint32_t count = RingCount(begin, latestCheckpoint);
+        ZoneValue(begin);
+        ZoneValue(latestCheckpoint);
 
         if (count == 0)   // no pending timestamp queries
         {
-            uintptr_t nextCheckpoint = m_queryCounter.load();
-            if (nextCheckpoint != latestCheckpoint)
-            {
-                // TODO: signal event / fence now?
-            }
+            //uintptr_t nextCheckpoint = m_queryCounter.load();
+            //if (nextCheckpoint != latestCheckpoint)
+            //{
+            //    // TODO: signal event / fence now?
+            //}
             return true;
         }
 
@@ -212,10 +214,11 @@ public:
         {
             count = RingSize() - RingIndex(begin);
         }
+        ZoneValue(count);
 
         if (count >= MaxQueries)
         {
-            fprintf(stdout, "TracyMetal: Collect: FULL [%llu, %llu] (%d)\n", begin, latestCheckpoint, count);
+            fprintf(stdout, "TracyMetal: Collect: FULL [%llu, %llu] (%u)\n", begin, latestCheckpoint, count);
             TracyMetalPanic("Collect: too many pending timestamp queries.", return false;);
         }
 
@@ -230,7 +233,7 @@ public:
 
         if (numResolvedTimestamps != count)
         {
-            fprintf(stdout, "TracyMetal: Collect: numResolvedTimestamps != count : %d != %d\n", numResolvedTimestamps, count);
+            fprintf(stdout, "TracyMetal: Collect: numResolvedTimestamps != count : %u != %u\n", numResolvedTimestamps, count);
         }
 
         for (auto i = 0; i < numResolvedTimestamps; i += 2)
@@ -239,7 +242,7 @@ public:
             MTLTimestamp& t_start = timestamps[i+0].timestamp;
             MTLTimestamp& t_end = timestamps[i+1].timestamp;
             uint32_t k = RingIndex(begin + i);
-            fprintf(stdout, "TracyMetal: Collect: timestamp[%d] = %llu | timestamp[%d] = %llu | diff = %llu\n", k, t_start, k+1, t_end, (t_end - t_start));
+            fprintf(stdout, "TracyMetal: Collect: timestamp[%u] = %llu | timestamp[%u] = %llu | diff = %llu\n", k, t_start, k+1, t_end, (t_end - t_start));
             if (t_start == MTLCounterErrorValue)
             {
                 TracyMetalPanic("Collect: invalid timestamp: MTLCounterErrorValue (0xFF..FF).");
@@ -250,7 +253,7 @@ public:
                 static int HACK_retries = 0;
                 if (++HACK_retries > 8) {
                     fprintf(stdout, "TracyMetal: Collect: giving up...\n", k, t_start, k+1, t_end);
-                    t_start = t_end = lastValidTimestamp + 10;
+                    t_start = t_end = lastValidTimestamp + 100;
                     HACK_retries = 0;
                 } else {
                     TracyMetalPanic("Collect: invalid timestamp: zero.");
@@ -304,11 +307,13 @@ private:
 
     tracy_force_inline unsigned int NextQueryId(int n=1)
     {
+        ZoneScopedNC("TracyMetal::NextQueryId", tracy::Color::LightCoral);
         auto id = m_queryCounter.fetch_add(n);
+        ZoneValue(id);
         auto count = RingCount(m_previousCheckpoint, id);
         if (count >= MaxQueries)
         {
-            fprintf(stdout, "TracyMetal: NextQueryId: FULL [%llu, %llu] (%d)\n", m_previousCheckpoint.load(), id, count);
+            fprintf(stdout, "TracyMetal: NextQueryId: FULL [%llu, %llu] (%u)\n", m_previousCheckpoint.load(), id, count);
             TracyMetalPanic("NextQueryId: too many pending timestamp queries.");
             // #TODO: return some sentinel value; ideally a "hidden" query index
         }

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -210,6 +210,7 @@ public:
 
         if (count >= MaxQueries)
         {
+            fprintf(stdout, "TracyMetal: Collect: FULL [%llu, %llu] (%d)\n", begin, latestCheckpoint, count);
             TracyMetalPanic("Collect: too many pending timestamp queries.", return false;);
         }
 
@@ -222,29 +223,54 @@ public:
             TracyMetalPanic("Collect: unable to resolve timestamps.", return false;);
         }
 
-        for (auto i = 0; i < numResolvedTimestamps; ++i)
+        if (numResolvedTimestamps != count)
         {
-            MTLTimestamp& timestamp = timestamps[i].timestamp;
-            if (timestamp == MTLCounterErrorValue)
+            fprintf(stdout, "TracyMetal: Collect: numResolvedTimestamps != count : %d != %d\n", numResolvedTimestamps, count);
+        }
+
+        for (auto i = 0; i < numResolvedTimestamps; i += 2)
+        {
+            static MTLTimestamp lastValidTimestamp = 0;
+            MTLTimestamp& t_start = timestamps[i+0].timestamp;
+            MTLTimestamp& t_end = timestamps[i+1].timestamp;
+            uint32_t k = RingIndex(begin + i);
+            fprintf(stdout, "TracyMetal: Collect: timestamp[%d] = %llu | timestamp[%d] = %llu | diff = %llu\n", k, t_start, k+1, t_end, (t_end - t_start));
+            if (t_start == MTLCounterErrorValue)
             {
                 TracyMetalPanic("Collect: invalid timestamp: MTLCounterErrorValue (0xFF..FF).");
                 break;
             }
-            if (timestamp == 0) // zero is apparently also considered "invalid"...
+            if (t_start == 0) // zero is apparently also considered "invalid"...
             {
-                TracyMetalPanic("Collect: invalid timestamp: zero.");
-                break;
+                static int HACK_retries = 0;
+                if (++HACK_retries > 8) {
+                    fprintf(stdout, "TracyMetal: Collect: giving up...\n", k, t_start, k+1, t_end);
+                    t_start = t_end = lastValidTimestamp + 10;
+                    HACK_retries = 0;
+                } else {
+                    TracyMetalPanic("Collect: invalid timestamp: zero.");
+                    break;
+                }
             }
-            m_previousCheckpoint += 1;
-            uint32_t k = RingIndex(begin + i);
-            fprintf(stdout, "TracyMetal: timestamp[%d]: %llu\n", k, timestamp);
+            m_previousCheckpoint += 2;
+            {
             auto* item = Profiler::QueueSerial();
             MemWrite(&item->hdr.type, QueueType::GpuTime);
-            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(timestamp));
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_start));
             MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k));
             MemWrite(&item->gpuTime.context, m_contextId);
             Profiler::QueueSerialFinish();
-            timestamp = MTLCounterErrorValue;  // "reset" timestamp
+            }
+            {
+            auto* item = Profiler::QueueSerial();
+            MemWrite(&item->hdr.type, QueueType::GpuTime);
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_end));
+            MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k+1));
+            MemWrite(&item->gpuTime.context, m_contextId);
+            Profiler::QueueSerialFinish();
+            }
+            lastValidTimestamp = t_end;
+            t_start = t_end = MTLCounterErrorValue;  // "reset" timestamps
         }
 
         //RecalibrateClocks();    // to account for drift

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -295,8 +295,10 @@ private:
     tracy_force_inline unsigned int NextQueryId(int n=1)
     {
         auto id = m_queryCounter.fetch_add(n);
-        if (RingCount(m_previousCheckpoint, id) >= MaxQueries)
+        auto count = RingCount(m_previousCheckpoint, id);
+        if (count >= MaxQueries)
         {
+            fprintf(stdout, "TracyMetal: NextQueryId: FULL [%llu, %llu] (%d)\n", m_previousCheckpoint.load(), id, count);
             TracyMetalPanic("NextQueryId: too many pending timestamp queries.");
             // #TODO: return some sentinel value; ideally a "hidden" query index
         }

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -43,6 +43,8 @@ using TracyMetalCtx = void*;
 // ok to import if in obj-c code
 #import <Metal/Metal.h>
 
+#define TRACY_METAL_DEBUG_NO_WRAPAROUND (0)
+
 #define VA_ARGS(...) , ##__VA_ARGS__
 
 #define TracyMetalPanic(ret, msg, ...) do { \
@@ -69,6 +71,9 @@ public:
         : m_device(device)
     {
         ZoneScopedNC("TracyMetalCtx", tracy::Color::Red4);
+        
+        TracyMetalPanic(, "MTLCounterErrorValue = 0x%llx", MTLCounterErrorValue);
+        TracyMetalPanic(, "MTLCounterDontSample = 0x%llx", MTLCounterDontSample);
         
         if (m_device == nil)
         {
@@ -125,6 +130,7 @@ public:
         m_counterSampleBuffer = counterSampleBuffer;
         
         m_timestampRequestTime.resize(MaxQueries);
+        go_horse.resize(MaxQueries);
 
         MTLTimestamp cpuTimestamp = 0;
         MTLTimestamp gpuTimestamp = 0;
@@ -211,6 +217,10 @@ public:
 
         uintptr_t begin = m_previousCheckpoint.load();
         uintptr_t latestCheckpoint = m_queryCounter.load(); // TODO: MTLEvent? MTLFence?;
+#if TRACY_METAL_DEBUG_NO_WRAPAROUND
+        latestCheckpoint = (latestCheckpoint >= MaxQueries) ? MaxQueries : latestCheckpoint;
+        //if (latestCheckpoint >= MaxQueries) return true;
+#endif
         uint32_t count = RingCount(begin, latestCheckpoint);
         ZoneValue(begin);
         ZoneValue(latestCheckpoint);
@@ -233,8 +243,10 @@ public:
 
         if (count >= MaxQueries)
         {
-            //TracyMetalPanic(return false, "Collect: FULL! too many pending timestamp queries. [%llu, %llu] (%u)", begin, latestCheckpoint, count);
+            TracyMetalPanic(return false, "Collect: FULL! too many pending timestamp queries. [%llu, %llu] (%u)", begin, latestCheckpoint, count);
         }
+
+        //TracyMetalPanic(, "Collect: [%llu, %llu] :: (%u)", begin, latestCheckpoint, count);
 
         NSRange range = NSMakeRange(RingIndex(begin), count);
         NSData* data = [m_counterSampleBuffer resolveCounterRange:range];
@@ -257,13 +269,25 @@ public:
             MTLTimestamp& t_end = timestamps[i+1].timestamp;
             uint32_t k = RingIndex(begin + i);
             //fprintf(stdout, "TracyMetal: Collect: timestamp[%u] = %llu | timestamp[%u] = %llu | diff = %llu\n", k, t_start, k+1, t_end, (t_end - t_start));
-            if (t_start == MTLCounterErrorValue)
+            if ((t_start == MTLCounterErrorValue)  || (t_end == MTLCounterErrorValue))
             {
                 TracyMetalPanic(, "Collect: invalid timestamp (MTLCounterErrorValue) at %u.", k);
                 break;
             }
-            if (t_start == 0 || t_end == 0) // zero is apparently also considered "invalid"...
+            if (go_horse[k+0] == 0)
             {
+                TracyMetalPanic(, "Collect: go_horse not ready at %u (%llu).", k+0, begin+i+0);
+                break;
+            }
+            if (go_horse[k+1] == 0)
+            {
+                TracyMetalPanic(, "Collect: go_horse not ready at %u (%llu).", k+1, begin+i+1);
+                break;
+            }
+            if ((t_start == 0) || (t_end == 0)) // zero is apparently also considered "invalid"...
+            {
+                break;
+                
                 auto checkTime = std::chrono::high_resolution_clock::now();
                 auto requestTime = m_timestampRequestTime[k];
                 auto ms_in_flight = std::chrono::duration<float>(checkTime-requestTime).count()*1000.0f;
@@ -278,11 +302,17 @@ public:
                 t_start = t_end = lastValidTimestamp + 100;
                 HACK_retries = 0;
             }
-            m_previousCheckpoint += 2;
+            auto t_start_copy = t_start;
+            auto t_end_copy = t_end;
+            t_start = t_end = MTLCounterErrorValue;  // "reset" timestamps
+            t_start = t_end = 0;
+            m_timestampRequestTime[k+0] += std::chrono::minutes(60);
+            m_timestampRequestTime[k+1] += std::chrono::minutes(60);
+            go_horse[k+0] = go_horse[k+1] = 0;
             {
             auto* item = Profiler::QueueSerial();
             MemWrite(&item->hdr.type, QueueType::GpuTime);
-            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_start));
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_start_copy));
             MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k));
             MemWrite(&item->gpuTime.context, m_contextId);
             Profiler::QueueSerialFinish();
@@ -290,14 +320,16 @@ public:
             {
             auto* item = Profiler::QueueSerial();
             MemWrite(&item->hdr.type, QueueType::GpuTime);
-            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_end));
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_end_copy));
             MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k+1));
             MemWrite(&item->gpuTime.context, m_contextId);
             Profiler::QueueSerialFinish();
             }
-            lastValidTimestamp = t_end;
-            t_start = t_end = MTLCounterErrorValue;  // "reset" timestamps
+            TracyMetalPanic(, "zone %u ]", k);
+            TracyMetalPanic(, "zone %u ]", k+1);
+            lastValidTimestamp = t_end_copy;
             TracyFreeN((void*)(uintptr_t)k, "TracyMetalTimestampQueryId");
+            m_previousCheckpoint += 2;
         }
         ZoneValue(RingCount(begin, m_previousCheckpoint.load()));
 
@@ -329,6 +361,9 @@ private:
     {
         ZoneScopedNC("TracyMetal::NextQueryId", tracy::Color::LightCoral);
         auto id = m_queryCounter.fetch_add(n);
+#if TRACY_METAL_DEBUG_NO_WRAPAROUND
+        if (id >= MaxQueries) return MaxQueries;
+#endif
         ZoneValue(id);
         auto count = RingCount(m_previousCheckpoint, id);
         if (count >= MaxQueries)
@@ -337,10 +372,11 @@ private:
             // #TODO: return some sentinel value; ideally a "hidden" query index
             return (MaxQueries - n);
         }
-        TracyAllocN((void*)(uintptr_t)RingIndex(id), 2, "TracyMetalTimestampQueryId");
         uint32_t idx = RingIndex(id);
+        TracyAllocN((void*)(uintptr_t)idx, 2, "TracyMetalTimestampQueryId");
         m_timestampRequestTime[idx] = std::chrono::high_resolution_clock::now();
-        //TracyMetalPanic(, "NextQueryId: %u (%llu)", idx, id);
+        //if (id >= MaxQueries)
+        //    TracyMetalPanic(, "NextQueryId: %u (%llu)", idx, id);
         return idx;
     }
 
@@ -362,6 +398,7 @@ private:
     atomic_counter::value_type m_nextCheckpoint = 0;
     
     std::vector<std::chrono::high_resolution_clock::time_point> m_timestampRequestTime;
+    std::vector<uint64_t> go_horse;
     
     std::mutex m_collectionMutex;
 };
@@ -381,18 +418,16 @@ public:
         m_ctx = ctx;
 
         auto queryId = m_queryId = ctx->NextQueryId(2);
+#if TRACY_METAL_DEBUG_NO_WRAPAROUND
+        if (queryId >= MetalCtx::MaxQueries) return;
+#endif
+
         desc.sampleBufferAttachments[0].sampleBuffer = ctx->m_counterSampleBuffer;
         desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = queryId;
         desc.sampleBufferAttachments[0].endOfEncoderSampleIndex = queryId+1;
 
-        auto* item = Profiler::QueueSerial();
-        MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
-        MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
-        MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
-        MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
-        MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
-        Profiler::QueueSerialFinish();
+        SubmitZoneBeginGpu(ctx, queryId, srcloc);
+        //SubmitZoneEndGpu(ctx, queryId+1);
     }
 
     tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLBlitPassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
@@ -407,18 +442,16 @@ public:
         m_ctx = ctx;
 
         auto queryId = m_queryId = ctx->NextQueryId(2);
+#if TRACY_METAL_DEBUG_NO_WRAPAROUND
+        if (queryId >= MetalCtx::MaxQueries) return;
+#endif
+
         desc.sampleBufferAttachments[0].sampleBuffer = ctx->m_counterSampleBuffer;
         desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = queryId;
         desc.sampleBufferAttachments[0].endOfEncoderSampleIndex = queryId+1;
 
-        auto* item = Profiler::QueueSerial();
-        MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
-        MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
-        MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
-        MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
-        MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
-        Profiler::QueueSerialFinish();
+        SubmitZoneBeginGpu(ctx, queryId, srcloc);
+        //SubmitZoneEndGpu(ctx, queryId+1);
     }
 
     tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLRenderPassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
@@ -433,20 +466,18 @@ public:
         m_ctx = ctx;
 
         auto queryId = m_queryId = ctx->NextQueryId(2);
+#if TRACY_METAL_DEBUG_NO_WRAPAROUND
+        if (queryId >= MetalCtx::MaxQueries) return;
+#endif
+
         desc.sampleBufferAttachments[0].sampleBuffer = ctx->m_counterSampleBuffer;
         desc.sampleBufferAttachments[0].startOfVertexSampleIndex = queryId;
         desc.sampleBufferAttachments[0].endOfVertexSampleIndex = MTLCounterDontSample;
         desc.sampleBufferAttachments[0].startOfFragmentSampleIndex = MTLCounterDontSample;
         desc.sampleBufferAttachments[0].endOfFragmentSampleIndex = queryId+1;
 
-        auto* item = Profiler::QueueSerial();
-        MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
-        MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
-        MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
-        MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
-        MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
-        Profiler::QueueSerialFinish();
+        SubmitZoneBeginGpu(ctx, queryId, srcloc);
+        //SubmitZoneEndGpu(ctx, queryId+1);
     }
 
 #if 0
@@ -462,34 +493,27 @@ public:
         m_cmdEncoder = cmdEncoder;
 
         auto queryId = m_queryId = ctx->NextQueryId();
+#if TRACY_METAL_DEBUG_NO_WRAPAROUND
+        if (queryId >= MetalCtx::MaxQueries) return;
+#endif
+
         [m_cmdEncoder sampleCountersInBuffer:m_ctx->m_counterSampleBuffer atSampleIndex:queryId withBarrier:YES];
 
-        auto* item = Profiler::QueueSerial();
-        MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
-        MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
-        MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
-        MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
-        MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
-
-        Profiler::QueueSerialFinish();
+        SubmitZoneBeginGpu(ctx, queryId, srcloc);
     }
 #endif
 
     tracy_force_inline ~MetalZoneScope()
     {
         if( !m_active ) return;
-
+        
         auto queryId = m_queryId + 1;
 
-        auto* item = Profiler::QueueSerial();
-        MemWrite( &item->hdr.type, QueueType::GpuZoneEndSerial );
-        MemWrite( &item->gpuZoneEnd.cpuTime, Profiler::GetTime() );
-        MemWrite( &item->gpuZoneEnd.thread, GetThreadHandle() );
-        MemWrite( &item->gpuZoneEnd.queryId, uint16_t( queryId ) );
-        MemWrite( &item->gpuZoneEnd.context, m_ctx->GetContextId() );
-
-        Profiler::QueueSerialFinish();
+#if TRACY_METAL_DEBUG_NO_WRAPAROUND
+        if (queryId >= MetalCtx::MaxQueries) return;
+#endif
+        
+        SubmitZoneEndGpu(m_ctx, queryId);
     }
 
 private:
@@ -497,6 +521,37 @@ private:
 
     MetalCtx* m_ctx;
     id<MTLComputeCommandEncoder> m_cmdEncoder;
+    
+    static void SubmitZoneBeginGpu(MetalCtx* ctx, uint32_t queryId, const SourceLocationData* srcloc)
+    {
+        auto* item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
+        MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
+        MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
+        MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
+        MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
+        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
+        Profiler::QueueSerialFinish();
+        
+        TracyMetalPanic(, "zone %u [", queryId);
+        
+        ctx->go_horse[queryId] = 1;
+    }
+    
+    static void SubmitZoneEndGpu(MetalCtx* ctx, uint32_t queryId)
+    {
+        auto* item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuZoneEndSerial );
+        MemWrite( &item->gpuZoneEnd.cpuTime, Profiler::GetTime() );
+        MemWrite( &item->gpuZoneEnd.thread, GetThreadHandle() );
+        MemWrite( &item->gpuZoneEnd.queryId, uint16_t( queryId ) );
+        MemWrite( &item->gpuZoneEnd.context, ctx->GetContextId() );
+        Profiler::QueueSerialFinish();
+        
+        TracyMetalPanic(, "zone %u {]", queryId);
+        
+        ctx->go_horse[queryId] = 1;
+    }
 
 public:
     uint32_t m_queryId = 0;

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -225,13 +225,12 @@ public:
         for (auto i = 0; i < numResolvedTimestamps; ++i)
         {
             MTLTimestamp& timestamp = timestamps[i].timestamp;
-            // TODO: check the value of timestamp: MTLCounterErrorValue, zero, or valid
             if (timestamp == MTLCounterErrorValue)
             {
                 TracyMetalPanic("Collect: invalid timestamp: MTLCounterErrorValue (0xFF..FF).");
                 break;
             }
-            if (timestamp == 0)
+            if (timestamp == 0) // zero is apparently also considered "invalid"...
             {
                 TracyMetalPanic("Collect: invalid timestamp: zero.");
                 break;

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -208,6 +208,11 @@ public:
             return true;
         }
 
+        if (RingIndex(begin) + count > RingSize())
+        {
+            count = RingSize() - RingIndex(begin);
+        }
+
         if (count >= MaxQueries)
         {
             fprintf(stdout, "TracyMetal: Collect: FULL [%llu, %llu] (%d)\n", begin, latestCheckpoint, count);
@@ -290,6 +295,11 @@ private:
         // wrap-around safe: all unsigned
         uintptr_t count = end - begin;
         return static_cast<uint32_t>(count);
+    }
+
+    tracy_force_inline uint32_t RingSize() const
+    {
+        return MaxQueries;
     }
 
     tracy_force_inline unsigned int NextQueryId(int n=1)

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -352,6 +352,60 @@ public:
         Profiler::QueueSerialFinish();
     }
 
+    tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLBlitPassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
+#ifdef TRACY_ON_DEMAND
+        : m_active( is_active && GetProfiler().IsConnected() )
+#else
+        : m_active( is_active )
+#endif
+    {
+        if ( !m_active ) return;
+        if (desc == nil) TracyMetalPanic("pass descriptor is nil.");
+        m_ctx = ctx;
+
+        auto queryId = m_queryId = ctx->NextQueryId(2);
+        desc.sampleBufferAttachments[0].sampleBuffer = ctx->m_counterSampleBuffer;
+        desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = queryId;
+        desc.sampleBufferAttachments[0].endOfEncoderSampleIndex = queryId+1;
+
+        auto* item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
+        MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
+        MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
+        MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
+        MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
+        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
+        Profiler::QueueSerialFinish();
+    }
+
+    tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLRenderPassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
+#ifdef TRACY_ON_DEMAND
+        : m_active( is_active && GetProfiler().IsConnected() )
+#else
+        : m_active( is_active )
+#endif
+    {
+        if ( !m_active ) return;
+        if (desc == nil) TracyMetalPanic("pass descriptor is nil.");
+        m_ctx = ctx;
+
+        auto queryId = m_queryId = ctx->NextQueryId(2);
+        desc.sampleBufferAttachments[0].sampleBuffer = ctx->m_counterSampleBuffer;
+        desc.sampleBufferAttachments[0].startOfVertexSampleIndex = queryId;
+        desc.sampleBufferAttachments[0].endOfVertexSampleIndex = MTLCounterDontSample;
+        desc.sampleBufferAttachments[0].startOfFragmentSampleIndex = MTLCounterDontSample;
+        desc.sampleBufferAttachments[0].endOfFragmentSampleIndex = queryId+1;
+
+        auto* item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
+        MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
+        MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
+        MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
+        MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
+        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
+        Profiler::QueueSerialFinish();
+    }
+
 #if 0
     tracy_force_inline MetalZoneScope( MetalCtx* ctx, id<MTLComputeCommandEncoder> cmdEncoder, const SourceLocationData* srcloc, bool is_active )
 #ifdef TRACY_ON_DEMAND

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -43,8 +43,6 @@ using TracyMetalCtx = void*;
 // ok to import if in obj-c code
 #import <Metal/Metal.h>
 
-#define TRACY_METAL_DEBUG_NO_WRAPAROUND (0)
-
 #define VA_ARGS(...) , ##__VA_ARGS__
 
 #define TracyMetalPanic(ret, msg, ...) do { \
@@ -99,35 +97,10 @@ public:
         {
             TracyMetalPanic(, "WARNING: timestamp sampling at tile dispatch boundary is not supported.");
         }
-        id<MTLCounterSet> timestampCounterSet = nil;
-        for (id<MTLCounterSet> counterSet in m_device.counterSets)
-        {
-            if ([counterSet.name isEqualToString:MTLCommonCounterSetTimestamp])
-            {
-                timestampCounterSet = counterSet;
-                break;
-            }
-        }
-        if (timestampCounterSet == nil)
-        {
-            TracyMetalPanic(return, "ERROR: timestamp counters are not supported on the platform.");
-        }
         
-        MTLCounterSampleBufferDescriptor* sampleDescriptor = [[MTLCounterSampleBufferDescriptor alloc] init];
-        sampleDescriptor.counterSet = timestampCounterSet;
-        sampleDescriptor.sampleCount = MaxQueries;
-        sampleDescriptor.storageMode = MTLStorageModeShared;
-        sampleDescriptor.label = @"TracyMetalTimestampPool";
-        
-        NSError* error = nil;
-        id<MTLCounterSampleBuffer> counterSampleBuffer = [m_device newCounterSampleBufferWithDescriptor:sampleDescriptor error:&error];
-        if (error != nil)
-        {
-            NSLog(@"%@", error.localizedDescription);
-            NSLog(@"%@", error.localizedFailureReason);
-            TracyMetalPanic(return, "ERROR: unable to create sample buffer for timestamp counters.");
-        }
-        m_counterSampleBuffer = counterSampleBuffer;
+        m_counterSampleBuffers[0] = NewTimestampSampleBuffer(m_device, MaxQueries);
+        m_counterSampleBuffers[1] = NewTimestampSampleBuffer(m_device, MaxQueries);
+        //m_counterSampleBuffer = NewTimestampSampleBuffer(m_device, MaxQueries);
         
         m_timestampRequestTime.resize(MaxQueries);
         go_horse.resize(MaxQueries);
@@ -217,14 +190,10 @@ public:
 
         uintptr_t begin = m_previousCheckpoint.load();
         uintptr_t latestCheckpoint = m_queryCounter.load(); // TODO: MTLEvent? MTLFence?;
-#if TRACY_METAL_DEBUG_NO_WRAPAROUND
-        latestCheckpoint = (latestCheckpoint >= MaxQueries) ? MaxQueries : latestCheckpoint;
-        //if (latestCheckpoint >= MaxQueries) return true;
-#endif
-        uint32_t count = RingCount(begin, latestCheckpoint);
         ZoneValue(begin);
         ZoneValue(latestCheckpoint);
 
+        uint32_t count = RingCount(begin, latestCheckpoint);
         if (count == 0)   // no pending timestamp queries
         {
             //uintptr_t nextCheckpoint = m_queryCounter.load();
@@ -235,13 +204,20 @@ public:
             return true;
         }
 
-        if (RingIndex(begin) + count > RingSize())
+        // resolve up until the ring buffer boundary and let a subsequenty call
+        // to Collect handle the wrap-around
+        bool reallocateBuffer = false;
+        if (RingIndex(begin) + count >= RingSize())
         {
             count = RingSize() - RingIndex(begin);
+            reallocateBuffer = true;
         }
         ZoneValue(count);
+        
+        auto buffer_idx = (begin / MaxQueries) % 2;
+        auto counterSampleBuffer = m_counterSampleBuffers[buffer_idx];
 
-        if (count >= MaxQueries)
+        if (count >= RingSize())
         {
             TracyMetalPanic(return false, "Collect: FULL! too many pending timestamp queries. [%llu, %llu] (%u)", begin, latestCheckpoint, count);
         }
@@ -249,7 +225,7 @@ public:
         //TracyMetalPanic(, "Collect: [%llu, %llu] :: (%u)", begin, latestCheckpoint, count);
 
         NSRange range = NSMakeRange(RingIndex(begin), count);
-        NSData* data = [m_counterSampleBuffer resolveCounterRange:range];
+        NSData* data = [counterSampleBuffer resolveCounterRange:range];
         NSUInteger numResolvedTimestamps = data.length / sizeof(MTLCounterResultTimestamp);
         MTLCounterResultTimestamp* timestamps = (MTLCounterResultTimestamp *)(data.bytes);
         if (timestamps == nil)
@@ -262,8 +238,10 @@ public:
             TracyMetalPanic(, "Collect: numResolvedTimestamps != count : %u != %u", (uint32_t)numResolvedTimestamps, count);
         }
 
+        int resolved = 0;
         for (auto i = 0; i < numResolvedTimestamps; i += 2)
         {
+            ZoneScopedN("TracyMetal::Collect::[i]");
             static MTLTimestamp lastValidTimestamp = 0;
             MTLTimestamp& t_start = timestamps[i+0].timestamp;
             MTLTimestamp& t_end = timestamps[i+1].timestamp;
@@ -295,21 +273,19 @@ public:
                 const float timeout_ms = 2000.0f;
                 if (ms_in_flight < timeout_ms)
                     break;
-                static int HACK_retries = 0;
-                //if (++HACK_retries <= 1000000)
-                //    break;
                 TracyMetalPanic(, "Collect: giving up on timestamp at %u [%.0fms in flight].", k, ms_in_flight);
                 t_start = t_end = lastValidTimestamp + 100;
-                HACK_retries = 0;
             }
+            TracyFreeN((void*)(uintptr_t)(k+0), "TracyMetalGpuZone");
+            TracyFreeN((void*)(uintptr_t)(k+1), "TracyMetalGpuZone");
             auto t_start_copy = t_start;
             auto t_end_copy = t_end;
-            t_start = t_end = MTLCounterErrorValue;  // "reset" timestamps
             t_start = t_end = 0;
             m_timestampRequestTime[k+0] += std::chrono::minutes(60);
             m_timestampRequestTime[k+1] += std::chrono::minutes(60);
             go_horse[k+0] = go_horse[k+1] = 0;
             {
+            ZoneScopedN("TracyMetal::Collect::QueueSerial");
             auto* item = Profiler::QueueSerial();
             MemWrite(&item->hdr.type, QueueType::GpuTime);
             MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_start_copy));
@@ -318,6 +294,7 @@ public:
             Profiler::QueueSerialFinish();
             }
             {
+            ZoneScopedN("TracyMetal::Collect::QueueSerial");
             auto* item = Profiler::QueueSerial();
             MemWrite(&item->hdr.type, QueueType::GpuTime);
             MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_end_copy));
@@ -325,13 +302,19 @@ public:
             MemWrite(&item->gpuTime.context, m_contextId);
             Profiler::QueueSerialFinish();
             }
-            TracyMetalPanic(, "zone %u ]", k);
-            TracyMetalPanic(, "zone %u ]", k+1);
+            //TracyMetalPanic(, "zone %u ]", k);
+            //TracyMetalPanic(, "zone %u ]", k+1);
             lastValidTimestamp = t_end_copy;
             TracyFreeN((void*)(uintptr_t)k, "TracyMetalTimestampQueryId");
-            m_previousCheckpoint += 2;
+            resolved += 2;
         }
         ZoneValue(RingCount(begin, m_previousCheckpoint.load()));
+        
+        m_previousCheckpoint += resolved;
+        
+        counterSampleBuffer = nil;
+        if ((resolved == count) && (m_previousCheckpoint.load() % MaxQueries) == 0)
+            m_counterSampleBuffers[buffer_idx] = NewTimestampSampleBuffer(m_device, MaxQueries);
 
         //RecalibrateClocks();    // to account for drift
 
@@ -357,13 +340,38 @@ private:
         return MaxQueries;
     }
 
+    struct Query { id<MTLCounterSampleBuffer> buffer; uint32_t idx; };
+
+    tracy_force_inline Query NextQuery()
+    {
+        ZoneScopedNC("TracyMetal::NextQuery", tracy::Color::LightCoral);
+        auto id = m_queryCounter.fetch_add(2);
+        ZoneValue(id);
+        auto count = RingCount(m_previousCheckpoint, id);
+        if (count >= MaxQueries)
+        {
+            TracyMetalPanic(, "NextQueryId: FULL! too many pending timestamp queries. [%llu, %llu] (%u)", m_previousCheckpoint.load(), id, count);
+            // #TODO: return some sentinel value; ideally a "hidden" query index
+            //return (MaxQueries - n);
+        }
+        uint32_t buffer_idx = (id / MaxQueries) % 2;
+        ZoneValue(buffer_idx);
+        auto buffer = m_counterSampleBuffers[buffer_idx];
+        if (buffer == nil)
+            TracyMetalPanic(, "NextQueryId: sample buffer is nil! (id=%llu)", id);
+        uint32_t idx = RingIndex(id);
+        ZoneValue(idx);
+        TracyAllocN((void*)(uintptr_t)idx, 2, "TracyMetalTimestampQueryId");
+        m_timestampRequestTime[idx] = std::chrono::high_resolution_clock::now();
+        //if (id >= MaxQueries)
+        //    TracyMetalPanic(, "NextQueryId: %u (%llu)", idx, id);
+        return Query{ buffer, idx };
+    }
+
     tracy_force_inline unsigned int NextQueryId(int n=1)
     {
         ZoneScopedNC("TracyMetal::NextQueryId", tracy::Color::LightCoral);
         auto id = m_queryCounter.fetch_add(n);
-#if TRACY_METAL_DEBUG_NO_WRAPAROUND
-        if (id >= MaxQueries) return MaxQueries;
-#endif
         ZoneValue(id);
         auto count = RingCount(m_previousCheckpoint, id);
         if (count >= MaxQueries)
@@ -384,12 +392,51 @@ private:
     {
         return m_contextId;
     }
+    
+    static id<MTLCounterSampleBuffer> NewTimestampSampleBuffer(id<MTLDevice> device, size_t count)
+    {
+        ZoneScopedN("TracyMetal::NewTimestampSampleBuffer");
+
+        id<MTLCounterSet> timestampCounterSet = nil;
+        for (id<MTLCounterSet> counterSet in device.counterSets)
+        {
+            if ([counterSet.name isEqualToString:MTLCommonCounterSetTimestamp])
+            {
+                timestampCounterSet = counterSet;
+                break;
+            }
+        }
+        if (timestampCounterSet == nil)
+        {
+            TracyMetalPanic(return nil, "ERROR: timestamp counters are not supported on the platform.");
+        }
+
+        MTLCounterSampleBufferDescriptor* sampleDescriptor = [[MTLCounterSampleBufferDescriptor alloc] init];
+        sampleDescriptor.counterSet = timestampCounterSet;
+        sampleDescriptor.sampleCount = MaxQueries;
+        sampleDescriptor.storageMode = MTLStorageModeShared;
+        sampleDescriptor.label = @"TracyMetalTimestampPool";
+
+        NSError* error = nil;
+        id<MTLCounterSampleBuffer> counterSampleBuffer = [device newCounterSampleBufferWithDescriptor:sampleDescriptor error:&error];
+        if (error != nil)
+        {
+            //NSLog(@"%@", error.localizedDescription);
+            //NSLog(@"%@", error.localizedFailureReason);
+            TracyMetalPanic(return nil,
+                "ERROR: unable to create sample buffer for timestamp counters : %s | %s",
+                [error.localizedDescription cString], [error.localizedFailureReason cString]);
+        }
+        
+        return counterSampleBuffer;
+    }
 
     uint8_t m_contextId = 255;
 
     id<MTLDevice> m_device = nil;
-    id<MTLCounterSampleBuffer> m_counterSampleBuffer = nil;
-    
+    id<MTLCounterSampleBuffer> m_counterSampleBuffers [2] = {};
+    //id<MTLCounterSampleBuffer> m_counterSampleBuffer;
+
     using atomic_counter = std::atomic<uintptr_t>;
     static_assert(atomic_counter::is_always_lock_free);
     atomic_counter m_queryCounter = 0;
@@ -417,16 +464,13 @@ public:
         if (desc == nil) TracyMetalPanic(return, "pass descriptor is nil.");
         m_ctx = ctx;
 
-        auto queryId = m_queryId = ctx->NextQueryId(2);
-#if TRACY_METAL_DEBUG_NO_WRAPAROUND
-        if (queryId >= MetalCtx::MaxQueries) return;
-#endif
+        auto query = m_query = ctx->NextQuery();
 
-        desc.sampleBufferAttachments[0].sampleBuffer = ctx->m_counterSampleBuffer;
-        desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = queryId;
-        desc.sampleBufferAttachments[0].endOfEncoderSampleIndex = queryId+1;
+        desc.sampleBufferAttachments[0].sampleBuffer = query.buffer;
+        desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = query.idx+0;
+        desc.sampleBufferAttachments[0].endOfEncoderSampleIndex   = query.idx+1;
 
-        SubmitZoneBeginGpu(ctx, queryId, srcloc);
+        SubmitZoneBeginGpu(ctx, query.idx+0, srcloc);
         //SubmitZoneEndGpu(ctx, queryId+1);
     }
 
@@ -441,16 +485,13 @@ public:
         if (desc == nil) TracyMetalPanic(return, "pass descriptor is nil.");
         m_ctx = ctx;
 
-        auto queryId = m_queryId = ctx->NextQueryId(2);
-#if TRACY_METAL_DEBUG_NO_WRAPAROUND
-        if (queryId >= MetalCtx::MaxQueries) return;
-#endif
+        auto query = m_query = ctx->NextQuery();
 
-        desc.sampleBufferAttachments[0].sampleBuffer = ctx->m_counterSampleBuffer;
-        desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = queryId;
-        desc.sampleBufferAttachments[0].endOfEncoderSampleIndex = queryId+1;
+        desc.sampleBufferAttachments[0].sampleBuffer = query.buffer;
+        desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = query.idx+0;
+        desc.sampleBufferAttachments[0].endOfEncoderSampleIndex = query.idx+1;
 
-        SubmitZoneBeginGpu(ctx, queryId, srcloc);
+        SubmitZoneBeginGpu(ctx, query.idx+0, srcloc);
         //SubmitZoneEndGpu(ctx, queryId+1);
     }
 
@@ -465,18 +506,15 @@ public:
         if (desc == nil) TracyMetalPanic(return, "pass descriptor is nil.");
         m_ctx = ctx;
 
-        auto queryId = m_queryId = ctx->NextQueryId(2);
-#if TRACY_METAL_DEBUG_NO_WRAPAROUND
-        if (queryId >= MetalCtx::MaxQueries) return;
-#endif
+        auto query = m_query = ctx->NextQuery();
 
-        desc.sampleBufferAttachments[0].sampleBuffer = ctx->m_counterSampleBuffer;
-        desc.sampleBufferAttachments[0].startOfVertexSampleIndex = queryId;
+        desc.sampleBufferAttachments[0].sampleBuffer = query.buffer;
+        desc.sampleBufferAttachments[0].startOfVertexSampleIndex = query.idx+0;
         desc.sampleBufferAttachments[0].endOfVertexSampleIndex = MTLCounterDontSample;
         desc.sampleBufferAttachments[0].startOfFragmentSampleIndex = MTLCounterDontSample;
-        desc.sampleBufferAttachments[0].endOfFragmentSampleIndex = queryId+1;
+        desc.sampleBufferAttachments[0].endOfFragmentSampleIndex = query.idx+1;
 
-        SubmitZoneBeginGpu(ctx, queryId, srcloc);
+        SubmitZoneBeginGpu(ctx, query.idx+0, srcloc);
         //SubmitZoneEndGpu(ctx, queryId+1);
     }
 
@@ -493,9 +531,6 @@ public:
         m_cmdEncoder = cmdEncoder;
 
         auto queryId = m_queryId = ctx->NextQueryId();
-#if TRACY_METAL_DEBUG_NO_WRAPAROUND
-        if (queryId >= MetalCtx::MaxQueries) return;
-#endif
 
         [m_cmdEncoder sampleCountersInBuffer:m_ctx->m_counterSampleBuffer atSampleIndex:queryId withBarrier:YES];
 
@@ -507,11 +542,7 @@ public:
     {
         if( !m_active ) return;
         
-        auto queryId = m_queryId + 1;
-
-#if TRACY_METAL_DEBUG_NO_WRAPAROUND
-        if (queryId >= MetalCtx::MaxQueries) return;
-#endif
+        auto queryId = m_query.idx + 1;
         
         SubmitZoneEndGpu(m_ctx, queryId);
     }
@@ -533,7 +564,8 @@ private:
         MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
         Profiler::QueueSerialFinish();
         
-        TracyMetalPanic(, "zone %u [", queryId);
+        //TracyMetalPanic(, "zone %u [", queryId);
+        TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone");
         
         ctx->go_horse[queryId] = 1;
     }
@@ -548,13 +580,14 @@ private:
         MemWrite( &item->gpuZoneEnd.context, ctx->GetContextId() );
         Profiler::QueueSerialFinish();
         
-        TracyMetalPanic(, "zone %u {]", queryId);
+        //TracyMetalPanic(, "zone %u {]", queryId);
+        TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone");
         
         ctx->go_horse[queryId] = 1;
     }
 
 public:
-    uint32_t m_queryId = 0;
+    MetalCtx::Query m_query = {};
 };
 
 }

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -100,10 +100,8 @@ public:
         
         m_counterSampleBuffers[0] = NewTimestampSampleBuffer(m_device, MaxQueries);
         m_counterSampleBuffers[1] = NewTimestampSampleBuffer(m_device, MaxQueries);
-        //m_counterSampleBuffer = NewTimestampSampleBuffer(m_device, MaxQueries);
         
         m_timestampRequestTime.resize(MaxQueries);
-        go_horse.resize(MaxQueries);
 
         MTLTimestamp cpuTimestamp = 0;
         MTLTimestamp gpuTimestamp = 0;
@@ -252,59 +250,39 @@ public:
                 TracyMetalPanic(, "Collect: invalid timestamp (MTLCounterErrorValue) at %u.", k);
                 break;
             }
-            if (go_horse[k+0] == 0)
-            {
-                TracyMetalPanic(, "Collect: go_horse not ready at %u (%llu).", k+0, begin+i+0);
-                break;
-            }
-            if (go_horse[k+1] == 0)
-            {
-                TracyMetalPanic(, "Collect: go_horse not ready at %u (%llu).", k+1, begin+i+1);
-                break;
-            }
             if ((t_start == 0) || (t_end == 0)) // zero is apparently also considered "invalid"...
             {
-                break;
-                
                 auto checkTime = std::chrono::high_resolution_clock::now();
                 auto requestTime = m_timestampRequestTime[k];
                 auto ms_in_flight = std::chrono::duration<float>(checkTime-requestTime).count()*1000.0f;
                 //TracyMetalPanic(, "Collect: invalid timestamp (zero) at %u [%.0fms in flight].", k, ms_in_flight);
-                const float timeout_ms = 2000.0f;
+                const float timeout_ms = 200.0f;
                 if (ms_in_flight < timeout_ms)
                     break;
+                ZoneScopedN("TracyMetal::Collect::Drop");
                 TracyMetalPanic(, "Collect: giving up on timestamp at %u [%.0fms in flight].", k, ms_in_flight);
-                t_start = t_end = lastValidTimestamp + 100;
+                t_start = lastValidTimestamp + 5;
+                t_end = t_start + 5;
             }
             TracyFreeN((void*)(uintptr_t)(k+0), "TracyMetalGpuZone");
             TracyFreeN((void*)(uintptr_t)(k+1), "TracyMetalGpuZone");
-            auto t_start_copy = t_start;
-            auto t_end_copy = t_end;
-            t_start = t_end = 0;
-            m_timestampRequestTime[k+0] += std::chrono::minutes(60);
-            m_timestampRequestTime[k+1] += std::chrono::minutes(60);
-            go_horse[k+0] = go_horse[k+1] = 0;
             {
-            ZoneScopedN("TracyMetal::Collect::QueueSerial");
             auto* item = Profiler::QueueSerial();
             MemWrite(&item->hdr.type, QueueType::GpuTime);
-            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_start_copy));
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_start));
             MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k));
             MemWrite(&item->gpuTime.context, m_contextId);
             Profiler::QueueSerialFinish();
             }
             {
-            ZoneScopedN("TracyMetal::Collect::QueueSerial");
             auto* item = Profiler::QueueSerial();
             MemWrite(&item->hdr.type, QueueType::GpuTime);
-            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_end_copy));
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(t_end));
             MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k+1));
             MemWrite(&item->gpuTime.context, m_contextId);
             Profiler::QueueSerialFinish();
             }
-            //TracyMetalPanic(, "zone %u ]", k);
-            //TracyMetalPanic(, "zone %u ]", k+1);
-            lastValidTimestamp = t_end_copy;
+            lastValidTimestamp = t_end;
             TracyFreeN((void*)(uintptr_t)k, "TracyMetalTimestampQueryId");
             resolved += 2;
         }
@@ -435,7 +413,6 @@ private:
 
     id<MTLDevice> m_device = nil;
     id<MTLCounterSampleBuffer> m_counterSampleBuffers [2] = {};
-    //id<MTLCounterSampleBuffer> m_counterSampleBuffer;
 
     using atomic_counter = std::atomic<uintptr_t>;
     static_assert(atomic_counter::is_always_lock_free);
@@ -445,7 +422,6 @@ private:
     atomic_counter::value_type m_nextCheckpoint = 0;
     
     std::vector<std::chrono::high_resolution_clock::time_point> m_timestampRequestTime;
-    std::vector<uint64_t> go_horse;
     
     std::mutex m_collectionMutex;
 };
@@ -564,10 +540,7 @@ private:
         MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
         Profiler::QueueSerialFinish();
         
-        //TracyMetalPanic(, "zone %u [", queryId);
         TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone");
-        
-        ctx->go_horse[queryId] = 1;
     }
     
     static void SubmitZoneEndGpu(MetalCtx* ctx, uint32_t queryId)
@@ -580,10 +553,7 @@ private:
         MemWrite( &item->gpuZoneEnd.context, ctx->GetContextId() );
         Profiler::QueueSerialFinish();
         
-        //TracyMetalPanic(, "zone %u {]", queryId);
         TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone");
-        
-        ctx->go_horse[queryId] = 1;
     }
 
 public:

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -68,29 +68,31 @@ public:
     MetalCtx(id<MTLDevice> device)
         : m_device(device)
     {
+        ZoneScopedNC("TracyMetalCtx", tracy::Color::Red4);
+        
         if (m_device == nil)
         {
-            TracyMetalPanic("device is nil.", return);
+            TracyMetalPanic(return, "device is nil.");
         }
         if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtStageBoundary])
         {
-            TracyMetalPanic("timestamp sampling at pipeline stage boundary is not supported.", return);
+            TracyMetalPanic(return, "ERROR: timestamp sampling at pipeline stage boundary is not supported.");
         }
         if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtDrawBoundary])
         {
-            TracyMetalPanic("timestamp sampling at draw call boundary is not supported.", /* return */);
+            TracyMetalPanic(, "WARNING: timestamp sampling at draw call boundary is not supported.");
         }
         if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtBlitBoundary])
         {
-            TracyMetalPanic("timestamp sampling at blit boundary is not supported.", /* return */);
+            TracyMetalPanic(, "WARNING: timestamp sampling at blit boundary is not supported.");
         }
         if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtDispatchBoundary])
         {
-            TracyMetalPanic("timestamp sampling at compute dispatch boundary is not supported.", /* return */);
+            TracyMetalPanic(, "WARNING: timestamp sampling at compute dispatch boundary is not supported.");
         }
         if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtTileDispatchBoundary])
         {
-            TracyMetalPanic("timestamp sampling at tile dispatch boundary is not supported.", /* return */);
+            TracyMetalPanic(, "WARNING: timestamp sampling at tile dispatch boundary is not supported.");
         }
         id<MTLCounterSet> timestampCounterSet = nil;
         for (id<MTLCounterSet> counterSet in m_device.counterSets)
@@ -103,7 +105,7 @@ public:
         }
         if (timestampCounterSet == nil)
         {
-            TracyMetalPanic("timestamp counters are not supported on the platform.", return);
+            TracyMetalPanic(return, "ERROR: timestamp counters are not supported on the platform.");
         }
         
         MTLCounterSampleBufferDescriptor* sampleDescriptor = [[MTLCounterSampleBufferDescriptor alloc] init];
@@ -118,17 +120,19 @@ public:
         {
             NSLog(@"%@", error.localizedDescription);
             NSLog(@"%@", error.localizedFailureReason);
-            TracyMetalPanic("unable to create sample buffer for timestamp counters.", return);
+            TracyMetalPanic(return, "ERROR: unable to create sample buffer for timestamp counters.");
         }
         m_counterSampleBuffer = counterSampleBuffer;
+        
+        m_timestampRequestTime.resize(MaxQueries);
 
         MTLTimestamp cpuTimestamp = 0;
         MTLTimestamp gpuTimestamp = 0;
         [m_device sampleTimestamps:&cpuTimestamp gpuTimestamp:&gpuTimestamp];
-        fprintf(stdout, "TracyMetal: Calibration: CPU timestamp: %llu\n", cpuTimestamp);
-        fprintf(stdout, "TracyMetal: Calibration: GPU timestamp: %llu\n", gpuTimestamp);
+        TracyMetalPanic(, "Calibration: CPU timestamp (Metal): %llu", cpuTimestamp);
+        TracyMetalPanic(, "Calibration: GPU timestamp (Metal): %llu", gpuTimestamp);
         cpuTimestamp = Profiler::GetTime();
-        fprintf(stdout, "TracyMetal: Calibration: CPU timestamp (profiler): %llu\n", cpuTimestamp);
+        TracyMetalPanic(, "Calibration: CPU timestamp (Tracy): %llu", cpuTimestamp);
         float period = 1.0f;
         
         m_contextId = GetGpuCtxCounter().fetch_add(1);
@@ -148,6 +152,7 @@ public:
 
     ~MetalCtx()
     {
+        ZoneScopedNC("~TracyMetalCtx", tracy::Color::Red4);
     }
 
     static MetalCtx* Create(id<MTLDevice> device)
@@ -156,7 +161,8 @@ public:
         new (ctx) MetalCtx(device);
         if (ctx->m_contextId == 255)
         {
-            TracyMetalPanic("error during context creation.", Destroy(ctx); return nullptr);
+            Destroy(ctx);
+            TracyMetalPanic(return nullptr, "ERROR: unable to create context.");
         }
         return ctx;
     }
@@ -227,8 +233,7 @@ public:
 
         if (count >= MaxQueries)
         {
-            fprintf(stdout, "TracyMetal: Collect: FULL [%llu, %llu] (%u)\n", begin, latestCheckpoint, count);
-            TracyMetalPanic("Collect: too many pending timestamp queries.", return false;);
+            //TracyMetalPanic(return false, "Collect: FULL! too many pending timestamp queries. [%llu, %llu] (%u)", begin, latestCheckpoint, count);
         }
 
         NSRange range = NSMakeRange(RingIndex(begin), count);
@@ -237,12 +242,12 @@ public:
         MTLCounterResultTimestamp* timestamps = (MTLCounterResultTimestamp *)(data.bytes);
         if (timestamps == nil)
         {
-            TracyMetalPanic("Collect: unable to resolve timestamps.", return false;);
+            TracyMetalPanic(return false, "Collect: unable to resolve timestamps.");
         }
 
         if (numResolvedTimestamps != count)
         {
-            fprintf(stdout, "TracyMetal: Collect: numResolvedTimestamps != count : %u != %u\n", numResolvedTimestamps, count);
+            TracyMetalPanic(, "Collect: numResolvedTimestamps != count : %u != %u", (uint32_t)numResolvedTimestamps, count);
         }
 
         for (auto i = 0; i < numResolvedTimestamps; i += 2)
@@ -251,23 +256,27 @@ public:
             MTLTimestamp& t_start = timestamps[i+0].timestamp;
             MTLTimestamp& t_end = timestamps[i+1].timestamp;
             uint32_t k = RingIndex(begin + i);
-            fprintf(stdout, "TracyMetal: Collect: timestamp[%u] = %llu | timestamp[%u] = %llu | diff = %llu\n", k, t_start, k+1, t_end, (t_end - t_start));
+            //fprintf(stdout, "TracyMetal: Collect: timestamp[%u] = %llu | timestamp[%u] = %llu | diff = %llu\n", k, t_start, k+1, t_end, (t_end - t_start));
             if (t_start == MTLCounterErrorValue)
             {
-                TracyMetalPanic("Collect: invalid timestamp: MTLCounterErrorValue (0xFF..FF).");
+                TracyMetalPanic(, "Collect: invalid timestamp (MTLCounterErrorValue) at %u.", k);
                 break;
             }
             if (t_start == 0 || t_end == 0) // zero is apparently also considered "invalid"...
             {
-                static int HACK_retries = 0;
-                if (++HACK_retries > 8) {
-                    fprintf(stdout, "TracyMetal: Collect: giving up...\n");
-                    t_start = t_end = lastValidTimestamp + 100;
-                    HACK_retries = 0;
-                } else {
-                    TracyMetalPanic("Collect: invalid timestamp: zero.");
+                auto checkTime = std::chrono::high_resolution_clock::now();
+                auto requestTime = m_timestampRequestTime[k];
+                auto ms_in_flight = std::chrono::duration<float>(checkTime-requestTime).count()*1000.0f;
+                //TracyMetalPanic(, "Collect: invalid timestamp (zero) at %u [%.0fms in flight].", k, ms_in_flight);
+                const float timeout_ms = 2000.0f;
+                if (ms_in_flight < timeout_ms)
                     break;
-                }
+                static int HACK_retries = 0;
+                //if (++HACK_retries <= 1000000)
+                //    break;
+                TracyMetalPanic(, "Collect: giving up on timestamp at %u [%.0fms in flight].", k, ms_in_flight);
+                t_start = t_end = lastValidTimestamp + 100;
+                HACK_retries = 0;
             }
             m_previousCheckpoint += 2;
             {
@@ -288,6 +297,7 @@ public:
             }
             lastValidTimestamp = t_end;
             t_start = t_end = MTLCounterErrorValue;  // "reset" timestamps
+            TracyFreeN((void*)(uintptr_t)k, "TracyMetalTimestampQueryId");
         }
         ZoneValue(RingCount(begin, m_previousCheckpoint.load()));
 
@@ -323,11 +333,15 @@ private:
         auto count = RingCount(m_previousCheckpoint, id);
         if (count >= MaxQueries)
         {
-            fprintf(stdout, "TracyMetal: NextQueryId: FULL [%llu, %llu] (%u)\n", m_previousCheckpoint.load(), id, count);
-            TracyMetalPanic("NextQueryId: too many pending timestamp queries.");
+            TracyMetalPanic(, "NextQueryId: FULL! too many pending timestamp queries. [%llu, %llu] (%u)", m_previousCheckpoint.load(), id, count);
             // #TODO: return some sentinel value; ideally a "hidden" query index
+            return (MaxQueries - n);
         }
-        return RingIndex(id);
+        TracyAllocN((void*)(uintptr_t)RingIndex(id), 2, "TracyMetalTimestampQueryId");
+        uint32_t idx = RingIndex(id);
+        m_timestampRequestTime[idx] = std::chrono::high_resolution_clock::now();
+        //TracyMetalPanic(, "NextQueryId: %u (%llu)", idx, id);
+        return idx;
     }
 
     tracy_force_inline uint8_t GetContextId() const
@@ -347,6 +361,8 @@ private:
     atomic_counter m_previousCheckpoint = 0;
     atomic_counter::value_type m_nextCheckpoint = 0;
     
+    std::vector<std::chrono::high_resolution_clock::time_point> m_timestampRequestTime;
+    
     std::mutex m_collectionMutex;
 };
 
@@ -361,7 +377,7 @@ public:
 #endif
     {
         if ( !m_active ) return;
-        if (desc == nil) TracyMetalPanic("pass descriptor is nil.");
+        if (desc == nil) TracyMetalPanic(return, "pass descriptor is nil.");
         m_ctx = ctx;
 
         auto queryId = m_queryId = ctx->NextQueryId(2);
@@ -387,7 +403,7 @@ public:
 #endif
     {
         if ( !m_active ) return;
-        if (desc == nil) TracyMetalPanic("pass descriptor is nil.");
+        if (desc == nil) TracyMetalPanic(return, "pass descriptor is nil.");
         m_ctx = ctx;
 
         auto queryId = m_queryId = ctx->NextQueryId(2);
@@ -413,7 +429,7 @@ public:
 #endif
     {
         if ( !m_active ) return;
-        if (desc == nil) TracyMetalPanic("pass descriptor is nil.");
+        if (desc == nil) TracyMetalPanic(return, "pass descriptor is nil.");
         m_ctx = ctx;
 
         auto queryId = m_queryId = ctx->NextQueryId(2);
@@ -481,6 +497,8 @@ private:
 
     MetalCtx* m_ctx;
     id<MTLComputeCommandEncoder> m_cmdEncoder;
+
+public:
     uint32_t m_queryId = 0;
 };
 

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -213,7 +213,7 @@ public:
             TracyMetalPanic("Collect: too many pending timestamp queries.", return false;);
         }
 
-        NSRange range = NSMakeRange(begin, count);
+        NSRange range = NSMakeRange(RingIndex(begin), count);
         NSData* data = [m_counterSampleBuffer resolveCounterRange:range];
         NSUInteger numResolvedTimestamps = data.length / sizeof(MTLCounterResultTimestamp);
         MTLCounterResultTimestamp* timestamps = (MTLCounterResultTimestamp *)(data.bytes);

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -43,7 +43,16 @@ using TracyMetalCtx = void*;
 // ok to import if in obj-c code
 #import <Metal/Metal.h>
 
-#define TracyMetalPanic(msg, ...) do { assert(false && "TracyMetal: " msg); TracyMessageLC("TracyMetal: " msg, tracy::Color::Red4); fprintf(stderr, "TracyMetal: %s\n", msg); __VA_ARGS__; } while(false);
+#define VA_ARGS(...) , ##__VA_ARGS__
+
+#define TracyMetalPanic(ret, msg, ...) do { \
+    char buffer [1024]; \
+    snprintf(buffer, sizeof(buffer), "TracyMetal: " msg VA_ARGS(__VA_ARGS__)); \
+    TracyMessageC(buffer, strlen(buffer), tracy::Color::OrangeRed); \
+    fprintf(stderr, "%s\n", buffer); \
+    assert(false && "TracyMetal: " msg); \
+    ret; \
+    } while(false);
 
 
 namespace tracy

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -55,6 +55,14 @@ using TracyMetalCtx = void*;
     } while(false);
 
 
+#define TRACY_METAL_DEBUG_MASK (0)
+
+#if TRACY_METAL_DEBUG_MASK
+#define TracyMetalDebug(mask, ...) if (mask & TRACY_METAL_DEBUG_MASK) { __VA_ARGS__; }
+#else
+#define TracyMetalDebug(mask, ...)
+#endif
+
 namespace tracy
 {
 
@@ -66,12 +74,12 @@ class MetalCtx
 
 public:
     MetalCtx(id<MTLDevice> device)
-        : m_device(device)
+    : m_device(device)
     {
         ZoneScopedNC("TracyMetalCtx", tracy::Color::Red4);
         
-        TracyMetalPanic(, "MTLCounterErrorValue = 0x%llx", MTLCounterErrorValue);
-        TracyMetalPanic(, "MTLCounterDontSample = 0x%llx", MTLCounterDontSample);
+        TracyMetalDebug(1<<0, TracyMetalPanic(, "MTLCounterErrorValue = 0x%llx", MTLCounterErrorValue));
+        TracyMetalDebug(1<<0, TracyMetalPanic(, "MTLCounterDontSample = 0x%llx", MTLCounterDontSample));
         
         if (m_device == nil)
         {
@@ -106,10 +114,12 @@ public:
         MTLTimestamp cpuTimestamp = 0;
         MTLTimestamp gpuTimestamp = 0;
         [m_device sampleTimestamps:&cpuTimestamp gpuTimestamp:&gpuTimestamp];
-        TracyMetalPanic(, "Calibration: CPU timestamp (Metal): %llu", cpuTimestamp);
-        TracyMetalPanic(, "Calibration: GPU timestamp (Metal): %llu", gpuTimestamp);
+        TracyMetalDebug(1<<0, TracyMetalPanic(, "Calibration: CPU timestamp (Metal): %llu", cpuTimestamp));
+        TracyMetalDebug(1<<0, TracyMetalPanic(, "Calibration: GPU timestamp (Metal): %llu", gpuTimestamp));
+
         cpuTimestamp = Profiler::GetTime();
-        TracyMetalPanic(, "Calibration: CPU timestamp (Tracy): %llu", cpuTimestamp);
+        TracyMetalDebug(1<<0, TracyMetalPanic(, "Calibration: CPU timestamp (Tracy): %llu", cpuTimestamp));
+
         float period = 1.0f;
         
         m_contextId = GetGpuCtxCounter().fetch_add(1);
@@ -220,7 +230,7 @@ public:
             TracyMetalPanic(return false, "Collect: FULL! too many pending timestamp queries. [%llu, %llu] (%u)", begin, latestCheckpoint, count);
         }
 
-        //TracyMetalPanic(, "Collect: [%llu, %llu] :: (%u)", begin, latestCheckpoint, count);
+        TracyMetalDebug(1<<3, TracyMetalPanic(, "Collect: [%llu, %llu] :: (%u)", begin, latestCheckpoint, count));
 
         NSRange range = NSMakeRange(RingIndex(begin), count);
         NSData* data = [counterSampleBuffer resolveCounterRange:range];
@@ -244,7 +254,7 @@ public:
             MTLTimestamp& t_start = timestamps[i+0].timestamp;
             MTLTimestamp& t_end = timestamps[i+1].timestamp;
             uint32_t k = RingIndex(begin + i);
-            //fprintf(stdout, "TracyMetal: Collect: timestamp[%u] = %llu | timestamp[%u] = %llu | diff = %llu\n", k, t_start, k+1, t_end, (t_end - t_start));
+            TracyMetalDebug(1<<4, TracyMetalPanic(, "Collect: timestamp[%u] = %llu | timestamp[%u] = %llu | diff = %llu\n", k, t_start, k+1, t_end, (t_end - t_start)));
             if ((t_start == MTLCounterErrorValue)  || (t_end == MTLCounterErrorValue))
             {
                 TracyMetalPanic(, "Collect: invalid timestamp (MTLCounterErrorValue) at %u.", k);
@@ -255,7 +265,7 @@ public:
                 auto checkTime = std::chrono::high_resolution_clock::now();
                 auto requestTime = m_timestampRequestTime[k];
                 auto ms_in_flight = std::chrono::duration<float>(checkTime-requestTime).count()*1000.0f;
-                //TracyMetalPanic(, "Collect: invalid timestamp (zero) at %u [%.0fms in flight].", k, ms_in_flight);
+                TracyMetalDebug(1<<4, TracyMetalPanic(, "Collect: invalid timestamp (zero) at %u [%.0fms in flight].", k, ms_in_flight));
                 const float timeout_ms = 200.0f;
                 if (ms_in_flight < timeout_ms)
                     break;
@@ -264,8 +274,8 @@ public:
                 t_start = lastValidTimestamp + 5;
                 t_end = t_start + 5;
             }
-            TracyFreeN((void*)(uintptr_t)(k+0), "TracyMetalGpuZone");
-            TracyFreeN((void*)(uintptr_t)(k+1), "TracyMetalGpuZone");
+            TracyMetalDebug(1<<2, TracyFreeN((void*)(uintptr_t)(k+0), "TracyMetalGpuZone"));
+            TracyMetalDebug(1<<2, TracyFreeN((void*)(uintptr_t)(k+1), "TracyMetalGpuZone"));
             {
             auto* item = Profiler::QueueSerial();
             MemWrite(&item->hdr.type, QueueType::GpuTime);
@@ -283,7 +293,7 @@ public:
             Profiler::QueueSerialFinish();
             }
             lastValidTimestamp = t_end;
-            TracyFreeN((void*)(uintptr_t)k, "TracyMetalTimestampQueryId");
+            TracyMetalDebug(1<<1, TracyFreeN((void*)(uintptr_t)k, "TracyMetalTimestampQueryId"));
             resolved += 2;
         }
         ZoneValue(RingCount(begin, m_previousCheckpoint.load()));
@@ -328,9 +338,13 @@ private:
         auto count = RingCount(m_previousCheckpoint, id);
         if (count >= MaxQueries)
         {
-            TracyMetalPanic(, "NextQueryId: FULL! too many pending timestamp queries. [%llu, %llu] (%u)", m_previousCheckpoint.load(), id, count);
-            // #TODO: return some sentinel value; ideally a "hidden" query index
-            //return (MaxQueries - n);
+            // TODO: return a proper (hidden) "sentinel" query
+            Query sentinel = Query{ m_counterSampleBuffers[1], MaxQueries-2 };
+            TracyMetalPanic(
+                return sentinel,
+                "NextQueryId: FULL! too many pending timestamp queries. [%llu, %llu] (%u)",
+                m_previousCheckpoint.load(), id, count
+            );
         }
         uint32_t buffer_idx = (id / MaxQueries) % 2;
         ZoneValue(buffer_idx);
@@ -339,31 +353,9 @@ private:
             TracyMetalPanic(, "NextQueryId: sample buffer is nil! (id=%llu)", id);
         uint32_t idx = RingIndex(id);
         ZoneValue(idx);
-        TracyAllocN((void*)(uintptr_t)idx, 2, "TracyMetalTimestampQueryId");
+        TracyMetalDebug(1<<1, TracyAllocN((void*)(uintptr_t)idx, 2, "TracyMetalTimestampQueryId"));
         m_timestampRequestTime[idx] = std::chrono::high_resolution_clock::now();
-        //if (id >= MaxQueries)
-        //    TracyMetalPanic(, "NextQueryId: %u (%llu)", idx, id);
         return Query{ buffer, idx };
-    }
-
-    tracy_force_inline unsigned int NextQueryId(int n=1)
-    {
-        ZoneScopedNC("TracyMetal::NextQueryId", tracy::Color::LightCoral);
-        auto id = m_queryCounter.fetch_add(n);
-        ZoneValue(id);
-        auto count = RingCount(m_previousCheckpoint, id);
-        if (count >= MaxQueries)
-        {
-            TracyMetalPanic(, "NextQueryId: FULL! too many pending timestamp queries. [%llu, %llu] (%u)", m_previousCheckpoint.load(), id, count);
-            // #TODO: return some sentinel value; ideally a "hidden" query index
-            return (MaxQueries - n);
-        }
-        uint32_t idx = RingIndex(id);
-        TracyAllocN((void*)(uintptr_t)idx, 2, "TracyMetalTimestampQueryId");
-        m_timestampRequestTime[idx] = std::chrono::high_resolution_clock::now();
-        //if (id >= MaxQueries)
-        //    TracyMetalPanic(, "NextQueryId: %u (%llu)", idx, id);
-        return idx;
     }
 
     tracy_force_inline uint8_t GetContextId() const
@@ -399,8 +391,7 @@ private:
         id<MTLCounterSampleBuffer> counterSampleBuffer = [device newCounterSampleBufferWithDescriptor:sampleDescriptor error:&error];
         if (error != nil)
         {
-            //NSLog(@"%@", error.localizedDescription);
-            //NSLog(@"%@", error.localizedFailureReason);
+            //NSLog(@"%@ | %@", error.localizedDescription, error.localizedFailureReason);
             TracyMetalPanic(return nil,
                 "ERROR: unable to create sample buffer for timestamp counters : %s | %s",
                 [error.localizedDescription cString], [error.localizedFailureReason cString]);
@@ -437,17 +428,16 @@ public:
 #endif
     {
         if ( !m_active ) return;
-        if (desc == nil) TracyMetalPanic(return, "pass descriptor is nil.");
+        if (desc == nil) TracyMetalPanic(return, "compute pass descriptor is nil.");
         m_ctx = ctx;
 
-        auto query = m_query = ctx->NextQuery();
+        auto& query = m_query = ctx->NextQuery();
 
         desc.sampleBufferAttachments[0].sampleBuffer = query.buffer;
         desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = query.idx+0;
         desc.sampleBufferAttachments[0].endOfEncoderSampleIndex   = query.idx+1;
 
-        SubmitZoneBeginGpu(ctx, query.idx+0, srcloc);
-        //SubmitZoneEndGpu(ctx, queryId+1);
+        SubmitZoneBeginGpu(ctx, query.idx + 0, srcloc);
     }
 
     tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLBlitPassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
@@ -458,17 +448,16 @@ public:
 #endif
     {
         if ( !m_active ) return;
-        if (desc == nil) TracyMetalPanic(return, "pass descriptor is nil.");
+        if (desc == nil) TracyMetalPanic(return, "blit pass descriptor is nil.");
         m_ctx = ctx;
 
-        auto query = m_query = ctx->NextQuery();
+        auto& query = m_query = ctx->NextQuery();
 
         desc.sampleBufferAttachments[0].sampleBuffer = query.buffer;
         desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = query.idx+0;
         desc.sampleBufferAttachments[0].endOfEncoderSampleIndex = query.idx+1;
 
-        SubmitZoneBeginGpu(ctx, query.idx+0, srcloc);
-        //SubmitZoneEndGpu(ctx, queryId+1);
+        SubmitZoneBeginGpu(ctx, query.idx + 0, srcloc);
     }
 
     tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLRenderPassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
@@ -479,10 +468,10 @@ public:
 #endif
     {
         if ( !m_active ) return;
-        if (desc == nil) TracyMetalPanic(return, "pass descriptor is nil.");
+        if (desc == nil) TracyMetalPanic(return, "render pass descriptor is nil.");
         m_ctx = ctx;
 
-        auto query = m_query = ctx->NextQuery();
+        auto& query = m_query = ctx->NextQuery();
 
         desc.sampleBufferAttachments[0].sampleBuffer = query.buffer;
         desc.sampleBufferAttachments[0].startOfVertexSampleIndex = query.idx+0;
@@ -490,8 +479,7 @@ public:
         desc.sampleBufferAttachments[0].startOfFragmentSampleIndex = MTLCounterDontSample;
         desc.sampleBufferAttachments[0].endOfFragmentSampleIndex = query.idx+1;
 
-        SubmitZoneBeginGpu(ctx, query.idx+0, srcloc);
-        //SubmitZoneEndGpu(ctx, queryId+1);
+        SubmitZoneBeginGpu(ctx, query.idx + 0, srcloc);
     }
 
 #if 0
@@ -506,21 +494,19 @@ public:
         m_ctx = ctx;
         m_cmdEncoder = cmdEncoder;
 
-        auto queryId = m_queryId = ctx->NextQueryId();
+        auto& query = m_query = ctx->NextQueryId();
 
-        [m_cmdEncoder sampleCountersInBuffer:m_ctx->m_counterSampleBuffer atSampleIndex:queryId withBarrier:YES];
+        [m_cmdEncoder sampleCountersInBuffer:m_ctx->m_counterSampleBuffer atSampleIndex:query.idx withBarrier:YES];
 
-        SubmitZoneBeginGpu(ctx, queryId, srcloc);
+        SubmitZoneBeginGpu(ctx, query.idx, srcloc);
     }
 #endif
 
     tracy_force_inline ~MetalZoneScope()
     {
         if( !m_active ) return;
-        
-        auto queryId = m_query.idx + 1;
-        
-        SubmitZoneEndGpu(m_ctx, queryId);
+
+        SubmitZoneEndGpu(m_ctx, m_query.idx + 1);
     }
 
 private:
@@ -540,7 +526,7 @@ private:
         MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
         Profiler::QueueSerialFinish();
         
-        TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone");
+        TracyMetalDebug(1<<2, TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone"));
     }
     
     static void SubmitZoneEndGpu(MetalCtx* ctx, uint32_t queryId)
@@ -553,10 +539,9 @@ private:
         MemWrite( &item->gpuZoneEnd.context, ctx->GetContextId() );
         Profiler::QueueSerialFinish();
         
-        TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone");
+        TracyMetalDebug(1<<2, TracyAllocN((void*)(uintptr_t)queryId, 1, "TracyMetalGpuZone"));
     }
 
-public:
     MetalCtx::Query m_query = {};
 };
 

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -3,7 +3,7 @@
 
 #ifndef TRACY_ENABLE
 
-#define TracyMetalContext(device,queue) nullptr
+#define TracyMetalContext(device) nullptr
 #define TracyMetalDestroy(ctx)
 #define TracyMetalContextName(ctx, name, size)
 
@@ -63,13 +63,25 @@ public:
         {
             TracyMetalPanic("device is nil.", return);
         }
-        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtDispatchBoundary])
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtStageBoundary])
         {
-            TracyMetalPanic("timestamp sampling at compute dispatch boundary is not supported.", return);
+            TracyMetalPanic("timestamp sampling at pipeline stage boundary is not supported.", return);
         }
         if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtDrawBoundary])
         {
-            TracyMetalPanic("timestamp sampling at draw boundary is not supported.", return);
+            TracyMetalPanic("timestamp sampling at draw call boundary is not supported.", /* return */);
+        }
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtBlitBoundary])
+        {
+            TracyMetalPanic("timestamp sampling at blit boundary is not supported.", /* return */);
+        }
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtDispatchBoundary])
+        {
+            TracyMetalPanic("timestamp sampling at compute dispatch boundary is not supported.", /* return */);
+        }
+        if (![m_device supportsCounterSampling:MTLCounterSamplingPointAtTileDispatchBoundary])
+        {
+            TracyMetalPanic("timestamp sampling at tile dispatch boundary is not supported.", /* return */);
         }
         id<MTLCounterSet> timestampCounterSet = nil;
         for (id<MTLCounterSet> counterSet in m_device.counterSets)
@@ -95,8 +107,8 @@ public:
         id<MTLCounterSampleBuffer> counterSampleBuffer = [m_device newCounterSampleBufferWithDescriptor:sampleDescriptor error:&error];
         if (error != nil)
         {
-            NSLog(error.localizedDescription);
-            NSLog(error.localizedFailureReason);
+            NSLog(@"%@", error.localizedDescription);
+            NSLog(@"%@", error.localizedFailureReason);
             TracyMetalPanic("unable to create sample buffer for timestamp counters.", return);
         }
         m_counterSampleBuffer = counterSampleBuffer;
@@ -122,6 +134,23 @@ public:
 
     ~MetalCtx()
     {
+    }
+
+    static MetalCtx* Create(id<MTLDevice> device)
+    {
+        auto ctx = static_cast<MetalCtx*>(tracy_malloc(sizeof(MetalCtx)));
+        new (ctx) MetalCtx(device);
+        if (ctx->m_contextId == 255)
+        {
+            TracyMetalPanic("error during context creation.", Destroy(ctx); return nullptr);
+        }
+        return ctx;
+    }
+
+    static void Destroy(MetalCtx* ctx)
+    {
+        ctx->~MetalCtx();
+        tracy_free(ctx);
     }
 
     void Name( const char* name, uint16_t len )
@@ -179,7 +208,7 @@ public:
             TracyMetalPanic("too many pending timestamp queries.", return false;);
         }
 
-        NSRange range = { };
+        NSRange range = { begin, latestCheckpoint };
         NSData* data = [m_counterSampleBuffer resolveCounterRange:range];
         NSUInteger numResolvedTimestamps = data.length / sizeof(MTLCounterResultTimestamp);
         MTLCounterResultTimestamp* timestamps = (MTLCounterResultTimestamp *)(data.bytes);
@@ -188,7 +217,7 @@ public:
             TracyMetalPanic("unable to resolve timestamps.", return false;);
         }
 
-        for (auto i = begin; i != latestCheckpoint; ++i)
+        for (auto i = 0; i < numResolvedTimestamps; ++i)
         {
             uint32_t k = RingIndex(i);
             MTLTimestamp& timestamp = timestamps[k].timestamp;
@@ -226,9 +255,9 @@ private:
         return static_cast<uint32_t>(count);
     }
 
-    tracy_force_inline unsigned int NextQueryId()
+    tracy_force_inline unsigned int NextQueryId(int n=1)
     {
-        auto id = m_queryCounter.fetch_add(1);
+        auto id = m_queryCounter.fetch_add(n);
         if (RingCount(m_previousCheckpoint, id) >= MaxQueries)
         {
             TracyMetalPanic("too many pending timestamp queries.");
@@ -260,6 +289,33 @@ private:
 class MetalZoneScope
 {
 public:
+    tracy_force_inline MetalZoneScope( MetalCtx* ctx, MTLComputePassDescriptor* desc, const SourceLocationData* srcloc, bool is_active )
+#ifdef TRACY_ON_DEMAND
+        : m_active( is_active && GetProfiler().IsConnected() )
+#else
+        : m_active( is_active )
+#endif
+    {
+        if ( !m_active ) return;
+        if (desc == nil) TracyMetalPanic("pass descriptor is nil.");
+        m_ctx = ctx;
+
+        auto queryId = m_queryId = ctx->NextQueryId(2);
+        desc.sampleBufferAttachments[0].sampleBuffer = ctx->m_counterSampleBuffer;
+        desc.sampleBufferAttachments[0].startOfEncoderSampleIndex = queryId;
+        desc.sampleBufferAttachments[0].endOfEncoderSampleIndex = queryId+1;
+
+        auto* item = Profiler::QueueSerial();
+        MemWrite( &item->hdr.type, QueueType::GpuZoneBeginSerial );
+        MemWrite( &item->gpuZoneBegin.cpuTime, Profiler::GetTime() );
+        MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)srcloc );
+        MemWrite( &item->gpuZoneBegin.thread, GetThreadHandle() );
+        MemWrite( &item->gpuZoneBegin.queryId, uint16_t( queryId ) );
+        MemWrite( &item->gpuZoneBegin.context, ctx->GetContextId() );
+        Profiler::QueueSerialFinish();
+    }
+
+#if 0
     tracy_force_inline MetalZoneScope( MetalCtx* ctx, id<MTLComputeCommandEncoder> cmdEncoder, const SourceLocationData* srcloc, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
@@ -271,7 +327,7 @@ public:
         m_ctx = ctx;
         m_cmdEncoder = cmdEncoder;
 
-        const auto queryId = ctx->NextQueryId();
+        auto queryId = m_queryId = ctx->NextQueryId();
         [m_cmdEncoder sampleCountersInBuffer:m_ctx->m_counterSampleBuffer atSampleIndex:queryId withBarrier:YES];
 
         auto* item = Profiler::QueueSerial();
@@ -284,13 +340,13 @@ public:
 
         Profiler::QueueSerialFinish();
     }
+#endif
 
     tracy_force_inline ~MetalZoneScope()
     {
         if( !m_active ) return;
 
-        const auto queryId = m_ctx->NextQueryId();
-        [m_cmdEncoder sampleCountersInBuffer:m_ctx->m_counterSampleBuffer atSampleIndex:queryId withBarrier:YES];
+        auto queryId = m_queryId + 1;
 
         auto* item = Profiler::QueueSerial();
         MemWrite( &item->hdr.type, QueueType::GpuZoneEndSerial );
@@ -307,27 +363,16 @@ private:
 
     MetalCtx* m_ctx;
     id<MTLComputeCommandEncoder> m_cmdEncoder;
+    uint32_t m_queryId = 0;
 };
 
-static inline MetalCtx* CreateMetalContext(id<MTLDevice> device)
-{
-    auto ctx = (MetalCtx*)tracy_malloc( sizeof( MetalCtx ) );
-    new (ctx) MetalCtx( device );
-    return ctx;
-}
-
-static inline void DestroyMetalContext( MetalCtx* ctx )
-{
-    ctx->~MetalCtx();
-    tracy_free( ctx );
-}
 }
 
 using TracyMetalCtx = tracy::MetalCtx*;
 
-#define TracyMetalContext(device) tracy::CreateMetalContext(device);
-#define TracyMetalDestroy(ctx) tracy::DestroyMetalContext(ctx);
-#define TracyMetalContextName(ctx, name, size) ctx->Name(name, size);
+#define TracyMetalContext(device) tracy::MetalCtx::Create(device)
+#define TracyMetalDestroy(ctx) tracy::MetalCtx::Destroy(ctx)
+#define TracyMetalContextName(ctx, name, size) ctx->Name(name, size)
 
 #if defined TRACY_HAS_CALLSTACK && defined TRACY_CALLSTACK
 #  define TracyMetalZone( ctx, name ) TracyMetalNamedZoneS( ctx, ___tracy_gpu_zone, name, TRACY_CALLSTACK, true )

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -1,6 +1,34 @@
 #ifndef __TRACYMETAL_HMM__
 #define __TRACYMETAL_HMM__
 
+/* The Metal back-end in Tracy operates differently than other GPU back-ends like Vulkan,
+   Direct3D and OpenGL. Specifically, TracyMetalZone() must be placed around the site where
+   a command encoder is created. This is because not all hardware supports timestamps at
+   command granularity, and can only provide timestamps around an entire command encoder.
+   This accommodates for all tiers of hardware; in the future, variants of TracyMetalZone()
+   will be added to support the habitual command-level granularity of Tracy GPU back-ends.
+   Metal also imposes a few restrictions that make the process of requesting and collecting
+   queries more complicated in Tracy:
+   a) timestamp query buffers are limited to 4096 queries (32KB, where each query is 8 bytes)
+   b) when a timestamp query buffer is created, Metal initializes all timestamps with zeroes,
+      and there's no way to reset them back to zero after timestamps get resolved; the only
+      way to clear the timestamps is by allocating a new timestamp query buffer
+   c) if a command encoder records no commands and its corresponding command buffer ends up
+      committed to the command queue, Metal will "optimize-away" the encoder along with any
+      timestamp queries associated with it (the timestamp will remain as zero and will never
+      get resolved)
+   Because of the limitations above, two timestamp buffers are managed internally. Once one
+   of the buffers fills up with requests, the second buffer can start serving new requests.
+   Once all requests in a buffer get resolved and collected, the entire buffer is discarded
+   and a new one allocated for future requests. (Proper cycling through a ring buffer would
+   require bookkeeping and completion handlers to collect only the known complete queries.)
+   In the current implementation, there is potential for a race condition when the buffer is
+   discarded and reallocated. In practice, the race condition will never materialize so long
+   as TracyMetalCollect() is called frequently to keep the amount of unresolved queries low.
+   Finally, there's a timeout mechanism during timestamp collection to detect "empty" command
+   encoders and ensure progress.
+*/
+
 #ifndef TRACY_ENABLE
 
 #define TracyMetalContext(device) nullptr

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -248,11 +248,11 @@ public:
                 TracyMetalPanic("Collect: invalid timestamp: MTLCounterErrorValue (0xFF..FF).");
                 break;
             }
-            if (t_start == 0) // zero is apparently also considered "invalid"...
+            if (t_start == 0 || t_end == 0) // zero is apparently also considered "invalid"...
             {
                 static int HACK_retries = 0;
                 if (++HACK_retries > 8) {
-                    fprintf(stdout, "TracyMetal: Collect: giving up...\n", k, t_start, k+1, t_end);
+                    fprintf(stdout, "TracyMetal: Collect: giving up...\n");
                     t_start = t_end = lastValidTimestamp + 100;
                     HACK_retries = 0;
                 } else {
@@ -280,6 +280,7 @@ public:
             lastValidTimestamp = t_end;
             t_start = t_end = MTLCounterErrorValue;  // "reset" timestamps
         }
+        ZoneValue(RingCount(begin, m_previousCheckpoint.load()));
 
         //RecalibrateClocks();    // to account for drift
 

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -120,7 +120,7 @@ public:
         fprintf(stdout, "TracyMetal: Calibration: GPU timestamp: %llu\n", gpuTimestamp);
         cpuTimestamp = Profiler::GetTime();
         fprintf(stdout, "TracyMetal: Calibration: CPU timestamp (profiler): %llu\n", cpuTimestamp);
-        float period = 1.08f;
+        float period = 1.0f;
         
         m_contextId = GetGpuCtxCounter().fetch_add(1);
         
@@ -131,7 +131,8 @@ public:
         MemWrite(&item->gpuNewContext.thread, uint32_t(0)); // #TODO: why not GetThreadHandle()?
         MemWrite(&item->gpuNewContext.period, period);
         MemWrite(&item->gpuNewContext.context, m_contextId);
-        MemWrite(&item->gpuNewContext.flags, GpuContextCalibration);
+        //MemWrite(&item->gpuNewContext.flags, GpuContextCalibration);
+        MemWrite(&item->gpuNewContext.flags, GpuContextFlags(0));
         MemWrite(&item->gpuNewContext.type, GpuContextType::Metal);
         Profiler::QueueSerialFinish();  // TODO: DeferItem() for TRACY_ON_DEMAND
     }

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -63,6 +63,10 @@ using TracyMetalCtx = void*;
 #define TracyMetalDebug(mask, ...)
 #endif
 
+#ifndef TracyMetalZoneScopeWireTap
+#define TracyMetalZoneScopeWireTap
+#endif//TracyMetalZoneScopeWireTap
+
 namespace tracy
 {
 
@@ -508,6 +512,8 @@ public:
 
         SubmitZoneEndGpu(m_ctx, m_query.idx + 1);
     }
+    
+    TracyMetalZoneScopeWireTap;
 
 private:
     const bool m_active;

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -115,10 +115,12 @@ public:
 
         MTLTimestamp cpuTimestamp = 0;
         MTLTimestamp gpuTimestamp = 0;
-        float period = 1.0f;
         [m_device sampleTimestamps:&cpuTimestamp gpuTimestamp:&gpuTimestamp];
         fprintf(stdout, "TracyMetal: Calibration: CPU timestamp: %llu\n", cpuTimestamp);
         fprintf(stdout, "TracyMetal: Calibration: GPU timestamp: %llu\n", gpuTimestamp);
+        cpuTimestamp = Profiler::GetTime();
+        fprintf(stdout, "TracyMetal: Calibration: CPU timestamp (profiler): %llu\n", cpuTimestamp);
+        float period = 1.08f;
         
         m_contextId = GetGpuCtxCounter().fetch_add(1);
         

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -144,6 +144,12 @@ public:
     ~MetalCtx()
     {
         ZoneScopedNC("~TracyMetalCtx", tracy::Color::Red4);
+        ZoneValue(m_previousCheckpoint.load());
+        ZoneValue(m_queryCounter.load());
+        // collect the last remnants of Metal GPU activity...
+        // TODO: add a timeout to this loop?
+        while (m_previousCheckpoint.load() != m_queryCounter.load())
+            Collect();
     }
 
     static MetalCtx* Create(id<MTLDevice> device)

--- a/public/tracy/TracyMetal.hmm
+++ b/public/tracy/TracyMetal.hmm
@@ -117,6 +117,8 @@ public:
         MTLTimestamp gpuTimestamp = 0;
         float period = 1.0f;
         [m_device sampleTimestamps:&cpuTimestamp gpuTimestamp:&gpuTimestamp];
+        fprintf(stdout, "TracyMetal: Calibration: CPU timestamp: %llu\n", cpuTimestamp);
+        fprintf(stdout, "TracyMetal: Calibration: GPU timestamp: %llu\n", gpuTimestamp);
         
         m_contextId = GetGpuCtxCounter().fetch_add(1);
         
@@ -205,31 +207,38 @@ public:
 
         if (count >= MaxQueries)
         {
-            TracyMetalPanic("too many pending timestamp queries.", return false;);
+            TracyMetalPanic("Collect: too many pending timestamp queries.", return false;);
         }
 
-        NSRange range = { begin, latestCheckpoint };
+        NSRange range = NSMakeRange(begin, count);
         NSData* data = [m_counterSampleBuffer resolveCounterRange:range];
         NSUInteger numResolvedTimestamps = data.length / sizeof(MTLCounterResultTimestamp);
         MTLCounterResultTimestamp* timestamps = (MTLCounterResultTimestamp *)(data.bytes);
         if (timestamps == nil)
         {
-            TracyMetalPanic("unable to resolve timestamps.", return false;);
+            TracyMetalPanic("Collect: unable to resolve timestamps.", return false;);
         }
 
         for (auto i = 0; i < numResolvedTimestamps; ++i)
         {
-            uint32_t k = RingIndex(i);
-            MTLTimestamp& timestamp = timestamps[k].timestamp;
+            MTLTimestamp& timestamp = timestamps[i].timestamp;
             // TODO: check the value of timestamp: MTLCounterErrorValue, zero, or valid
             if (timestamp == MTLCounterErrorValue)
             {
+                TracyMetalPanic("Collect: invalid timestamp: MTLCounterErrorValue (0xFF..FF).");
+                break;
+            }
+            if (timestamp == 0)
+            {
+                TracyMetalPanic("Collect: invalid timestamp: zero.");
                 break;
             }
             m_previousCheckpoint += 1;
+            uint32_t k = RingIndex(begin + i);
+            fprintf(stdout, "TracyMetal: timestamp[%d]: %llu\n", k, timestamp);
             auto* item = Profiler::QueueSerial();
             MemWrite(&item->hdr.type, QueueType::GpuTime);
-            MemWrite(&item->gpuTime.gpuTime, timestamp);
+            MemWrite(&item->gpuTime.gpuTime, static_cast<int64_t>(timestamp));
             MemWrite(&item->gpuTime.queryId, static_cast<uint16_t>(k));
             MemWrite(&item->gpuTime.context, m_contextId);
             Profiler::QueueSerialFinish();
@@ -260,7 +269,7 @@ private:
         auto id = m_queryCounter.fetch_add(n);
         if (RingCount(m_previousCheckpoint, id) >= MaxQueries)
         {
-            TracyMetalPanic("too many pending timestamp queries.");
+            TracyMetalPanic("NextQueryId: too many pending timestamp queries.");
             // #TODO: return some sentinel value; ideally a "hidden" query index
         }
         return RingIndex(id);


### PR DESCRIPTION
(I still need to update the manual, but I'm putting the code here for review to save some time).

The Metal back-end in Tracy operates differently than other GPU back-ends like Vulkan, Direct3D and OpenGL. Specifically, `TracyMetalZone()` must be placed around the site where a command encoder is created.

This is because not all hardware supports timestamps at command granularity, and can only provide timestamps around an entire command encoder. This accommodates for all tiers of hardware; in the future, variants of `TracyMetalZone()` will be added to support the habitual command-level granularity of Tracy GPU back-ends.

Metal also imposes a few restrictions that make the process of requesting and collecting queries more complicated in Tracy:
- timestamp query buffers are limited to 4096 queries (32KB, where each query is 8 bytes)
- when a timestamp query buffer is created, Metal initializes all timestamps with zeroes, and there's no way to reset them back to zero after timestamps get resolved; the only way to clear the timestamps is by allocating a new timestamp query buffer
- if a command encoder records no commands and its corresponding command buffer ends up committed to the command queue, Metal will "optimize-away" the encoder along with any timestamp queries associated with it (the timestamp will remain as zero and will never get resolved)

Because of the limitations above, two timestamp buffers are managed internally. Once one of the buffers fills up with requests, the second buffer can start serving new requests.

Once all requests in a buffer get resolved and collected, the entire buffer is discarded and a new one allocated for future requests. (Proper cycling through a ring buffer would require bookkeeping and completion handlers to collect only the known complete queries.)

In the current implementation, there is potential for a race condition when the buffer is discarded and reallocated. In practice, the race condition will never materialize so long as TracyMetalCollect() is called frequently to keep the amount of unresolved queries low.

Finally, there's a timeout mechanism during timestamp collection to detect "empty" command encoders and ensure progress.