### PR TITLE
Use correct header on NetBSD.

### DIFF
--- a/public/common/TracySystem.cpp
+++ b/public/common/TracySystem.cpp
@@ -26,7 +26,9 @@
 #  include <fcntl.h>
 #elif defined __FreeBSD__
 #  include <sys/thr.h>
-#elif defined __NetBSD__ || defined __DragonFly__
+#elif defined __NetBSD__
+#  include <lwp.h>
+#elif defined __DragonFly__
 #  include <sys/lwp.h>
 #elif defined __QNX__
 #  include <process.h>


### PR DESCRIPTION
Fixes
In file included from .../public/TracyClient.cpp:14:
.../public/common/TracySystem.cpp: In function ‘uint32_t tracy::detail::GetThreadHandleImpl()’:
.../public/common/TracySystem.cpp:79:12: error: ‘_lwp_self’ was not declared in this scope
   79 |     return _lwp_self();
      |            ^~~~~~~~~
