### PR TITLE
[suggestion] Add .clang-format to help fit the existing coding style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,18 @@
+# Empirical format config, based on observed style guide
+# Use this only as an help to fit the surrounding code style - don't reformat whole files at once
+---
+BasedOnStyle: LLVM
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Allman
+BreakConstructorInitializers: BeforeComma
+BreakStringLiterals: false
+ColumnLimit: 120
+FixNamespaceComments: false
+IndentPPDirectives: AfterHash
+IndentWidth: 4
+PointerAlignment: Left
+SpaceBeforeParens: Never
+SpacesInParentheses: true
+TabWidth: 4

--- a/public/common/TracyProtocol.hpp
+++ b/public/common/TracyProtocol.hpp
@@ -9,17 +9,32 @@ namespace tracy
 
 constexpr unsigned Lz4CompressBound( unsigned isize ) { return isize + ( isize / 255 ) + 16; }
 
-enum : uint32_t { ProtocolVersion = 66 };
-enum : uint16_t { BroadcastVersion = 3 };
+enum : uint32_t
+{
+    ProtocolVersion = 66
+};
+enum : uint16_t
+{
+    BroadcastVersion = 3
+};
 
 using lz4sz_t = uint32_t;
 
-enum { TargetFrameSize = 256 * 1024 };
-enum { LZ4Size = Lz4CompressBound( TargetFrameSize ) };
-static_assert( LZ4Size <= (std::numeric_limits<lz4sz_t>::max)(), "LZ4Size greater than lz4sz_t" );
+enum
+{
+    TargetFrameSize = 256 * 1024
+};
+enum
+{
+    LZ4Size = Lz4CompressBound( TargetFrameSize )
+};
+static_assert( LZ4Size <= ( std::numeric_limits<lz4sz_t>::max )(), "LZ4Size greater than lz4sz_t" );
 static_assert( TargetFrameSize * 2 >= 64 * 1024, "Not enough space for LZ4 stream buffer" );
 
-enum { HandshakeShibbolethSize = 8 };
+enum
+{
+    HandshakeShibbolethSize = 8
+};
 static const char HandshakeShibboleth[HandshakeShibbolethSize] = { 'T', 'r', 'a', 'c', 'y', 'P', 'r', 'f' };
 
 enum HandshakeStatus : uint8_t
@@ -31,8 +46,14 @@ enum HandshakeStatus : uint8_t
     HandshakeDropped
 };
 
-enum { WelcomeMessageProgramNameSize = 64 };
-enum { WelcomeMessageHostInfoSize = 1024 };
+enum
+{
+    WelcomeMessageProgramNameSize = 64
+};
+enum
+{
+    WelcomeMessageHostInfoSize = 1024
+};
 
 #pragma pack( push, 1 )
 
@@ -65,8 +86,10 @@ struct ServerQueryPacket
     uint32_t extra;
 };
 
-enum { ServerQueryPacketSize = sizeof( ServerQueryPacket ) };
-
+enum
+{
+    ServerQueryPacketSize = sizeof( ServerQueryPacket )
+};
 
 enum CpuArchitecture : uint8_t
 {
@@ -77,15 +100,14 @@ enum CpuArchitecture : uint8_t
     CpuArchArm64
 };
 
-
 struct WelcomeFlag
 {
     enum _t : uint8_t
     {
-        OnDemand        = 1 << 0,
-        IsApple         = 1 << 1,
-        CodeTransfer    = 1 << 2,
-        CombineSamples  = 1 << 3,
+        OnDemand = 1 << 0,
+        IsApple = 1 << 1,
+        CodeTransfer = 1 << 2,
+        CombineSamples = 1 << 3,
         IdentifySamples = 1 << 4,
     };
 };
@@ -109,8 +131,10 @@ struct WelcomeMessage
     char hostInfo[WelcomeMessageHostInfoSize];
 };
 
-enum { WelcomeMessageSize = sizeof( WelcomeMessage ) };
-
+enum
+{
+    WelcomeMessageSize = sizeof( WelcomeMessage )
+};
 
 struct OnDemandPayloadMessage
 {
@@ -118,8 +142,10 @@ struct OnDemandPayloadMessage
     uint64_t currentTime;
 };
 
-enum { OnDemandPayloadMessageSize = sizeof( OnDemandPayloadMessage ) };
-
+enum
+{
+    OnDemandPayloadMessageSize = sizeof( OnDemandPayloadMessage )
+};
 
 struct BroadcastMessage
 {
@@ -127,7 +153,7 @@ struct BroadcastMessage
     uint16_t listenPort;
     uint32_t protocolVersion;
     uint64_t pid;
-    int32_t activeTime;        // in seconds
+    int32_t activeTime; // in seconds
     char programName[WelcomeMessageProgramNameSize];
 };
 
@@ -157,10 +183,22 @@ struct BroadcastMessage_v0
     char programName[WelcomeMessageProgramNameSize];
 };
 
-enum { BroadcastMessageSize = sizeof( BroadcastMessage ) };
-enum { BroadcastMessageSize_v2 = sizeof( BroadcastMessage_v2 ) };
-enum { BroadcastMessageSize_v1 = sizeof( BroadcastMessage_v1 ) };
-enum { BroadcastMessageSize_v0 = sizeof( BroadcastMessage_v0 ) };
+enum
+{
+    BroadcastMessageSize = sizeof( BroadcastMessage )
+};
+enum
+{
+    BroadcastMessageSize_v2 = sizeof( BroadcastMessage_v2 )
+};
+enum
+{
+    BroadcastMessageSize_v1 = sizeof( BroadcastMessage_v1 )
+};
+enum
+{
+    BroadcastMessageSize_v0 = sizeof( BroadcastMessage_v0 )
+};
 
 #pragma pack( pop )
 


### PR DESCRIPTION
While working on #825 I found useful to spin up this config file to be able to fit the existing coding style.

It's not perfect, but I already goes a long way; maybe you'd be interested ?

Known caveats:
- could not manage to keep small enum on a single line
- you put 2 spaces in ifdefs (instead of the 4 elsewhere), haven't managed to replicate it
- it's not possible to remove the spaces around binary operators https://github.com/llvm/llvm-project/issues/31431
 
I committed 2 files so you can quickly look at the diff and get a sense of how files are affected