### PR TITLE
Use `int32_t` type instead of `int`

### DIFF
--- a/public/client/TracyCallstack.hpp
+++ b/public/client/TracyCallstack.hpp
@@ -10,7 +10,7 @@
 namespace tracy
 {
 static constexpr bool has_callstack() { return false; }
-static tracy_force_inline void* Callstack( int /*depth*/ ) { return nullptr; }
+static tracy_force_inline void* Callstack( int32_t /*depth*/ ) { return nullptr; }
 }
 
 #else
@@ -86,7 +86,7 @@ extern "C"
     TRACY_API extern ___tracy_t_RtlWalkFrameChain ___tracy_RtlWalkFrameChain;
 }
 
-static tracy_force_inline void* Callstack( int depth )
+static tracy_force_inline void* Callstack( int32_t depth )
 {
     assert( depth >= 1 && depth < 63 );
     auto trace = (uintptr_t*)tracy_malloc( ( 1 + depth ) * sizeof( uintptr_t ) );
@@ -115,7 +115,7 @@ static _Unwind_Reason_Code tracy_unwind_callback( struct _Unwind_Context* ctx, v
     return _URC_NO_REASON;
 }
 
-static tracy_force_inline void* Callstack( int depth )
+static tracy_force_inline void* Callstack( int32_t depth )
 {
     assert( depth >= 1 && depth < 63 );
 
@@ -130,7 +130,7 @@ static tracy_force_inline void* Callstack( int depth )
 
 #elif TRACY_HAS_CALLSTACK == 3 || TRACY_HAS_CALLSTACK == 4 || TRACY_HAS_CALLSTACK == 6
 
-static tracy_force_inline void* Callstack( int depth )
+static tracy_force_inline void* Callstack( int32_t depth )
 {
     assert( depth >= 1 );
 

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4046,7 +4046,7 @@ void Profiler::ReportTopology()
 #endif
 }
 
-void Profiler::SendCallstack( int depth, const char* skipBefore )
+void Profiler::SendCallstack( int32_t depth, const char* skipBefore )
 {
 #ifdef TRACY_HAS_CALLSTACK
     auto ptr = Callstack( depth );
@@ -4276,7 +4276,7 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_l
     return ctx;
 }
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int depth, int32_t active )
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int32_t depth, int32_t active )
 {
     ___tracy_c_zone_context ctx;
 #ifdef TRACY_ON_DEMAND
@@ -4341,7 +4341,7 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t
     return ctx;
 }
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int depth, int32_t active )
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int32_t depth, int32_t active )
 {
     ___tracy_c_zone_context ctx;
 #ifdef TRACY_ON_DEMAND
@@ -4473,7 +4473,7 @@ TRACY_API void ___tracy_emit_zone_value( TracyCZoneCtx ctx, uint64_t value )
 }
 
 TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int32_t secure ) { tracy::Profiler::MemAlloc( ptr, size, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int depth, int32_t secure )
+TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int32_t depth, int32_t secure )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
@@ -4485,7 +4485,7 @@ TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t siz
     }
 }
 TRACY_API void ___tracy_emit_memory_free( const void* ptr, int32_t secure ) { tracy::Profiler::MemFree( ptr, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int depth, int32_t secure )
+TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int32_t depth, int32_t secure )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
@@ -4497,7 +4497,7 @@ TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int depth, 
     }
 }
 TRACY_API void ___tracy_emit_memory_discard( const char* name, int32_t secure ) { tracy::Profiler::MemDiscard( name, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int depth )
+TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int32_t depth )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
@@ -4509,7 +4509,7 @@ TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t
     }
 }
 TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int32_t secure, const char* name ) { tracy::Profiler::MemAllocNamed( ptr, size, secure != 0, name ); }
-TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int depth, int32_t secure, const char* name )
+TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int32_t depth, int32_t secure, const char* name )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
@@ -4521,7 +4521,7 @@ TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size
     }
 }
 TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int32_t secure, const char* name ) { tracy::Profiler::MemFreeNamed( ptr, secure != 0, name ); }
-TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int depth, int32_t secure, const char* name )
+TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int32_t depth, int32_t secure, const char* name )
 {
     if( depth > 0 && tracy::has_callstack() )
     {

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4472,8 +4472,8 @@ TRACY_API void ___tracy_emit_zone_value( TracyCZoneCtx ctx, uint64_t value )
     }
 }
 
-TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int secure ) { tracy::Profiler::MemAlloc( ptr, size, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int depth, int secure )
+TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int32_t secure ) { tracy::Profiler::MemAlloc( ptr, size, secure != 0 ); }
+TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int depth, int32_t secure )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
@@ -4484,8 +4484,8 @@ TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t siz
         tracy::Profiler::MemAlloc( ptr, size, secure != 0 );
     }
 }
-TRACY_API void ___tracy_emit_memory_free( const void* ptr, int secure ) { tracy::Profiler::MemFree( ptr, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int depth, int secure )
+TRACY_API void ___tracy_emit_memory_free( const void* ptr, int32_t secure ) { tracy::Profiler::MemFree( ptr, secure != 0 ); }
+TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int depth, int32_t secure )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
@@ -4496,8 +4496,8 @@ TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int depth, 
         tracy::Profiler::MemFree( ptr, secure != 0 );
     }
 }
