### PR TITLE
Add absolute time info to Zone info view

### DIFF
--- a/profiler/src/profiler/TracyView_ZoneInfo.cpp
+++ b/profiler/src/profiler/TracyView_ZoneInfo.cpp
@@ -457,6 +457,8 @@ void View::DrawZoneInfoWindow()
         const auto ztime = end - ev.Start();
         const auto selftime = GetZoneSelfTime( ev );
         TextFocused( "Time from start of program:", TimeToStringExact( ev.Start() ) );
+        const std::time_t ts = m_worker.GetCaptureTime() + ev.Start() / 1000000000;
+        TextFocused( "Wall clock time:", std::asctime( std::localtime( &ts) ) );
         TextFocused( "Execution time:", TimeToString( ztime ) );
 #ifndef TRACY_NO_STATISTICS
         if( m_worker.AreSourceLocationZonesReady() )


### PR DESCRIPTION
For correlation with other traces (like Wireshark or tracy from another process) I find it really helpful to have an absolute timestamp in the zone info view. As all required data is available, the implementation is straightforward.
For my purposes second granularity is fine.