### PR TITLE
Remove constexpr from GetSamplingInterval

### DIFF
--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -330,7 +330,7 @@ static void SetupVsync()
 #endif
 }
 
-static constexpr int GetSamplingInterval()
+static int GetSamplingInterval()
 {
     return GetSamplingPeriod() / 100;
 }


### PR DESCRIPTION
GetSamplingInterval relies on functions that had their constexpr removed [here](https://github.com/wolfpld/tracy/commit/fb18a81d79933e50231aa345b5112a5ec0fb0613).

Should remove constexpr here as well