-TRACY_API void ___tracy_emit_memory_discard( const char* name, int secure ) { tracy::Profiler::MemDiscard( name, secure != 0 ); }
-TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int secure, int depth )
+TRACY_API void ___tracy_emit_memory_discard( const char* name, int32_t secure ) { tracy::Profiler::MemDiscard( name, secure != 0 ); }
+TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int depth )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
@@ -4508,8 +4508,8 @@ TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int sec
         tracy::Profiler::MemDiscard( name, secure != 0 );
     }
 }
-TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int secure, const char* name ) { tracy::Profiler::MemAllocNamed( ptr, size, secure != 0, name ); }
-TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int depth, int secure, const char* name )
+TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int32_t secure, const char* name ) { tracy::Profiler::MemAllocNamed( ptr, size, secure != 0, name ); }
+TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int depth, int32_t secure, const char* name )
 {
     if( depth > 0 && tracy::has_callstack() )
     {
@@ -4520,8 +4520,8 @@ TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size
         tracy::Profiler::MemAllocNamed( ptr, size, secure != 0, name );
     }
 }
-TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int secure, const char* name ) { tracy::Profiler::MemFreeNamed( ptr, secure != 0, name ); }
-TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int depth, int secure, const char* name )
+TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int32_t secure, const char* name ) { tracy::Profiler::MemFreeNamed( ptr, secure != 0, name ); }
+TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int depth, int32_t secure, const char* name )
 {
     if( depth > 0 && tracy::has_callstack() )
     {

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4540,10 +4540,10 @@ TRACY_API void ___tracy_emit_plot( const char* name, double val ) { tracy::Profi
 TRACY_API void ___tracy_emit_plot_float( const char* name, float val ) { tracy::Profiler::PlotData( name, val ); }
 TRACY_API void ___tracy_emit_plot_int( const char* name, int64_t val ) { tracy::Profiler::PlotData( name, val ); }
 TRACY_API void ___tracy_emit_plot_config( const char* name, int type, int step, int fill, uint32_t color ) { tracy::Profiler::ConfigurePlot( name, tracy::PlotFormatType(type), step, fill, color ); }
-TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int callstack ) { tracy::Profiler::Message( txt, size, callstack ); }
-TRACY_API void ___tracy_emit_messageL( const char* txt, int callstack ) { tracy::Profiler::Message( txt, callstack ); }
-TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int callstack ) { tracy::Profiler::MessageColor( txt, size, color, callstack ); }
-TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int callstack ) { tracy::Profiler::MessageColor( txt, color, callstack ); }
+TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int32_t callstack_depth ) { tracy::Profiler::Message( txt, size, callstack_depth ); }
+TRACY_API void ___tracy_emit_messageL( const char* txt, int32_t callstack_depth ) { tracy::Profiler::Message( txt, callstack_depth ); }
+TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int32_t callstack_depth ) { tracy::Profiler::MessageColor( txt, size, color, callstack_depth ); }
+TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int32_t callstack_depth ) { tracy::Profiler::MessageColor( txt, color, callstack_depth ); }
 TRACY_API void ___tracy_emit_message_appinfo( const char* txt, size_t size ) { tracy::Profiler::MessageAppInfo( txt, size ); }
 
 TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, uint32_t color ) {

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4980,9 +4980,9 @@ TRACY_API void ___tracy_shutdown_profiler( void )
     tracy::ShutdownProfiler();
 }
 
-TRACY_API int ___tracy_profiler_started( void )
+TRACY_API int32_t ___tracy_profiler_started( void )
 {
-    return tracy::s_isProfilerStarted.load( std::memory_order_seq_cst );
+    return static_cast<int32_t>( tracy::s_isProfilerStarted.load( std::memory_order_seq_cst ) );
 }
 #  endif
 

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4841,7 +4841,7 @@ TRACY_API void ___tracy_terminate_lockable_ctx( struct __tracy_lockable_context_
     tracy::tracy_free((void*)lockdata);
 }
 
-TRACY_API int ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata )
+TRACY_API int32_t ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata )
 {
 #ifdef TRACY_ON_DEMAND
     bool queue = false;
@@ -4853,7 +4853,7 @@ TRACY_API int ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context
         if( active != connected ) lockdata->m_active.store( connected, std::memory_order_relaxed );
         if( connected ) queue = true;
     }
-    if( !queue ) return false;
+    if( !queue ) return static_cast<int32_t>(false);
 #endif
 
     auto item = tracy::Profiler::QueueSerial();
@@ -4862,7 +4862,7 @@ TRACY_API int ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context
     tracy::MemWrite( &item->lockWait.id, lockdata->m_id );
     tracy::MemWrite( &item->lockWait.time, tracy::Profiler::GetTime() );
     tracy::Profiler::QueueSerialFinish();
