### PR TITLE
Fix worker AddSourceLocationPayload source file string length calculation

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -3643,7 +3643,8 @@ void Worker::AddSourceLocationPayload( const char* data, size_t sz )
     const auto func = StoreString( data, end - data );
     end++;
 
-    data = end + strlen( data );
+    data = end;
+    end = data + strlen( data );
     const auto source = StoreString( data, end - data );
     end++;
 


### PR DESCRIPTION
Fixes incorrect length calculation for the source file string, which would lead to the source file string being completely wrong and the `StoreString` would have an overflowed size if the file name is longer than the function name.