### PR TITLE
Enable -fexperimental-library only for C++ frontend of AppleClang

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -23,7 +23,9 @@ else()
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    add_compile_options(-fexperimental-library)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        add_compile_options(-fexperimental-library)
+    endif()
 endif()
 
 if(WIN32)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -24,7 +24,7 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-        add_compile_options(-fexperimental-library)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fexperimental-library>)
     endif()
 endif()
 


### PR DESCRIPTION
I have tried to compile Tracy with GCC on MacOS I have noticed that `-fexperimental-library` flag was set while GCC does not support this flag. This flag is also meaningless for C source code, so with this patch it will be enabled only for C++ with AppleClang compiler.