-    return true;
+    return static_cast<int32_t>(true);
 }
 
 TRACY_API void ___tracy_after_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata )

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4959,9 +4959,9 @@ TRACY_API void ___tracy_custom_name_lockable_ctx( struct __tracy_lockable_contex
     tracy::Profiler::QueueSerialFinish();
 }
 
-TRACY_API int ___tracy_connected( void )
+TRACY_API int32_t ___tracy_connected( void )
 {
-    return tracy::GetProfiler().IsConnected();
+    return static_cast<int32_t>( tracy::GetProfiler().IsConnected() );
 }
 
 #ifdef TRACY_FIBERS

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4539,7 +4539,7 @@ TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_
 TRACY_API void ___tracy_emit_plot( const char* name, double val ) { tracy::Profiler::PlotData( name, val ); }
 TRACY_API void ___tracy_emit_plot_float( const char* name, float val ) { tracy::Profiler::PlotData( name, val ); }
 TRACY_API void ___tracy_emit_plot_int( const char* name, int64_t val ) { tracy::Profiler::PlotData( name, val ); }
-TRACY_API void ___tracy_emit_plot_config( const char* name, int type, int step, int fill, uint32_t color ) { tracy::Profiler::ConfigurePlot( name, tracy::PlotFormatType(type), step, fill, color ); }
+TRACY_API void ___tracy_emit_plot_config( const char* name, int32_t type, int32_t step, int32_t fill, uint32_t color ) { tracy::Profiler::ConfigurePlot( name, tracy::PlotFormatType(type), step != 0, fill != 0, color ); }
 TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int32_t callstack_depth ) { tracy::Profiler::Message( txt, size, callstack_depth ); }
 TRACY_API void ___tracy_emit_messageL( const char* txt, int32_t callstack_depth ) { tracy::Profiler::Message( txt, callstack_depth ); }
 TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int32_t callstack_depth ) { tracy::Profiler::MessageColor( txt, size, color, callstack_depth ); }

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4248,7 +4248,7 @@ int64_t Profiler::GetTimeQpc()
 extern "C" {
 #endif
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int active )
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int32_t active )
 {
     ___tracy_c_zone_context ctx;
 #ifdef TRACY_ON_DEMAND
@@ -4276,7 +4276,7 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_l
     return ctx;
 }
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int depth, int active )
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int depth, int32_t active )
 {
     ___tracy_c_zone_context ctx;
 #ifdef TRACY_ON_DEMAND
@@ -4309,7 +4309,7 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___trac
     return ctx;
 }
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int active )
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t active )
 {
     ___tracy_c_zone_context ctx;
 #ifdef TRACY_ON_DEMAND
@@ -4341,7 +4341,7 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int act
     return ctx;
 }
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int depth, int active )
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int depth, int32_t active )
 {
     ___tracy_c_zone_context ctx;
 #ifdef TRACY_ON_DEMAND

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4535,7 +4535,7 @@ TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int32
 TRACY_API void ___tracy_emit_frame_mark( const char* name ) { tracy::Profiler::SendFrameMark( name ); }
 TRACY_API void ___tracy_emit_frame_mark_start( const char* name ) { tracy::Profiler::SendFrameMark( name, tracy::QueueType::FrameMarkMsgStart ); }
 TRACY_API void ___tracy_emit_frame_mark_end( const char* name ) { tracy::Profiler::SendFrameMark( name, tracy::QueueType::FrameMarkMsgEnd ); }
-TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_t h, uint8_t offset, int flip ) { tracy::Profiler::SendFrameImage( image, w, h, offset, flip ); }
+TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_t h, uint8_t offset, int32_t flip ) { tracy::Profiler::SendFrameImage( image, w, h, offset, flip != 0 ); }
 TRACY_API void ___tracy_emit_plot( const char* name, double val ) { tracy::Profiler::PlotData( name, val ); }
 TRACY_API void ___tracy_emit_plot_float( const char* name, float val ) { tracy::Profiler::PlotData( name, val ); }
 TRACY_API void ___tracy_emit_plot_int( const char* name, int64_t val ) { tracy::Profiler::PlotData( name, val ); }

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4894,7 +4894,7 @@ TRACY_API void ___tracy_after_unlock_lockable_ctx( struct __tracy_lockable_conte
     tracy::Profiler::QueueSerialFinish();
 }
 
-TRACY_API void ___tracy_after_try_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata, int acquired )
+TRACY_API void ___tracy_after_try_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata, int32_t acquired )
 {
 #ifdef TRACY_ON_DEMAND
     if( !acquired ) return;

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -510,7 +510,7 @@ public:
         GetProfiler().m_serialLock.unlock();
     }
 
-    static tracy_force_inline void MemAllocCallstack( const void* ptr, size_t size, int depth, bool secure )
+    static tracy_force_inline void MemAllocCallstack( const void* ptr, size_t size, int32_t depth, bool secure )
     {
         if( secure && !ProfilerAvailable() ) return;
         if( depth > 0 && has_callstack() )
@@ -534,7 +534,7 @@ public:
         }
     }
 
