### PR TITLE
Fix for assert in GetGpuSourceLocationZonesCntReal

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -3425,7 +3425,10 @@ uint64_t* Worker::GetSourceLocationZonesCntReal( uint16_t srcloc )
 uint64_t* Worker::GetGpuSourceLocationZonesCntReal( uint16_t srcloc )
 {
     auto it = m_data.gpuSourceLocationZonesCnt.find( srcloc );
-    assert( it != m_data.gpuSourceLocationZonesCnt.end() );
+    if( it == m_data.gpuSourceLocationZonesCnt.end() )
+    {
+        it = m_data.gpuSourceLocationZonesCnt.emplace( srcloc, 0 ).first;
+    }
     m_data.gpuCntLast.first = srcloc;
     m_data.gpuCntLast.second = &it->second;
     return &it->second;


### PR DESCRIPTION
When TRACY_NO_STATISTICS is defined, the assert in GetGpuSourceLocationZonesCntReal will always get hit as nothing is ever inserted in gpuSourceLocationZonesCnt unless reading from a file.

Match the behavior with GetGpuSourceLocationZonesReal to add the source location if it is missing.