### PR TITLE
Install header files into one folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,9 +178,9 @@ export(TARGETS TracyClient
 install(FILES ${tracy_includes}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tracy)
 install(FILES ${client_includes}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/client)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tracy/client)
 install(FILES ${common_includes}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/common)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tracy/common)
 install(EXPORT TracyConfig
         NAMESPACE Tracy::
         FILE TracyTargets.cmake

--- a/meson.build
+++ b/meson.build
@@ -205,8 +205,8 @@ tracy = library('tracy', tracy_src, tracy_header_files,
     install             : true)
 
 install_headers(includes, subdir : 'tracy')
-install_headers(common_includes, subdir : 'common')
-install_headers(client_includes, subdir : 'client')
+install_headers(common_includes, subdir : 'tracy/common')
+install_headers(client_includes, subdir : 'tracy/client')
 
 tracy_dep_compile_args = tracy_common_args
 


### PR DESCRIPTION
all headers from one project are best kept in one place
without this the headers would be spewed all over the include directory in your prefix