### PR TITLE
Implement Zones inheriting colors from parent Zones as an option.

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3412,6 +3412,7 @@ In this window, you can set various trace-related options. For example, the time
 \item \emph{Source location dynamic} -- Zone color is determined by source location (function name) and depth level.
 \end{itemize}
 Enabling the \emph{Ignore custom} option will force usage of the selected zone coloring scheme, disregarding any colors set by the user in profiled code.
+Enabling the \emph{Inherit parent colors} option will cause zones that have a color set by the user in the profiled code to be propagated down to the child zones, although slightly darker.
 \item \emph{\faRulerHorizontal{} Zone name shortening} -- controls display behavior of long zone names, which don't fit inside a zone box:
 \begin{itemize}
 \item \emph{Disabled} -- Shortening of zone names is not performed and names are always displayed in full (e.g.\ \texttt{bool ns::container<float>::add(const float\&)}).

--- a/profiler/src/profiler/TracyColor.hpp
+++ b/profiler/src/profiler/TracyColor.hpp
@@ -20,6 +20,14 @@ static tracy_force_inline uint32_t HighlightColor( uint32_t color )
         ( std::min<int>( 0xFF, ( ( ( color & 0x000000FF )       ) + V ) )       );
 }
 
+static tracy_force_inline uint32_t DarkenColorSlightly( uint32_t color )
+{
+    return 0xFF000000 |
+        ( ( ( ( color & 0x00FF0000 ) >> 16 ) * 4 / 5 ) << 16 ) |
+        ( ( ( ( color & 0x0000FF00 ) >> 8  ) * 4 / 5 ) << 8  ) |
+        ( ( ( ( color & 0x000000FF )       ) * 4 / 5 )       );
+}
+
 static tracy_force_inline uint32_t DarkenColor( uint32_t color )
 {
     return 0xFF000000 |

--- a/profiler/src/profiler/TracyTimelineDraw.hpp
+++ b/profiler/src/profiler/TracyTimelineDraw.hpp
@@ -24,6 +24,7 @@ struct TimelineDraw
     short_ptr<void*> ev;
     Int48 rend;
     uint32_t num;
+    uint32_t customColor;
 };
 
 

--- a/profiler/src/profiler/TracyTimelineItemThread.hpp
+++ b/profiler/src/profiler/TracyTimelineItemThread.hpp
@@ -37,10 +37,10 @@ private:
 #ifndef TRACY_NO_STATISTICS
     int PreprocessGhostLevel( const TimelineContext& ctx, const Vector<GhostZone>& vec, int depth, bool visible );
 #endif
-    int PreprocessZoneLevel( const TimelineContext& ctx, const Vector<short_ptr<ZoneEvent>>& vec, int depth, bool visible );
+    int PreprocessZoneLevel( const TimelineContext& ctx, const Vector<short_ptr<ZoneEvent>>& vec, int depth, bool visible, uint32_t parentCustomColor );
 
     template<typename Adapter, typename V>
-    int PreprocessZoneLevel( const TimelineContext& ctx, const V& vec, int depth, bool visible );
+    int PreprocessZoneLevel( const TimelineContext& ctx, const V& vec, int depth, bool visible, uint32_t parentCustomColor );
 
     void PreprocessContextSwitches( const TimelineContext& ctx, const ContextSwitch& ctxSwitch, bool visible );
     void PreprocessSamples( const TimelineContext& ctx, const Vector<SampleData>& vec, bool visible, int yPos );

--- a/profiler/src/profiler/TracyUserData.cpp
+++ b/profiler/src/profiler/TracyUserData.cpp
@@ -145,6 +145,7 @@ void UserData::LoadState( ViewData& data )
                 if( ini_sget( ini, "options", "drawCpuUsageGraph", "%d", &v ) ) data.drawCpuUsageGraph = v;
                 if( ini_sget( ini, "options", "drawSamples", "%d", &v ) ) data.drawSamples = v;
                 if( ini_sget( ini, "options", "dynamicColors", "%d", &v ) ) data.dynamicColors = v;
+                if( ini_sget( ini, "options", "inheritParentColors", "%d", &v ) ) data.inheritParentColors = v;
                 if( ini_sget( ini, "options", "forceColors", "%d", &v ) ) data.forceColors = v;
                 if( ini_sget( ini, "options", "ghostZones", "%d", &v ) ) data.ghostZones = v;
                 if( ini_sget( ini, "options", "frameTarget", "%d", &v ) ) data.frameTarget = v;
@@ -194,6 +195,7 @@ void UserData::SaveState( const ViewData& data )
         fprintf( f, "drawCpuUsageGraph = %d\n", data.drawCpuUsageGraph );
         fprintf( f, "drawSamples = %d\n", data.drawSamples );
         fprintf( f, "dynamicColors = %d\n", data.dynamicColors );
+        fprintf( f, "inheritParentColors = %d\n", data.inheritParentColors );
         fprintf( f, "forceColors = %d\n", data.forceColors );
         fprintf( f, "ghostZones = %d\n", data.ghostZones );
         fprintf( f, "frameTarget = %d\n", data.frameTarget );

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -308,14 +308,17 @@ private:
 
     void AddAnnotation( int64_t start, int64_t end );
 
