### PR TITLE
Fix savings calculation.

### DIFF
--- a/profiler/src/profiler/TracyView_Compare.cpp
+++ b/profiler/src/profiler/TracyView_Compare.cpp
@@ -193,23 +193,32 @@ static void PrintSpeedupOrSlowdown( double time_this, double time_external, cons
     double factor = time_this / time_external;
     if( time_external >= time_this )
     {
-        label = "less than external";
+        label = "less";
         color = ImVec4( 0.1f, 0.6f, 0.1f, 1.0f );
     } else {
-        label = "more than external";
+        label = "more";
         color = ImVec4( 0.8f, 0.1f, 0.1f, 1.0f );
     }
-    TextColoredUnformatted( color, metric );
+    ImGui::TextDisabled( "%s:", metric );
     ImGui::SameLine();
-    TextColoredUnformatted(color, time_diff );
+    TextColoredUnformatted( color, time_diff );
     ImGui::SameLine();
     TextColoredUnformatted( color, label );
     ImGui::SameLine();
+    ImGui::TextUnformatted( "than external" );
+    ImGui::SameLine();
     ImGui::Spacing();
     ImGui::SameLine();
-    char buf[64];
-    sprintf(buf, "(%s  =  %.2f%%  %s)", ICON_FA_LEMON, factor * 100, ICON_FA_GEM );
-    TextDisabledUnformatted( buf );
+
+    TextDisabledUnformatted("(");
+    ImGui::SameLine();
+    TextColoredUnformatted( ImVec4( 0xDD/511.f, 0xDD/511.f, 0x22/511.f, 1.f ), ICON_FA_LEMON );
+    ImGui::SameLine();
+    ImGui::TextDisabled("=  %.2f%%", factor * 100 );
+    ImGui::SameLine();
+    TextColoredUnformatted( ImVec4( 0xDD/511.f, 0x22/511.f, 0x22/511.f, 1.f ), ICON_FA_GEM );
+    ImGui::SameLine();
+    TextDisabledUnformatted(")");
 }
 
 void View::DrawCompare()

--- a/profiler/src/profiler/TracyView_Compare.cpp
+++ b/profiler/src/profiler/TracyView_Compare.cpp
@@ -207,10 +207,8 @@ static void PrintSpeedupOrSlowdown( double time_this, double time_external, cons
     ImGui::SameLine();
     ImGui::Spacing();
     ImGui::SameLine();
-    char buf[128];
-    sprintf(buf, "(this %s %c%s is %.2f%% of external %s %c%s)",
-            ICON_FA_LEMON, tolower( metric[0] ), metric + 1, factor * 100,
-            ICON_FA_GEM, tolower( metric[0] ), metric + 1 );
+    char buf[64];
+    sprintf(buf, "(%s  =  %.2f%%  %s)", ICON_FA_LEMON, factor * 100, ICON_FA_GEM );
     TextDisabledUnformatted( buf );
 }
 

--- a/profiler/src/profiler/TracyView_Compare.cpp
+++ b/profiler/src/profiler/TracyView_Compare.cpp
@@ -185,42 +185,35 @@ static void PrintDiff( const std::string& diff )
     }
 }
 
-static void PrintSpeedupOrSlowdown( double time_this, double time_external )
+static void PrintSpeedupOrSlowdown( double time_this, double time_external, const char *metric )
 {
     const char *label, *label2;
     const char *time_diff = TimeToString( abs( time_external - time_this ) );
     ImVec4 color;
-    double factor;
+    double factor = time_this / time_external;
     if( time_external >= time_this )
     {
-        label = "Speedup:", label2 = "faster";
-        color = ImVec4( 0.1f, 0.6f, 0.1f, 1.0f);
-        factor = time_external / time_this;
+        label = "less than external", label2 = "faster";
+        color = ImVec4( 0.1f, 0.6f, 0.1f, 1.0f );
     } else {
-        label = "Slowdown:", label2 = "slower";
+        label = "more than external", label2 = "slower";
         color = ImVec4( 0.8f, 0.1f, 0.1f, 1.0f );
-        factor = time_this / time_external;
     }
-    TextColoredUnformatted( color, label );
+    TextColoredUnformatted( color, metric );
     ImGui::SameLine();
     TextColoredUnformatted(color, time_diff );
     ImGui::SameLine();
-    TextColoredUnformatted( color, label2 );
+    TextColoredUnformatted( color, label );
     ImGui::SameLine();
     ImGui::Spacing();
     ImGui::SameLine();
     char buf[64];
-    memcpy( buf, "( ", 2 );
-    char *ptr = &buf[2];
+    memcpy( buf, "(Time factor compared to external: ", 35 );
+    char *ptr = &buf[35];
     ptr = PrintFloat( ptr, buf + sizeof(buf), factor, 3 );
-    memcpy( ptr, "x ", 2 );
-    ptr += 2;
-    int ssz = strlen( label2 );
-    memcpy( ptr, label2, ssz );
-    ptr += ssz;
-    memcpy( ptr, " )", 3 );
+    memcpy( ptr, ")", 2 );
+    ptr += 23;
     TextDisabledUnformatted( buf );
-
 }
 
 void View::DrawCompare()