-    static tracy_force_inline void MemFreeCallstack( const void* ptr, int depth, bool secure )
+    static tracy_force_inline void MemFreeCallstack( const void* ptr, int32_t depth, bool secure )
     {
         if( secure && !ProfilerAvailable() ) return;
         if( !ProfilerAllocatorAvailable() )
@@ -591,7 +591,7 @@ public:
         GetProfiler().m_serialLock.unlock();
     }
 
-    static tracy_force_inline void MemAllocCallstackNamed( const void* ptr, size_t size, int depth, bool secure, const char* name )
+    static tracy_force_inline void MemAllocCallstackNamed( const void* ptr, size_t size, int32_t depth, bool secure, const char* name )
     {
         if( secure && !ProfilerAvailable() ) return;
         if( depth > 0 && has_callstack() )
@@ -616,7 +616,7 @@ public:
         }
     }
 
-    static tracy_force_inline void MemFreeCallstackNamed( const void* ptr, int depth, bool secure, const char* name )
+    static tracy_force_inline void MemFreeCallstackNamed( const void* ptr, int32_t depth, bool secure, const char* name )
     {
         if( secure && !ProfilerAvailable() ) return;
         if( depth > 0 && has_callstack() )
@@ -654,7 +654,7 @@ public:
         GetProfiler().m_serialLock.unlock();
     }
 
-    static tracy_force_inline void MemDiscardCallstack( const char* name, bool secure, int depth )
+    static tracy_force_inline void MemDiscardCallstack( const char* name, bool secure, int32_t depth )
     {
         if( secure && !ProfilerAvailable() ) return;
         if( depth > 0 && has_callstack() )
@@ -677,7 +677,7 @@ public:
         }
     }
 
-    static tracy_force_inline void SendCallstack( int depth )
+    static tracy_force_inline void SendCallstack( int32_t depth )
     {
         if( depth > 0 && has_callstack() )
         {
@@ -735,7 +735,7 @@ public:
     }
 #endif
 
-    void SendCallstack( int depth, const char* skipBefore );
+    void SendCallstack( int32_t depth, const char* skipBefore );
     static void CutCallstack( void* callstack, const char* skipBefore );
 
     static bool ShouldExit();

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -387,58 +387,58 @@ public:
         TracyLfqCommit;
     }
 
-    static tracy_force_inline void Message( const char* txt, size_t size, int callstack )
+    static tracy_force_inline void Message( const char* txt, size_t size, int32_t callstack_depth )
     {
         assert( size < (std::numeric_limits<uint16_t>::max)() );
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
-        if( callstack != 0 )
+        if( callstack_depth != 0 && has_callstack() )
         {
-            tracy::GetProfiler().SendCallstack( callstack );
+            tracy::GetProfiler().SendCallstack( callstack_depth );
         }
 
         auto ptr = (char*)tracy_malloc( size );
         memcpy( ptr, txt, size );
 
-        TracyQueuePrepare( callstack == 0 ? QueueType::Message : QueueType::MessageCallstack );
+        TracyQueuePrepare( callstack_depth == 0 ? QueueType::Message : QueueType::MessageCallstack );
         MemWrite( &item->messageFat.time, GetTime() );
         MemWrite( &item->messageFat.text, (uint64_t)ptr );
         MemWrite( &item->messageFat.size, (uint16_t)size );
         TracyQueueCommit( messageFatThread );
     }
 
-    static tracy_force_inline void Message( const char* txt, int callstack )
+    static tracy_force_inline void Message( const char* txt, int32_t callstack_depth )
     {
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
-        if( callstack != 0 )
+        if( callstack_depth != 0 && has_callstack() )
         {
-            tracy::GetProfiler().SendCallstack( callstack );
+            tracy::GetProfiler().SendCallstack( callstack_depth );
         }
 
-        TracyQueuePrepare( callstack == 0 ? QueueType::MessageLiteral : QueueType::MessageLiteralCallstack );
+        TracyQueuePrepare( callstack_depth == 0 ? QueueType::MessageLiteral : QueueType::MessageLiteralCallstack );
         MemWrite( &item->messageLiteral.time, GetTime() );
         MemWrite( &item->messageLiteral.text, (uint64_t)txt );
         TracyQueueCommit( messageLiteralThread );
     }
 
-    static tracy_force_inline void MessageColor( const char* txt, size_t size, uint32_t color, int callstack )
+    static tracy_force_inline void MessageColor( const char* txt, size_t size, uint32_t color, int32_t callstack_depth )
     {
         assert( size < (std::numeric_limits<uint16_t>::max)() );
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
-        if( callstack != 0 )
+        if( callstack_depth != 0 && has_callstack() )
         {
-            tracy::GetProfiler().SendCallstack( callstack );
+            tracy::GetProfiler().SendCallstack( callstack_depth );
         }
 
         auto ptr = (char*)tracy_malloc( size );
         memcpy( ptr, txt, size );
 
-        TracyQueuePrepare( callstack == 0 ? QueueType::MessageColor : QueueType::MessageColorCallstack );
+        TracyQueuePrepare( callstack_depth == 0 ? QueueType::MessageColor : QueueType::MessageColorCallstack );
         MemWrite( &item->messageColorFat.time, GetTime() );
         MemWrite( &item->messageColorFat.text, (uint64_t)ptr );
         MemWrite( &item->messageColorFat.b, uint8_t( ( color       ) & 0xFF ) );
@@ -448,17 +448,17 @@ public:
         TracyQueueCommit( messageColorFatThread );
     }
 
