### PR TITLE
Expose `TRACY_VERBOSE` in cmake for debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ set_option(TRACY_SYMBOL_OFFLINE_RESOLVE "Instead of full runtime symbol resoluti
 set_option(TRACY_LIBBACKTRACE_ELF_DYNLOAD_SUPPORT "Enable libbacktrace to support dynamically loaded elfs in symbol resolution resolution after the first symbol resolve operation" OFF)
 
 # advanced
+set_option(TRACY_VERBOSE "[advanced] Verbose output from the profiler" OFF)
+mark_as_advanced(TRACY_VERBOSE)
 set_option(TRACY_DEMANGLE "[advanced] Don't use default demangling function - You'll need to provide your own" OFF)
 mark_as_advanced(TRACY_DEMANGLE)
 

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -638,6 +638,10 @@ Although the basic features will work without them, you'll have to grant elevate
     \item \texttt{-{}-pid=host}
 \end{itemize}
 
+\subsubsection{Troubleshooting}
+
+Setting the \texttt{TRACY\_VERBOSE} variable will make the client display advanced information about the detected features. By matching those debug prints to the source code, you might be able to uncover why some of the features are missing on your platform.
+
 \subsubsection{Changing network port}
 
 By default, the client and server communicate on the network using port 8086. The profiling session utilizes the TCP protocol, and the client sends presence announcement broadcasts over UDP.


### PR DESCRIPTION
Proved very useful to debug kernel permissions issues ! I did not know it existed, so I added a small entry in the doc to mention it. It seems that's a frequent topic of discussion in the discord, that might help newcomers debug by themselves