### PR TITLE
Silence GCC fscanf warning in TracySysPower.cpp

### DIFF
--- a/public/client/TracySysPower.cpp
+++ b/public/client/TracySysPower.cpp
@@ -85,7 +85,7 @@ void SysPower::ScanDirectory( const char* path, int parent )
                 FILE* f = fopen( tmp, "r" );
                 if( f )
                 {
-                    fscanf( f, "%" PRIu64, &maxRange );
+                    (void)fscanf( f, "%" PRIu64, &maxRange );
                     fclose( f );
                 }
             }


### PR DESCRIPTION
`fscanf` is `[[warn_unused_result]]`, which triggers `-Wunused-result` in GCC 13.2 + Ubuntu 24.04.

In this instance I believe it is correct for `maxRange` to remain unchanged if reading from sysfs should fail for some reason, since that error condition is checked in line 133.