### PR TITLE
Fix processing FrameData with no frames

### DIFF
--- a/profiler/src/profiler/TracyView_FrameTimeline.cpp
+++ b/profiler/src/profiler/TracyView_FrameTimeline.cpp
@@ -95,7 +95,7 @@ void View::DrawTimelineFrames( const FrameData& frames )
 {
     const std::pair <int, int> zrange = m_worker.GetFrameRange( frames, m_vd.zvStart, m_vd.zvEnd );
     if( zrange.first < 0 ) return;
-    if( m_worker.GetFrameBegin( frames, zrange.first ) > m_vd.zvEnd || m_worker.GetFrameEnd( frames, zrange.second ) < m_vd.zvStart ) return;
+    if( m_worker.GetFrameBegin( frames, zrange.first ) > m_vd.zvEnd || m_worker.GetFrameEnd( frames, zrange.second - 1 ) < m_vd.zvStart ) return;
 
     const auto wpos = ImGui::GetCursorScreenPos();
     const auto dpos = wpos + ImVec2( 0.5f, 0.5f );

--- a/profiler/src/profiler/TracyView_Messages.cpp
+++ b/profiler/src/profiler/TracyView_Messages.cpp
@@ -243,7 +243,7 @@ void View::DrawMessageLine( const MessageData& msg, bool hasCallstack, int& idx 
     {
         m_msgHighlight = &msg;
 
-        if( m_showMessageImages )
+        if( m_showMessageImages && m_worker.GetFrameCount( *m_frames ) > 0 )
         {
             const auto frameIdx = m_worker.GetFrameRange( *m_frames, msg.time, msg.time ).first;
             auto fi = m_worker.GetFrameImage( *m_frames, frameIdx );

--- a/profiler/src/profiler/TracyView_Navigation.cpp
+++ b/profiler/src/profiler/TracyView_Navigation.cpp
@@ -74,7 +74,7 @@ void View::ZoomToRange( int64_t start, int64_t end, bool pause )
 
 void View::ZoomToPrevFrame()
 {
-    if( m_vd.zvStart >= m_worker.GetFrameBegin( *m_frames, 0 ) )
+    if( m_worker.GetFrameCount( *m_frames ) > 0 && m_vd.zvStart >= m_worker.GetFrameBegin( *m_frames, 0 ) )
     {
         size_t frame;
         if( m_frames->continuous )
@@ -98,6 +98,8 @@ void View::ZoomToPrevFrame()
 
 void View::ZoomToNextFrame()
 {
+    if( m_worker.GetFrameCount( *m_frames ) == 0 ) return;
+
     int64_t start;
     if( m_zoomAnim.active )
     {
@@ -133,6 +135,7 @@ void View::CenterAtTime( int64_t t )
 void View::SetViewToLastFrames()
 {
     const int total = m_worker.GetFrameCount( *m_frames );
+    if( total == 0 ) return;
 
     m_vd.zvStart = m_worker.GetFrameBegin( *m_frames, std::max( 0, total - 4 ) );
     if( total == 1 )

--- a/profiler/src/profiler/TracyView_Timeline.cpp
+++ b/profiler/src/profiler/TracyView_Timeline.cpp
@@ -310,7 +310,7 @@ void View::DrawTimeline()
         auto& frames = m_worker.GetFrames();
         for( auto fd : frames )
         {
-            if( Vis( fd ) )
+            if( Vis( fd ) && m_worker.GetFrameCount( *fd ) > 0 )
             {
                 DrawTimelineFrames( *fd );
             }

--- a/profiler/src/profiler/TracyView_TraceInfo.cpp
+++ b/profiler/src/profiler/TracyView_TraceInfo.cpp
@@ -183,7 +183,7 @@ void View::DrawInfo()
         ImGui::TreePop();
     }
 
-    if( m_worker.AreFramesUsed() && ImGui::TreeNode( "Frame statistics" ) )
+    if( m_worker.AreFramesUsed() && ImGui::TreeNode( "Frame statistics" ) && m_worker.GetFrameCount( *m_frames ) > 0 )
     {
         auto fsz = m_worker.GetFullFrameCount( *m_frames );
         if( fsz != 0 )

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -2074,6 +2074,7 @@ int64_t Worker::GetFirstTime() const
 
 int64_t Worker::GetFrameTime( const FrameData& fd, size_t idx ) const
 {
+    assert( idx < fd.frames.size() );
     if( fd.continuous )
     {
         if( idx < fd.frames.size() - 1 )
@@ -2108,6 +2109,7 @@ int64_t Worker::GetFrameBegin( const FrameData& fd, size_t idx ) const
 
 int64_t Worker::GetFrameEnd( const FrameData& fd, size_t idx ) const
 {
+    assert( idx < fd.frames.size() );
     if( fd.continuous )
     {
         if( idx < fd.frames.size() - 1 )
@@ -2142,6 +2144,7 @@ const FrameImage* Worker::GetFrameImage( const FrameData& fd, size_t idx ) const
 
 std::pair<int, int> Worker::GetFrameRange( const FrameData& fd, int64_t from, int64_t to )
 {
+    assert( !fd.frames.empty() );
     auto zitbegin = std::lower_bound( fd.frames.begin(), fd.frames.end(), from, [] ( const auto& lhs, const auto& rhs ) { return lhs.start < rhs; } );
     if( zitbegin == fd.frames.end() ) zitbegin--;
 


### PR DESCRIPTION
I'm trying to solve the issue #789 

The #666 partially fixed the problem by allowing us to not use `DeferItem` at all. But it causes some stability issues: ignoring of unpaired `MarkEnd` leaves `FrameData` object with empty `frames`. But the server processing is built around the fact, that `FrameData::frames` are guaranteed to be filled with something (e.g. `Worker::GetFrameRange` goes out-of-bounds if `FrameData::frames` is empty). We've faced this while doing the following:

1. Compile project with `TRACY_ON_DEMAND`
2. Launch `tracy-profiler` and leave it waiting for `127.0.0.1`
3. Launch profiled project
4. `tracy-profiler` crashes

This PR tries to close all possibly unsafe places (`GetFrameBegin/End/Range` shouldn't be called when `FrameData::frames` is empty). The usual stacktrace locally is `View::DrawTimelineFrames( *fd )` -> `Worker::GetFrameRange( *fd )` -> `out-of-bounds on zitbegin--`

The small synthetic example which crashes the master but seems stable with my fix. It should be placed in `examples/test_delay`.
CMakeLists.txt
```
cmake_minimum_required(VERSION 3.17)
set(CMAKE_CXX_STANDARD 17)
project(test_delay)
add_executable(${PROJECT_NAME} main.cpp ../../public/TracyClient.cpp)
target_include_directories(${PROJECT_NAME} PUBLIC ../../public/tracy)
target_compile_definitions(${PROJECT_NAME} PUBLIC TRACY_ENABLE TRACY_ON_DEMAND)
```
main.cpp
```c++
#include <iostream>
#include <thread>
#include <chrono>

#include <../../public/tracy/Tracy.hpp>

constexpr const int N_RUNS=3;

constexpr static const char* runNames[N_RUNS] = {
    "Run0",
    "Run1",
    "Run2"
};

int main(int, char**)
{
    for (int i = 0; i < N_RUNS; ++i)
    {
        std::cout << "Run #" << i << " started" << std::endl;
        FrameMarkStart(runNames[i]);
        std::this_thread::sleep_for(std::chrono::seconds(5));
        FrameMarkEnd(runNames[i]);
        std::cout << "Run #" << i << " finished" << std::endl;
    }

    return 0;
```

P.S. I thought about a way to not let `FrameData` like these into processing in the first place (filtering them somehow) but didn't find a proper place in the code.