@@ -1004,7 +997,7 @@ void View::DrawCompare()
                         ImGui::SameLine();
                         TextFocused( "Total time (ext.):", TimeToString( total1 * adj1 ) );
                         ImGui::Indent();
-                        PrintSpeedupOrSlowdown( total0 * adj0, total1 * adj1 );
+                        PrintSpeedupOrSlowdown( total0 * adj0, total1 * adj1, "Total time" );
                         ImGui::Unindent();
                         TextFocused( "Max counts:", cumulateTime ? TimeToString( maxVal ) : RealToString( floor( maxVal ) ) );
 
@@ -1059,7 +1052,8 @@ void View::DrawCompare()
                             TooltipIfHovered( "Standard deviation" );
                         }
                         ImGui::Indent();
-                        PrintSpeedupOrSlowdown( m_compare.average[0], m_compare.average[1] );
+                        PrintSpeedupOrSlowdown( m_compare.average[0], m_compare.average[1], "Mean time" );
+                        PrintSpeedupOrSlowdown( m_compare.median[0], m_compare.median[1], "Median time" );
                         ImGui::Unindent();
 
                         ImGui::PushStyleColor( ImGuiCol_Text, ImVec4( 0xDD/511.f, 0xDD/511.f, 0x22/511.f, 1.f ) );

--- a/profiler/src/profiler/TracyView_Compare.cpp
+++ b/profiler/src/profiler/TracyView_Compare.cpp
@@ -968,7 +968,7 @@ void View::DrawCompare()
                         TextFocused( "Savings:", TimeToString( total1 * adj1 - total0 * adj0 ) );
                         ImGui::SameLine();
                         char buf[64];
-                        PrintStringPercent( buf, ( total0 * adj0 ) / ( total1 * adj1 ) * 100 );
+                        PrintStringPercent( buf, (1.0 - ( total0 * adj0 ) / ( total1 * adj1 )) * 100 );
                         TextDisabledUnformatted( buf );
                         TextFocused( "Max counts:", cumulateTime ? TimeToString( maxVal ) : RealToString( floor( maxVal ) ) );
 

--- a/profiler/src/profiler/TracyView_Compare.cpp
+++ b/profiler/src/profiler/TracyView_Compare.cpp
@@ -187,16 +187,16 @@ static void PrintDiff( const std::string& diff )
 
 static void PrintSpeedupOrSlowdown( double time_this, double time_external, const char *metric )
 {
-    const char *label, *label2;
+    const char *label;
     const char *time_diff = TimeToString( abs( time_external - time_this ) );
     ImVec4 color;
     double factor = time_this / time_external;
     if( time_external >= time_this )
     {
-        label = "less than external", label2 = "faster";
+        label = "less than external";
         color = ImVec4( 0.1f, 0.6f, 0.1f, 1.0f );
     } else {
-        label = "more than external", label2 = "slower";
+        label = "more than external";
         color = ImVec4( 0.8f, 0.1f, 0.1f, 1.0f );
     }
     TextColoredUnformatted( color, metric );

--- a/profiler/src/profiler/TracyView_Compare.cpp
+++ b/profiler/src/profiler/TracyView_Compare.cpp
@@ -207,12 +207,10 @@ static void PrintSpeedupOrSlowdown( double time_this, double time_external, cons
     ImGui::SameLine();
     ImGui::Spacing();
     ImGui::SameLine();
-    char buf[64];
-    memcpy( buf, "(Time factor compared to external: ", 35 );
-    char *ptr = &buf[35];
-    ptr = PrintFloat( ptr, buf + sizeof(buf), factor, 3 );
-    memcpy( ptr, ")", 2 );
-    ptr += 23;
+    char buf[128];
+    sprintf(buf, "(this %s %c%s is %.2f%% of external %s %c%s)",
+            ICON_FA_LEMON, tolower( metric[0] ), metric + 1, factor * 100,
+            ICON_FA_GEM, tolower( metric[0] ), metric + 1 );
     TextDisabledUnformatted( buf );
 }
 


### PR DESCRIPTION
The fraction printed represented how much of the time was left after the savings are deduced. However, as it's printed after the "Savings:" label, it makes more sense to report how much time of the original one was saved.

Going from 1s to 100ms now reports 90% savings, instead of 10%.