+public:
     uint32_t GetThreadColor( uint64_t thread, int depth );
     uint32_t GetSrcLocColor( const SourceLocation& srcloc, int depth );
     uint32_t GetRawSrcLocColor( const SourceLocation& srcloc, int depth );
-    uint32_t GetZoneColor( const ZoneEvent& ev, uint64_t thread, int depth );
+    uint32_t GetZoneColor( const ZoneEvent& ev, uint64_t thread, int depth, uint32_t customColor );
+    uint32_t GetZoneCustomColor( const ZoneEvent& ev, uint64_t thread );
     uint32_t GetZoneColor( const GpuEvent& ev );
-    ZoneColorData GetZoneColorData( const ZoneEvent& ev, uint64_t thread, int depth );
+    ZoneColorData GetZoneColorData( const ZoneEvent& ev, uint64_t thread, int depth, uint32_t customColor );
     ZoneColorData GetZoneColorData( const GpuEvent& ev );
 
+private:
     void ZoomToZone( const ZoneEvent& ev );
     void ZoomToZone( const GpuEvent& ev );
     void ZoomToPrevFrame();
@@ -331,6 +334,7 @@ private:
     void CallstackTooltipContents( uint32_t idx );
     void CrashTooltip();
 
+public:
     const ZoneEvent* GetZoneParent( const ZoneEvent& zone ) const;
     const ZoneEvent* GetZoneParent( const ZoneEvent& zone, uint64_t tid ) const;
     const ZoneEvent* GetZoneChild( const ZoneEvent& zone, int64_t time ) const;
@@ -348,6 +352,7 @@ private:
     const char* GetFrameSetName( const FrameData& fd ) const;
     static const char* GetFrameSetName( const FrameData& fd, const Worker& worker );
 
+private:
 #ifndef TRACY_NO_STATISTICS
     void FindZones();
     void FindZonesCompare();

--- a/profiler/src/profiler/TracyViewData.hpp
+++ b/profiler/src/profiler/TracyViewData.hpp
@@ -53,6 +53,7 @@ struct ViewData
     uint8_t drawCpuUsageGraph = true;
     uint8_t drawSamples = true;
     uint8_t dynamicColors = 1;
+    uint8_t inheritParentColors = 1;
     uint8_t forceColors = false;
     uint8_t ghostZones = true;
     ShortenName shortenName = ShortenName::NoSpaceAndNormalize;

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -225,6 +225,9 @@ void View::DrawOptions()
     ImGui::SameLine();
     bool forceColors = m_vd.forceColors;
     if( SmallCheckbox( "Ignore custom", &forceColors ) ) m_vd.forceColors = forceColors;
+    ImGui::SameLine();
+    bool inheritColors = m_vd.inheritParentColors;
+    if( SmallCheckbox( "Inherit parent colors", &inheritColors ) ) m_vd.inheritParentColors = inheritColors;
     ImGui::Indent();
     ImGui::PushStyleVar( ImGuiStyleVar_FramePadding, ImVec2( 0, 0 ) );
     ImGui::RadioButton( "Static", &ival, 0 );

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -223,7 +223,7 @@ void View::DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineD
         case TimelineDrawType::Folded:
         {
             auto& ev = *(const ZoneEvent*)v.ev.get();
-            const auto color = m_vd.dynamicColors == 2 ? 0xFF666666 : GetThreadColor( tid, v.depth );
+            const auto color = m_vd.dynamicColors == 2 ? 0xFF666666 : DarkenColor( GetZoneColor( ev, tid, v.depth, v.customColor ) );
             const auto rend = v.rend.Val();
             const auto px0 = ( ev.Start() - vStart ) * pxns;
             const auto px1 = ( rend - vStart ) * pxns;
@@ -284,7 +284,7 @@ void View::DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineD
             auto& ev = *(const ZoneEvent*)v.ev.get();
             const auto end = m_worker.GetZoneEnd( ev );
             const auto zsz = std::max( ( end - ev.Start() ) * pxns, pxns * 0.5 );
-            const auto zoneColor = GetZoneColorData( ev, tid, v.depth );
+            const auto zoneColor = GetZoneColorData( ev, tid, v.depth, v.customColor );
             const char* zoneName = m_worker.GetZoneName( ev );
 
             auto tsz = ImGui::CalcTextSize( zoneName );


### PR DESCRIPTION
Option for coloring zones without custom color by inheriting it from a parent that has a custom color. If inherited, the color is made slightly darker to distinguish the "sources" of the colors and the ones inheriting from each other.

Option saved to ini file.

Performance considerations:
 
 - parents only fetched when feature enabled _and_ zone-to-be-drawn does not have a custom color.
 - parent array is `alloca()`'d

Screenshot without:

![image](https://github.com/user-attachments/assets/3c3ee730-0aa0-4994-9545-0e825466c05e)

With:

![image](https://github.com/user-attachments/assets/f270379a-105b-45c1-ad56-9345aa199246)