-    static tracy_force_inline void MessageColor( const char* txt, uint32_t color, int callstack )
+    static tracy_force_inline void MessageColor( const char* txt, uint32_t color, int32_t callstack_depth )
     {
 #ifdef TRACY_ON_DEMAND
         if( !GetProfiler().IsConnected() ) return;
 #endif
-        if( callstack != 0 )
+        if( callstack_depth != 0 && has_callstack() )
         {
-            tracy::GetProfiler().SendCallstack( callstack );
+            tracy::GetProfiler().SendCallstack( callstack_depth );
         }
 
-        TracyQueuePrepare( callstack == 0 ? QueueType::MessageLiteralColor : QueueType::MessageLiteralColorCallstack );
+        TracyQueuePrepare( callstack_depth == 0 ? QueueType::MessageLiteralColor : QueueType::MessageLiteralColorCallstack );
         MemWrite( &item->messageColorLiteral.time, GetTime() );
         MemWrite( &item->messageColorLiteral.text, (uint64_t)txt );
         MemWrite( &item->messageColorLiteral.b, uint8_t( ( color       ) & 0xFF ) );

--- a/public/client/TracyScoped.hpp
+++ b/public/client/TracyScoped.hpp
@@ -23,7 +23,7 @@ public:
     ScopedZone& operator=( const ScopedZone& ) = delete;
     ScopedZone& operator=( ScopedZone&& ) = delete;
 
-    tracy_force_inline ScopedZone( const SourceLocationData* srcloc, int depth = -1, bool is_active = true )
+    tracy_force_inline ScopedZone( const SourceLocationData* srcloc, int32_t depth = -1, bool is_active = true )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
 #else
@@ -46,7 +46,7 @@ public:
         TracyQueueCommit( zoneBeginThread );
     }
 
-    tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color, int depth = -1, bool is_active = true )
+    tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color, int32_t depth = -1, bool is_active = true )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
 #else
@@ -71,7 +71,7 @@ public:
         TracyQueueCommit( zoneBeginThread );
     }
 
-    tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int depth, bool is_active = true ) : ScopedZone( line, source, sourceSz, function, functionSz, name, nameSz, 0, depth, is_active ) {}
+    tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int32_t depth, bool is_active = true ) : ScopedZone( line, source, sourceSz, function, functionSz, name, nameSz, 0, depth, is_active ) {}
 
     tracy_force_inline ~ScopedZone()
     {

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -349,7 +349,7 @@ TRACY_API void ___tracy_emit_message_appinfo( const char* txt, size_t size );
 
 TRACY_API struct __tracy_lockable_context_data* ___tracy_announce_lockable_ctx( const struct ___tracy_source_location_data* srcloc );
 TRACY_API void ___tracy_terminate_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
-TRACY_API int ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
+TRACY_API int32_t ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
 TRACY_API void ___tracy_after_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
 TRACY_API void ___tracy_after_unlock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
 TRACY_API void ___tracy_after_try_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata, int acquired );

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -204,7 +204,7 @@ typedef struct __tracy_lockable_context_data* TracyCLockCtx;
 #ifdef TRACY_MANUAL_LIFETIME
 TRACY_API void ___tracy_startup_profiler(void);
 TRACY_API void ___tracy_shutdown_profiler(void);
-TRACY_API int ___tracy_profiler_started(void);
+TRACY_API int32_t ___tracy_profiler_started(void);
 
 #  define TracyCIsStarted ___tracy_profiler_started()
 #else

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -265,16 +265,16 @@ TRACY_API int ___tracy_connected(void);
 #define TracyCZoneValue( ctx, value ) ___tracy_emit_zone_value( ctx, value );
 
 
-TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int secure );
-TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int depth, int secure );
-TRACY_API void ___tracy_emit_memory_free( const void* ptr, int secure );
-TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int depth, int secure );
-TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int secure, const char* name );
-TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int depth, int secure, const char* name );
-TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int secure, const char* name );
-TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int depth, int secure, const char* name );
-TRACY_API void ___tracy_emit_memory_discard( const char* name, int secure );
-TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int secure, int size );
+TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int32_t secure );
+TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int depth, int32_t secure );
+TRACY_API void ___tracy_emit_memory_free( const void* ptr, int32_t secure );
+TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int depth, int32_t secure );
+TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int32_t secure, const char* name );
+TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int depth, int32_t secure, const char* name );
+TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int32_t secure, const char* name );
+TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int depth, int32_t secure, const char* name );
+TRACY_API void ___tracy_emit_memory_discard( const char* name, int32_t secure );
+TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int size );
 
 TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int callstack );
 TRACY_API void ___tracy_emit_messageL( const char* txt, int callstack );

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -214,10 +214,10 @@ TRACY_API int32_t ___tracy_profiler_started(void);
 TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, uint32_t color );
 TRACY_API uint64_t ___tracy_alloc_srcloc_name( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color );
 
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int active );
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int depth, int active );
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int active );
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int depth, int active );
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int32_t active );
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int depth, int32_t active );
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t active );
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int depth, int32_t active );
 TRACY_API void ___tracy_emit_zone_end( TracyCZoneCtx ctx );
 TRACY_API void ___tracy_emit_zone_text( TracyCZoneCtx ctx, const char* txt, size_t size );
 TRACY_API void ___tracy_emit_zone_name( TracyCZoneCtx ctx, const char* txt, size_t size );

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -215,9 +215,9 @@ TRACY_API uint64_t ___tracy_alloc_srcloc( uint32_t line, const char* source, siz
 TRACY_API uint64_t ___tracy_alloc_srcloc_name( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color );
 
 TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int32_t active );
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int depth, int32_t active );
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int32_t depth, int32_t active );
 TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t active );
-TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int depth, int32_t active );
+TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int32_t depth, int32_t active );
 TRACY_API void ___tracy_emit_zone_end( TracyCZoneCtx ctx );
 TRACY_API void ___tracy_emit_zone_text( TracyCZoneCtx ctx, const char* txt, size_t size );
 TRACY_API void ___tracy_emit_zone_name( TracyCZoneCtx ctx, const char* txt, size_t size );
@@ -266,15 +266,15 @@ TRACY_API int ___tracy_connected(void);
 
 
 TRACY_API void ___tracy_emit_memory_alloc( const void* ptr, size_t size, int32_t secure );
-TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int depth, int32_t secure );
+TRACY_API void ___tracy_emit_memory_alloc_callstack( const void* ptr, size_t size, int32_t depth, int32_t secure );
 TRACY_API void ___tracy_emit_memory_free( const void* ptr, int32_t secure );
-TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int depth, int32_t secure );
+TRACY_API void ___tracy_emit_memory_free_callstack( const void* ptr, int32_t depth, int32_t secure );
 TRACY_API void ___tracy_emit_memory_alloc_named( const void* ptr, size_t size, int32_t secure, const char* name );
-TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int depth, int32_t secure, const char* name );
+TRACY_API void ___tracy_emit_memory_alloc_callstack_named( const void* ptr, size_t size, int32_t depth, int32_t secure, const char* name );
 TRACY_API void ___tracy_emit_memory_free_named( const void* ptr, int32_t secure, const char* name );
-TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int depth, int32_t secure, const char* name );
+TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int32_t depth, int32_t secure, const char* name );
 TRACY_API void ___tracy_emit_memory_discard( const char* name, int32_t secure );
-TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int size );
+TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int32_t depth );
 
 TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int32_t callstack_depth );
 TRACY_API void ___tracy_emit_messageL( const char* txt, int32_t callstack_depth );

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -314,7 +314,7 @@ TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_
 TRACY_API void ___tracy_emit_plot( const char* name, double val );
 TRACY_API void ___tracy_emit_plot_float( const char* name, float val );
 TRACY_API void ___tracy_emit_plot_int( const char* name, int64_t val );
-TRACY_API void ___tracy_emit_plot_config( const char* name, int type, int step, int fill, uint32_t color );
+TRACY_API void ___tracy_emit_plot_config( const char* name, int32_t type, int32_t step, int32_t fill, uint32_t color );
 TRACY_API void ___tracy_emit_message_appinfo( const char* txt, size_t size );
 
 #define TracyCPlot( name, val ) ___tracy_emit_plot( name, val );

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -246,7 +246,7 @@ TRACY_API void ___tracy_emit_gpu_context_name_serial( const struct ___tracy_gpu_
 TRACY_API void ___tracy_emit_gpu_calibration_serial( const struct ___tracy_gpu_calibration_data );
 TRACY_API void ___tracy_emit_gpu_time_sync_serial( const struct ___tracy_gpu_time_sync_data );
 
-TRACY_API int ___tracy_connected(void);
+TRACY_API int32_t ___tracy_connected(void);
 
 #ifndef TRACY_CALLSTACK
 #define TRACY_CALLSTACK 0

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -302,7 +302,7 @@ TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int32_t
 TRACY_API void ___tracy_emit_frame_mark( const char* name );
 TRACY_API void ___tracy_emit_frame_mark_start( const char* name );
 TRACY_API void ___tracy_emit_frame_mark_end( const char* name );
-TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_t h, uint8_t offset, int flip );
+TRACY_API void ___tracy_emit_frame_image( const void* image, uint16_t w, uint16_t h, uint8_t offset, int32_t flip );
 
 #define TracyCFrameMark ___tracy_emit_frame_mark( 0 );
 #define TracyCFrameMarkNamed( name ) ___tracy_emit_frame_mark( name );

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -276,10 +276,10 @@ TRACY_API void ___tracy_emit_memory_free_callstack_named( const void* ptr, int d
 TRACY_API void ___tracy_emit_memory_discard( const char* name, int32_t secure );
 TRACY_API void ___tracy_emit_memory_discard_callstack( const char* name, int32_t secure, int size );
 
-TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int callstack );
-TRACY_API void ___tracy_emit_messageL( const char* txt, int callstack );
-TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int callstack );
-TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int callstack );
+TRACY_API void ___tracy_emit_message( const char* txt, size_t size, int32_t callstack_depth );
+TRACY_API void ___tracy_emit_messageL( const char* txt, int32_t callstack_depth );
+TRACY_API void ___tracy_emit_messageC( const char* txt, size_t size, uint32_t color, int32_t callstack_depth );
+TRACY_API void ___tracy_emit_messageLC( const char* txt, uint32_t color, int32_t callstack_depth );
 
 #define TracyCAlloc( ptr, size ) ___tracy_emit_memory_alloc_callstack( ptr, size, TRACY_CALLSTACK, 0 )
 #define TracyCFree( ptr ) ___tracy_emit_memory_free_callstack( ptr, TRACY_CALLSTACK, 0 )

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -140,7 +140,7 @@ struct ___tracy_source_location_data
 struct ___tracy_c_zone_context
 {
     uint32_t id;
-    int active;
+    int32_t active;
 };
 
 struct ___tracy_gpu_time_data
