### PR TITLE
Fix crash on Android due to wrong TLS model

### DIFF
--- a/public/client/tracy_rpmalloc.cpp
+++ b/public/client/tracy_rpmalloc.cpp
@@ -690,7 +690,9 @@ static pthread_key_t _memory_thread_heap;
 #    define _Thread_local __declspec(thread)
 #    define TLS_MODEL
 #  else
-#    ifndef __HAIKU__
+#    if defined(__ANDROID__) && __ANDROID_API__ >= 29 && defined(__NDK_MAJOR__) && __NDK_MAJOR__ >= 26
+#      define TLS_MODEL __attribute__((tls_model("local-dynamic")))
+#    elif !defined(__HAIKU__)
 #      define TLS_MODEL __attribute__((tls_model("initial-exec")))
 #    else
 #      define TLS_MODEL


### PR DESCRIPTION
For android ndk, it is always a dynamic .so to let java load. 
So "initial-exec" would either not work, or crash for ndk 26+ with minSdk 29+.

check here: https://github.com/android/ndk/wiki/Changelog-r26#changes

[Issue 1679](https://github.com/android/ndk/issues/1679): Clang will now automatically enable ELF TLS for minSdkVersion 29 or higher.