### PR TITLE
Percentiles p75, p90 for FindZone view

### DIFF
--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -667,6 +667,7 @@ private:
         size_t sortedNum = 0, selSortNum, selSortActive;
         float average, selAverage;
         float median, selMedian;
+        float p75, p90;
         int64_t total, selTotal;
         int64_t selTime;
         bool drawAvgMed = true;
@@ -710,6 +711,8 @@ private:
             sortedNum = 0;
             average = 0;
             median = 0;
+            p75 = 0;
+            p90 = 0;
             total = 0;
             tmin = std::numeric_limits<int64_t>::max();
             tmax = std::numeric_limits<int64_t>::min();

--- a/profiler/src/profiler/TracyView_FindZone.cpp
+++ b/profiler/src/profiler/TracyView_FindZone.cpp
@@ -549,10 +549,13 @@ void View::DrawFindZone()
                 std::inplace_merge( vec.begin(), mid, vec.end() );
 
                 const auto vsz = vec.size();
+                const auto vszQuarter = vsz / 4;
                 if( vsz != 0 )
                 {
                     m_findZone.average = float( total ) / vsz;
                     m_findZone.median = vec[vsz/2];
+                    m_findZone.p75 = vec[3 * vszQuarter];
+                    m_findZone.p90 = vec[vsz / 10 * 9];
                     m_findZone.total = total;
                     m_findZone.sortedNum = i;
                     m_findZone.tmin = tmin;
@@ -970,6 +973,12 @@ void View::DrawFindZone()
                         ImGui::Spacing();
                         ImGui::SameLine();
                         TextFocused( "Median:", TimeToString( m_findZone.median ) );
+                        ImGui::SameLine();
+                        ImGui::Spacing();
+                        TextFocused( "P75:", TimeToString( m_findZone.p75 ) );
+                        ImGui::SameLine();
+                        ImGui::Spacing();
+                        TextFocused( "P90:", TimeToString( m_findZone.p90 ) );
                         ImGui::SameLine();
                         ImGui::Spacing();
                         ImGui::SameLine();

--- a/profiler/src/profiler/TracyView_FindZone.cpp
+++ b/profiler/src/profiler/TracyView_FindZone.cpp
@@ -549,12 +549,11 @@ void View::DrawFindZone()
                 std::inplace_merge( vec.begin(), mid, vec.end() );
 
                 const auto vsz = vec.size();
-                const auto vszQuarter = vsz / 4;
                 if( vsz != 0 )
                 {
                     m_findZone.average = float( total ) / vsz;
                     m_findZone.median = vec[vsz/2];
-                    m_findZone.p75 = vec[3 * vszQuarter];
+                    m_findZone.p75 = vec[3 * (vsz / 4)];
                     m_findZone.p90 = vec[vsz / 10 * 9];
                     m_findZone.total = total;
                     m_findZone.sortedNum = i;


### PR DESCRIPTION
Small contribution proposal from my side: during work on TPEG decoding messages I found it useful to have percentiles values for zone statistics. It helped me better understand the nature of the problem that I'm facing and show the gain from the improvements that I'm currently working on.

Didn't add P75 and P90 as a lines to the histogram. If you feel my contribution brings any value to core Tracy, then I can add them as well (don't use them much).