### PR TITLE
[Meson][Windows] detect MSVC usage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('tracy', ['cpp'], version: '0.11.0', meson_version: '>=1.1.0')
+project('tracy', ['cpp'], version: '0.11.1', meson_version: '>=1.3.0', default_options : ['cpp_std=c++11'])
 
 # internal compiler flags
 tracy_compile_args = []
@@ -189,8 +189,9 @@ tracy_public_include_dirs = include_directories('public')
 
 compiler = meson.get_compiler('cpp')
 override_options = []
-if compiler.get_id() != 'msvc' and compiler.get_id() != 'clang-cl'
-  override_options += 'cpp_std=c++11'
+# MSVC c++ lib does not work properly with C++11 and compilation may fail
+if compiler.has_define('_MSC_VER') and get_option('cpp_std') == 'c++11'
+  override_options += 'cpp_std=c++14'
 endif
 
 tracy_compile_args += tracy_common_args


### PR DESCRIPTION
previous check tested for compiler ID in meson, detection of an specific MSVC macro is preferred so it works in any compiler that includes the MSVC stdlib.

I noticed this error while trying to compile the `0.11.0` version

- changes the compiler check to macro check `_MSC_VER` which is an [Microsoft specific macro](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170#microsoft-specific-predefined-macros)
- changes the current defined version to `0.11.1`, previous was `0.11.0`
