### PR TITLE
fix CpuId when compiling with clang on windows

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -308,7 +308,7 @@ struct ThreadHandleWrapper
 static inline void CpuId( uint32_t* regs, uint32_t leaf )
 {
     memset(regs, 0, sizeof(uint32_t) * 4);
-#if defined _WIN32
+#if defined _MSC_VER
     __cpuidex( (int*)regs, leaf, 0 );
 #else
     __get_cpuid( leaf, regs, regs+1, regs+2, regs+3 );


### PR DESCRIPTION
The `__cpuidex` intrinsic is only offered by msvc. 
```
PS C:\Users\Techatrix\zls> zig c++ --version
clang version 18.1.7 (https://github.com/ziglang/zig-bootstrap ec2dca85a340f134d2fcfdc9007e91f9abed6996)
Target: x86_64-unknown-windows-gnu  
Thread model: posix
InstalledDir: C:/Users/Techatrix/zls

PS C:\Users\Techatrix\zls> zig c++ -c .\src\tracy\public\TracyClient.cpp -DTRACY_ENABLE=1
In file included from .\src\tracy\public\TracyClient.cpp:23:
.\src\tracy\public/client/TracyProfiler.cpp:312:5: error: use of undeclared identifier '__cpuidex'
  312 |     __cpuidex( (int*)regs, leaf, 0 );
      |     ^
1 error generated.
```