@@ -158,7 +158,7 @@ struct ___tracy_gpu_zone_begin_data {
 
 struct ___tracy_gpu_zone_begin_callstack_data {
     uint64_t srcloc;
-    int depth;
+    int32_t depth;
     uint16_t queryId;
     uint8_t context;
 };

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -352,7 +352,7 @@ TRACY_API void ___tracy_terminate_lockable_ctx( struct __tracy_lockable_context_
 TRACY_API int32_t ___tracy_before_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
 TRACY_API void ___tracy_after_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
 TRACY_API void ___tracy_after_unlock_lockable_ctx( struct __tracy_lockable_context_data* lockdata );
-TRACY_API void ___tracy_after_try_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata, int acquired );
+TRACY_API void ___tracy_after_try_lock_lockable_ctx( struct __tracy_lockable_context_data* lockdata, int32_t acquired );
 TRACY_API void ___tracy_mark_lockable_ctx( struct __tracy_lockable_context_data* lockdata, const struct ___tracy_source_location_data* srcloc );
 TRACY_API void ___tracy_custom_name_lockable_ctx( struct __tracy_lockable_context_data* lockdata, const char* name, size_t nameSz );
 

--- a/public/tracy/TracyD3D11.hpp
+++ b/public/tracy/TracyD3D11.hpp
@@ -307,7 +307,7 @@ public:
         WriteQueueItem(item, QueueType::GpuZoneBeginSerial, reinterpret_cast<uint64_t>(srcloc));
     }
 
-    tracy_force_inline D3D11ZoneScope( D3D11Ctx* ctx, const SourceLocationData* srcloc, int depth, bool active )
+    tracy_force_inline D3D11ZoneScope( D3D11Ctx* ctx, const SourceLocationData* srcloc, int32_t depth, bool active )
         : D3D11ZoneScope(ctx, active)
     {
         if( !m_active ) return;
@@ -327,7 +327,7 @@ public:
         WriteQueueItem(item, QueueType::GpuZoneBeginAllocSrcLocSerial, sourceLocation);
     }
 
-    tracy_force_inline D3D11ZoneScope(D3D11Ctx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int depth, bool active)
+    tracy_force_inline D3D11ZoneScope(D3D11Ctx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int32_t depth, bool active)
         : D3D11ZoneScope(ctx, active)
     {
         if( !m_active ) return;

--- a/public/tracy/TracyD3D12.hpp
+++ b/public/tracy/TracyD3D12.hpp
@@ -385,7 +385,7 @@ namespace tracy
             WriteQueueItem(item, QueueType::GpuZoneBeginSerial, reinterpret_cast<uint64_t>(srcLocation));
         }
 
-        tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, ID3D12GraphicsCommandList* cmdList, const SourceLocationData* srcLocation, int depth, bool active)
+        tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, ID3D12GraphicsCommandList* cmdList, const SourceLocationData* srcLocation, int32_t depth, bool active)
             : D3D12ZoneScope(ctx, cmdList, active)
         {
             if (!m_active) return;
@@ -405,7 +405,7 @@ namespace tracy
             WriteQueueItem(item, QueueType::GpuZoneBeginAllocSrcLocSerial, sourceLocation);
         }
 
-        tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, ID3D12GraphicsCommandList* cmdList, int depth, bool active)
+        tracy_force_inline D3D12ZoneScope(D3D12QueueCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, ID3D12GraphicsCommandList* cmdList, int32_t depth, bool active)
             : D3D12ZoneScope(ctx, cmdList, active)
         {
             if (!m_active) return;

--- a/public/tracy/TracyOpenCL.hpp
+++ b/public/tracy/TracyOpenCL.hpp
@@ -255,7 +255,7 @@ namespace tracy {
             Profiler::QueueSerialFinish();
         }
 
-        tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, const SourceLocationData* srcLoc, int depth, bool is_active)
+        tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, const SourceLocationData* srcLoc, int32_t depth, bool is_active)
 #ifdef TRACY_ON_DEMAND
             : m_active(is_active&& GetProfiler().IsConnected())
 #else
