### PR TITLE
Fix ThreadData-sorting bug.

### DIFF
--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -715,10 +715,17 @@ bool View::DrawImpl()
     auto& threadHints = m_worker.GetPendingThreadHints();
     if( !threadHints.empty() )
     {
+        m_threadReinsert.reserve( threadHints.size()  );
         for( auto v : threadHints )
         {
             auto it = std::find_if( m_threadOrder.begin(), m_threadOrder.end(), [v]( const auto& t ) { return t->id == v; } );
-            if( it != m_threadOrder.end() ) m_threadOrder.erase( it );      // Will be added in the correct place later, like any newly appearing thread
+            if( it != m_threadOrder.end() )
+            {
+                // Will be reinserted in the correct place later.
+                // A separate list is kept of threads that were already known to avoid having to figure out which one is missing in m_threadOrder.
+                m_threadReinsert.push_back( *it );
+                m_threadOrder.erase( it );
+            }
         }
         m_worker.ClearPendingThreadHints();
     }

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -386,6 +386,7 @@ private:
     unordered_flat_map<const void*, int> m_gpuDrift;
     unordered_flat_map<const PlotData*, PlotView> m_plotView;
     Vector<const ThreadData*> m_threadOrder;
+    Vector<const ThreadData*> m_threadReinsert;
     Vector<float> m_threadDnd;
 
     tracy_force_inline bool& VisibleMsgThread( uint64_t thread )


### PR DESCRIPTION
For a detailed analysis of what was the bug, see [#875](https://github.com/wolfpld/tracy/issues/875#issuecomment-2341232551). Closes #875. But in summary, the bug is due to the fact the sorting code assumes any difference in number of items in `m_threadOrder` and `worker.GetThreadData()` is exclusively due to the elements in the end of `Worker::GetThreadData()`. On the surface, this is true, but the erasing logic to process Thread Hints breaks this assumed invariant.