### PR TITLE
Fix upper limit of unique SourceLocations w.r.t. manual

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -3298,7 +3298,7 @@ int16_t Worker::ShrinkSourceLocationReal( uint64_t srcloc )
 
 int16_t Worker::NewShrinkedSourceLocation( uint64_t srcloc )
 {
-    assert( m_data.sourceLocationExpand.size() < std::numeric_limits<int16_t>::max() );
+    assert( m_data.sourceLocationExpand.size() < std::numeric_limits<uint16_t>::max() );
     const auto sz = int16_t( m_data.sourceLocationExpand.size() );
     m_data.sourceLocationExpand.push_back( srcloc );
 #ifndef TRACY_NO_STATISTICS


### PR DESCRIPTION
The manual mentions 65534 unique source locations:
https://github.com/wolfpld/tracy/blob/1bd84419c09dae2b5f9e2c8f5e29697e911fed38/manual/tracy.tex#L667

So it looks like the current assert is wrong:
https://github.com/wolfpld/tracy/blob/1bd84419c09dae2b5f9e2c8f5e29697e911fed38/server/TracyWorker.cpp#L3336

and should be:
```
assert( m_data.sourceLocationExpand.size() < std::numeric_limits<uint16_t>::max() );
```