### PR TITLE
Added Custom GPU Context Type

### DIFF
--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -38,7 +38,8 @@ constexpr const char* GpuContextNames[] = {
     "OpenCL",
     "Direct3D 12",
     "Direct3D 11",
-    "Metal"
+    "Metal",
+    "Custom"
 };
 
 struct MemoryPage;

--- a/public/common/TracyProtocol.hpp
+++ b/public/common/TracyProtocol.hpp
@@ -9,7 +9,7 @@ namespace tracy
 
 constexpr unsigned Lz4CompressBound( unsigned isize ) { return isize + ( isize / 255 ) + 16; }
 
-enum : uint32_t { ProtocolVersion = 70 };
+enum : uint32_t { ProtocolVersion = 71 };
 enum : uint16_t { BroadcastVersion = 3 };
 
 using lz4sz_t = uint32_t;

--- a/public/common/TracyQueue.hpp
+++ b/public/common/TracyQueue.hpp
@@ -402,7 +402,8 @@ enum class GpuContextType : uint8_t
     OpenCL,
     Direct3D12,
     Direct3D11,
-    Metal
+    Metal,
+    Custom
 };
 
 enum GpuContextFlags : uint8_t


### PR DESCRIPTION
It is possible to implement custom integration in GPU zones submission
That works, but unfortunately you need to pretend to be one of existing integrations for such setup to work
This PR adds "Custom" GPU Context Type specifically for this usecase
It is by design will not be implemented in Tracy repo, and user is free to use it for custom integrations
![image](https://github.com/user-attachments/assets/24703539-4782-4086-a7e2-cd32cabfa8df)