@@ -304,7 +304,7 @@ namespace tracy {
             Profiler::QueueSerialFinish();
         }
 
-        tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int depth, bool is_active)
+        tracy_force_inline OpenCLCtxScope(OpenCLCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int32_t depth, bool is_active)
 #ifdef TRACY_ON_DEMAND
             : m_active(is_active && GetProfiler().IsConnected())
 #else

--- a/public/tracy/TracyOpenGL.hpp
+++ b/public/tracy/TracyOpenGL.hpp
@@ -25,7 +25,7 @@ class GpuCtxScope
 {
 public:
     GpuCtxScope( const SourceLocationData*, bool ) {}
-    GpuCtxScope( const SourceLocationData*, int, bool ) {}
+    GpuCtxScope( const SourceLocationData*, int32_t, bool ) {}
 };
 }
 
@@ -222,7 +222,7 @@ public:
         TracyLfqCommit;
     }
 
-    tracy_force_inline GpuCtxScope( const SourceLocationData* srcloc, int depth, bool is_active )
+    tracy_force_inline GpuCtxScope( const SourceLocationData* srcloc, int32_t depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
 #else
@@ -271,7 +271,7 @@ public:
         TracyLfqCommit;
     }
 
-    tracy_force_inline GpuCtxScope( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int depth, bool is_active )
+    tracy_force_inline GpuCtxScope( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int32_t depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
 #else

--- a/public/tracy/TracyVulkan.hpp
+++ b/public/tracy/TracyVulkan.hpp
@@ -265,7 +265,7 @@ public:
         }
 #endif
         assert( head > m_tail );
-        
+
         const unsigned int wrappedTail = (unsigned int)( m_tail % m_queryCount );
 
         unsigned int cnt;
@@ -531,7 +531,7 @@ public:
         Profiler::QueueSerialFinish();
     }
 
-    tracy_force_inline VkCtxScope( VkCtx* ctx, const SourceLocationData* srcloc, VkCommandBuffer cmdbuf, int depth, bool is_active )
+    tracy_force_inline VkCtxScope( VkCtx* ctx, const SourceLocationData* srcloc, VkCommandBuffer cmdbuf, int32_t depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
 #else
@@ -580,7 +580,7 @@ public:
         Profiler::QueueSerialFinish();
     }
 
-    tracy_force_inline VkCtxScope( VkCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, VkCommandBuffer cmdbuf, int depth, bool is_active )
+    tracy_force_inline VkCtxScope( VkCtx* ctx, uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, VkCommandBuffer cmdbuf, int32_t depth, bool is_active )
 #ifdef TRACY_ON_DEMAND
         : m_active( is_active && GetProfiler().IsConnected() )
 #else

--- a/python/bindings/Memory.hpp
+++ b/python/bindings/Memory.hpp
@@ -7,7 +7,7 @@ namespace py = pybind11;
 #include "tracy/Tracy.hpp"
 
 using OptionalString = std::optional<std::string>;
-using OptionalInt = std::optional<int>;
+using OptionalInt = std::optional<int32_t>;
 
 #ifdef TRACY_ENABLE
 template <typename Type = uint64_t>

--- a/python/bindings/Module.cpp
+++ b/python/bindings/Module.cpp
@@ -820,7 +820,7 @@ PYBIND11_MODULE(TracyClientBindings, m) {
 
   m.def(
       "_plot_config",
-      [](const std::string &name, int type, bool step, bool fill,
+      [](const std::string &name, int32_t type, bool step, bool fill,
          uint32_t color = 0) {
         if (!tracy::IsEnabled()) return static_cast<OptionalNumber>(0ul);
         auto entry = NameBuffer::Add(name);

--- a/python/bindings/ScopedZone.hpp
+++ b/python/bindings/ScopedZone.hpp
@@ -27,7 +27,7 @@ bool SetText(const std::string& text, tracy::ScopedZone* zone) {
 class PyScopedZone {
  public:
   PyScopedZone(const std::optional<std::string>& name, uint32_t color,
-               std::optional<int> depth, bool active,
+               std::optional<int32_t> depth, bool active,
                const std::string& function, const std::string& source,
                uint32_t line)
       : m_name(name),
@@ -88,7 +88,7 @@ class PyScopedZone {
  private:
   std::optional<std::string> m_name;
   uint32_t m_color;
-  std::optional<int> m_depth;
+  std::optional<int32_t> m_depth;
   bool m_active;
 
   std::string m_function;
@@ -101,7 +101,7 @@ class PyScopedZone {
 
 class PyScopedZone {
  public:
-  PyScopedZone(const std::optional<std::string>&, uint32_t, std::optional<int>,
+  PyScopedZone(const std::optional<std::string>&, uint32_t, std::optional<int32_t>,
                bool, const std::string&, const std::string&, uint32_t line) {}
   virtual ~PyScopedZone(){};
 


### PR DESCRIPTION
This patch updates C API (and others too) for using `int32_t` type. After the patch,  tracy should be more portable for cases if `int` type has a size different from 4 bytes.   

Fixes #953