### PR TITLE
Safe copy to fix issue #888

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1473,10 +1473,11 @@ Profiler::Profiler()
     m_pipeBufSize = 16384;
 #  else
     m_pipeBufSize = (int)(ptrdiff_t)m_safeSendBufferSize;
-    while( fcntl( m_pipe[0], F_SETPIPE_SZ, m_pipeBufSize ) == -1 && errno == EPERM )
+    while( fcntl( m_pipe[0], F_SETPIPE_SZ, m_pipeBufSize ) < 0 && errno == EPERM )
         m_pipeBufSize /= 2; // too big; reduce
     m_pipeBufSize = fcntl( m_pipe[0], F_GETPIPE_SZ );
 #  endif
+    fcntl( m_pipe[1], F_SETFL, O_NONBLOCK );
 #endif
 
 #if !defined(TRACY_DELAYED_INIT) || !defined(TRACY_MANUAL_LIFETIME)

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1463,7 +1463,6 @@ Profiler::Profiler()
         m_userPort = atoi( userPort );
     }
 
-    m_safeSendBufferSize = 65536;
     m_safeSendBuffer = (char*)tracy_malloc( m_safeSendBufferSize );
 
 #ifndef _WIN32
@@ -1528,7 +1527,7 @@ void Profiler::RemoveCrashHandler()
 #if defined __linux__ && !defined TRACY_NO_CRASH_HANDLER
     if( m_crashHandlerInstalled )
     {
-        auto restore = [ this ]( int signum, struct sigaction* prev ) {
+        auto restore = []( int signum, struct sigaction* prev ) {
             struct sigaction old;
             sigaction( signum, prev, &old );
             if( old.sa_sigaction != CrashHandler ) sigaction( signum, &old, nullptr ); // A different signal handler was installed over ours => put it back

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -862,7 +862,7 @@ private:
         // Send through the pipe to ensure safe reads
         for( size_t offset = 0; offset != size; /*in loop*/ )
         {
-            size_t sendsize = std::min( size - offset, (size_t)(ptrdiff_t)m_pipeBufSize );
+            size_t sendsize = size - offset;
             ssize_t result1, result2;
             while( ( result1 = write( m_pipe[1], p + offset, sendsize ) ) < 0 && errno == EINTR )
                 /* retry */;

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -1010,7 +1010,7 @@ private:
     std::atomic_bool m_inUse{ false };
 #endif
     char* m_safeSendBuffer;
-    size_t m_safeSendBufferSize;
+    constexpr static size_t m_safeSendBufferSize = 65536;
 
 #if defined _WIN32
     void* m_prevHandler;

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -1063,9 +1063,7 @@ private:
     char* m_safeSendBuffer;
     size_t m_safeSendBufferSize;
 
-#if defined _WIN32
-    void* m_exceptionHandler;
-#else
+#ifndef _WIN32
     int m_pipe[2];
     int m_pipeBufSize;
 #endif

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -1012,7 +1012,9 @@ private:
     char* m_safeSendBuffer;
     size_t m_safeSendBufferSize;
 
-#ifndef _WIN32
+#if defined _WIN32
+    void* m_prevHandler;
+#else
     int m_pipe[2];
     int m_pipeBufSize;
 #endif

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -1010,7 +1010,6 @@ private:
     std::atomic_bool m_inUse{ false };
 #endif
     char* m_safeSendBuffer;
-    constexpr static size_t m_safeSendBufferSize = 65536;
 
 #if defined _WIN32
     void* m_prevHandler;


### PR DESCRIPTION
Fix for issue #888 

Instead of attempting to read potentially unsafe memory that may be in a module that unloaded, this uses Structured Exception Handling on Windows or pipes on POSIX platforms to ensure that the entire memory region can be read.