### PR TITLE
Display zone values also in hex

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -5309,7 +5309,7 @@ void Worker::ProcessZoneColor( const QueueZoneColor& ev )
 void Worker::ProcessZoneValue( const QueueZoneValue& ev )
 {
     char tmp[32];
-    const auto tsz = sprintf( tmp, "%" PRIu64, ev.value );
+    const auto tsz = sprintf( tmp, "%" PRIu64 " [0x%" PRIx64 "]", ev.value, ev.value );
 
     auto td = RetrieveThread( m_threadCtx );
     if( !td )


### PR DESCRIPTION
For better readability display zone values not only in decimal but also in hex.