### PR TITLE
Add cross-project LTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,17 +15,30 @@ endif()
 
 option(TRACY_STATIC "Whether to build Tracy as a static library" ${DEFAULT_STATIC})
 option(TRACY_Fortran "Build Fortran bindings" OFF)
+option(TRACY_LTO "Enable Link-Time optimization" OFF)
 
 if(TRACY_Fortran)
   enable_language(Fortran)
   set(CMAKE_Fortran_VERSION 2003)
 endif()
 
+if(TRACY_LTO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT LTO_SUPPORTED)
+    if(NOT LTO_SUPPORTED)
+        message(WARNING "LTO is not supported!")
+    endif()
+else()
+    set(LTO_SUPPORTED OFF)
+endif()
+
 find_package(Threads REQUIRED)
 
 set(TRACY_PUBLIC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/public)
 
-if(TRACY_STATIC)
+if(LTO_SUPPORTED)
+    set(TRACY_VISIBILITY "OBJECT")
+elseif(TRACY_STATIC)
     set(TRACY_VISIBILITY "STATIC")
 else()
     set(TRACY_VISIBILITY "SHARED")
@@ -33,6 +46,7 @@ endif()
 
 add_library(TracyClient ${TRACY_VISIBILITY} "${TRACY_PUBLIC_DIR}/TracyClient.cpp")
 target_compile_features(TracyClient PUBLIC cxx_std_11)
+set_target_properties(TracyClient PROPERTIES INTERPROCEDURAL_OPTIMIZATION ${LTO_SUPPORTED})
 target_include_directories(TracyClient SYSTEM PUBLIC
     $<BUILD_INTERFACE:${TRACY_PUBLIC_DIR}>
     $<INSTALL_INTERFACE:include>)
@@ -53,7 +67,8 @@ if(TRACY_Fortran)
         PUBLIC
             TracyClient
     )
-    set_target_properties(TracyClientF90 PROPERTIES Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR})
+    set_target_properties(TracyClientF90 PROPERTIES Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}
+                                                    INTERPROCEDURAL_OPTIMIZATION ${LTO_SUPPORTED})
 endif()
 
 # Public dependency on some libraries required when using Mingw

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,9 @@ project(Tracy LANGUAGES CXX VERSION ${TRACY_VERSION_STRING})
 file(GENERATE OUTPUT .gitignore CONTENT "*")
 
 if(${BUILD_SHARED_LIBS})
-	set(DEFAULT_STATIC OFF)
+    set(DEFAULT_STATIC OFF)
 else()
-	set(DEFAULT_STATIC ON)
+    set(DEFAULT_STATIC ON)
 endif()
 
 option(TRACY_STATIC "Whether to build Tracy as a static library" ${DEFAULT_STATIC})
@@ -26,9 +26,9 @@ find_package(Threads REQUIRED)
 set(TRACY_PUBLIC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/public)
 
 if(TRACY_STATIC)
-	set(TRACY_VISIBILITY "STATIC")
+    set(TRACY_VISIBILITY "STATIC")
 else()
-	set(TRACY_VISIBILITY "SHARED")
+    set(TRACY_VISIBILITY "SHARED")
 endif()
 
 add_library(TracyClient ${TRACY_VISIBILITY} "${TRACY_PUBLIC_DIR}/TracyClient.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(TRACY_Fortran)
   set(CMAKE_Fortran_VERSION 2003)
 endif()
 
-if(TRACY_LTO)
+if(TRACY_LTO OR CMAKE_INTERPROCEDURAL_OPTIMIZATION)
     include(CheckIPOSupported)
     check_ipo_supported(RESULT LTO_SUPPORTED)
     if(NOT LTO_SUPPORTED)

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -441,7 +441,7 @@ You can integrate Tracy with CMake by adding the git submodule folder as a subdi
 
 \begin{lstlisting}
 # set options before add_subdirectory
-# available options: TRACY_ENABLE, TRACY_ON_DEMAND, TRACY_NO_BROADCAST, TRACY_NO_CODE_TRANSFER, ...
+# available options: TRACY_ENABLE, TRACY_LTO, TRACY_ON_DEMAND, TRACY_NO_BROADCAST, TRACY_NO_CODE_TRANSFER, ...
 option(TRACY_ENABLE "" ON)
 option(TRACY_ON_DEMAND "" ON)
 add_subdirectory(3rdparty/tracy)  # target: TracyClient or alias Tracy::TracyClient
@@ -2406,6 +2406,20 @@ Link \texttt{Tracy::TracyClientF90} to any target where you use Tracy for profil
 target_link_libraries(<TARGET> PUBLIC Tracy::TracyClientF90)
 \end{lstlisting}
 
+For using Link-Time optimizations, link both \texttt{Tracy::TracyClient} and \texttt{Tracy::TracyClientF90} to any target where you use Tracy for profiling:
+
+\begin{lstlisting}
+target_link_libraries(<TARGET> PUBLIC Tracy::TracyClient Tracy::TracyClientF90)
+\end{lstlisting}
+
+\begin{bclogo}[
+noborder=true,
+couleur=black!5,
+logo=\bcbombe
+]{Important}
+The same compiler (vendor + version) must be used for LTO for \textbf{ALL} languages in project.
+\end{bclogo}
+
 \begin{bclogo}[
 noborder=true,
 couleur=black!5,
@@ -2433,6 +2447,12 @@ Then add this to any target where you use tracy for profiling:
 
 \begin{lstlisting}
 target_link_libraries(<TARGET> PUBLIC TracyClientF90)
+\end{lstlisting}
+
+For using Link-Time optimizations (LTO), you also need to link with \texttt{TracyClient}:
+
+\begin{lstlisting}
+target_link_libraries(<TARGET> PUBLIC TracyClient TracyClientF90)
 \end{lstlisting}
 \end{bclogo}
 

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -479,6 +479,9 @@ target_link_libraries(<TARGET> PUBLIC TracyClient)
 \end{lstlisting}
 \end{bclogo}
 
+While using \texttt{set(CMAKE\_INTERPROCEDURAL\_OPTIMIZATION ON)} is a convenient way to enable Link-Time Optimization (LTO) for an entire project, there are situations in which this may not work due to excessive compilation times, linking issues, compiler bugs, or other reasons.
+For such cases, Tracy provides an option to enable Link-Time Optimization for itself using the \texttt{TRACY\_LTO} variable during the CMake configuration stage.
+
 \subsubsection{Meson integration}
 
 If you are using the Meson build system, you can add Tracy using the Wrap dependency system. To do this, place the \texttt{tracy.wrap} file in the \texttt{subprojects} directory of your project, with the following content. The \texttt{head} \texttt{revision} field tracks Tracy's \texttt{master} branch. If you want to lock to a specific version of Tracy instead, you can just set the \texttt{revision} field to an appropriate git tag.


### PR DESCRIPTION
This PR adds `TRACY_LTO` flag that enables Link-Time optimizations for Tracy. It should improve performance of Tracy calls. 