### PR TITLE
Fix inheriting color bug.

### DIFF
--- a/profiler/src/profiler/TracyTimelineItemThread.cpp
+++ b/profiler/src/profiler/TracyTimelineItemThread.cpp
@@ -400,7 +400,7 @@ int TimelineItemThread::PreprocessGhostLevel( const TimelineContext& ctx, const 
 }
 #endif
 
-int TimelineItemThread::PreprocessZoneLevel( const TimelineContext& ctx, const Vector<short_ptr<ZoneEvent>>& vec, int depth, bool visible, uint32_t inheritedColor )
+int TimelineItemThread::PreprocessZoneLevel( const TimelineContext& ctx, const Vector<short_ptr<ZoneEvent>>& vec, int depth, bool visible, const uint32_t inheritedColor )
 {
     if( vec.is_magic() )
     {
@@ -413,7 +413,7 @@ int TimelineItemThread::PreprocessZoneLevel( const TimelineContext& ctx, const V
 }
 
 template<typename Adapter, typename V>
-int TimelineItemThread::PreprocessZoneLevel( const TimelineContext& ctx, const V& vec, int depth, bool visible, uint32_t inheritedColor )
+int TimelineItemThread::PreprocessZoneLevel( const TimelineContext& ctx, const V& vec, int depth, bool visible, const uint32_t inheritedColor )
 {
     const auto vStart = ctx.vStart;
     const auto vEnd = ctx.vEnd;
@@ -458,6 +458,7 @@ int TimelineItemThread::PreprocessZoneLevel( const TimelineContext& ctx, const V
         {
             const auto hasChildren = ev.HasChildren();
             auto currentInherited = inheritedColor;
+            auto childrenInherited = inheritedColor;
             if( m_view.GetViewData().inheritParentColors )
             {
                 uint32_t color = 0;
@@ -474,12 +475,12 @@ int TimelineItemThread::PreprocessZoneLevel( const TimelineContext& ctx, const V
                 if( color != 0 )
                 {
                     currentInherited = color | 0xFF000000;
-                    if( hasChildren ) inheritedColor = DarkenColorSlightly( color );
+                    if( hasChildren ) childrenInherited = DarkenColorSlightly( color );
                 }
             }
             if( hasChildren )
             {
-                const auto d = PreprocessZoneLevel( ctx, m_worker.GetZoneChildren( ev.Child() ), depth + 1, visible, inheritedColor );
+                const auto d = PreprocessZoneLevel( ctx, m_worker.GetZoneChildren( ev.Child() ), depth + 1, visible, childrenInherited );
                 if( d > maxdepth ) maxdepth = d;
             }
             if( visible ) m_draw.emplace_back( TimelineDraw { TimelineDrawType::Zone, uint16_t( depth ), (void**)&ev, 0, 0, currentInherited } );

--- a/profiler/src/profiler/TracyTimelineItemThread.hpp
+++ b/profiler/src/profiler/TracyTimelineItemThread.hpp
@@ -37,10 +37,10 @@ private:
 #ifndef TRACY_NO_STATISTICS
     int PreprocessGhostLevel( const TimelineContext& ctx, const Vector<GhostZone>& vec, int depth, bool visible );
 #endif
-    int PreprocessZoneLevel( const TimelineContext& ctx, const Vector<short_ptr<ZoneEvent>>& vec, int depth, bool visible, uint32_t inheritedColor );
+    int PreprocessZoneLevel( const TimelineContext& ctx, const Vector<short_ptr<ZoneEvent>>& vec, int depth, bool visible, const uint32_t inheritedColor );
 
     template<typename Adapter, typename V>
-    int PreprocessZoneLevel( const TimelineContext& ctx, const V& vec, int depth, bool visible, uint32_t inheritedColor );
+    int PreprocessZoneLevel( const TimelineContext& ctx, const V& vec, int depth, bool visible, const uint32_t inheritedColor );
 
     void PreprocessContextSwitches( const TimelineContext& ctx, const ContextSwitch& ctxSwitch, bool visible );
     void PreprocessSamples( const TimelineContext& ctx, const Vector<SampleData>& vec, bool visible, int yPos );


### PR DESCRIPTION
Marked it as `const` to see better what the issue was. That's also why in my original PR, it was named "parent color": that makes clearer that it shouldn't be touched.