### PR TITLE
Find libunwind if requested so we can link to it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,13 @@ if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
     target_link_libraries(TracyClient PUBLIC ${EXECINFO_LIBRARY})
 endif()
 
+if(TRACY_LIBUNWIND_BACKTRACE)
+    include(FindPkgConfig)
+    pkg_check_modules(unwind REQUIRED libunwind)
+    target_include_directories(TracyClient INTERFACE ${unwind_INCLUDE_DIRS})
+    target_link_libraries(TracyClient INTERFACE ${unwind_LINK_LIBRARIES})
+endif()
+
 add_library(Tracy::TracyClient ALIAS TracyClient)
 
 macro(set_option option help value)


### PR DESCRIPTION
When I link my programs to the client library, `libunwind` symbols are unresolved.

This patch addresses that issue.  I have seen that the meson script also does a similar thing.

I'm not so sure about the position of the fix inside the CMakeLists.txt, but I hope it is ok.