### PR TITLE
Server CMake: Enable multi-processor compilation in Visual Studio projects

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -27,6 +27,7 @@ endif()
 
 if(WIN32)
     add_definitions(-DNOMINMAX -DWIN32_LEAN_AND_MEAN)
+    add_compile_options(/MP)
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=always")


### PR DESCRIPTION
Adds /MP flag to server CMake Windows/Visual Studio configuration, to enable multi-processor compilation. This significantly speeds up clean build times, especially for the profiler.