### PR TITLE
Fix python bindings build

### DIFF
--- a/python/bindings/ScopedZone.hpp
+++ b/python/bindings/ScopedZone.hpp
@@ -77,7 +77,7 @@ class PyScopedZone {
       m_zone = new tracy::ScopedZone(
           m_line, m_source.c_str(), m_source.size(), m_function.c_str(),
           m_function.size(), m_name ? m_name->c_str() : nullptr,
-          m_name ? m_name->size() : 0ul, m_color, m_active);
+          m_name ? m_name->size() : 0ul, m_color, -1, m_active);
   }
 
   void Exit() {


### PR DESCRIPTION
Building tracey client with Python bindings enabled is failling with the error below.

This is on a MacOS with Clang, details below.

```
In file included from /Users/phsilva/dev/tracy/python/bindings/Module.cpp:2:
/Users/phsilva/dev/tracy/python/bindings/ScopedZone.hpp:77:20: error: call to constructor of 'tracy::ScopedZone' is ambiguous
   77 |       m_zone = new tracy::ScopedZone(
      |                    ^
   78 |           m_line, m_source.c_str(), m_source.size(), m_function.c_str(),
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   79 |           m_function.size(), m_name ? m_name->c_str() : nullptr,
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   80 |           m_name ? m_name->size() : 0ul, m_color, m_active);
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/phsilva/dev/tracy/public/tracy/../client/TracyScoped.hpp:49:24: note: candidate constructor
   49 |     tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color, int32_t depth = -1, bool is_active = true )
      |                        ^
/Users/phsilva/dev/tracy/public/tracy/../client/TracyScoped.hpp:74:24: note: candidate constructor
   74 |     tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, int32_t depth, bool is_active = true ) : ScopedZone( line, source, sourceSz, function, functionSz, name, nameSz, 0, depth, is_active ) {}
      |                        ^
1 error generated.
ninja: build stopped: subcommand failed.
```

Apparently this was changed in PR #957 at:

https://github.com/foxtran/tracy/blob/b9c7cd1738a8303b79adf0cf6d18a6f7e1be02be/public/client/TracyScoped.hpp#L49


```
cmake -S . -B build-client -G Ninja -DTRACY_CLIENT_PYTHON=1 -DTRACY_STATIC=OFF
Parsing public/common/TracyVersion.hpp file
VERSION 0.11.2
-- The CXX compiler identification is AppleClang 16.0.0.16000026
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- TRACY_ENABLE: ON
-- TRACY_ON_DEMAND: OFF
-- TRACY_CALLSTACK: OFF
-- TRACY_NO_CALLSTACK: OFF
-- TRACY_NO_CALLSTACK_INLINES: OFF
-- TRACY_ONLY_LOCALHOST: OFF
-- TRACY_NO_BROADCAST: OFF
-- TRACY_ONLY_IPV4: OFF
-- TRACY_NO_CODE_TRANSFER: OFF
-- TRACY_NO_CONTEXT_SWITCH: OFF
-- TRACY_NO_EXIT: OFF
-- TRACY_NO_SAMPLING: OFF
-- TRACY_NO_VERIFY: OFF
-- TRACY_NO_VSYNC_CAPTURE: OFF
-- TRACY_NO_FRAME_IMAGE: OFF
-- TRACY_NO_SYSTEM_TRACING: OFF
-- TRACY_PATCHABLE_NOPSLEDS: OFF
-- TRACY_DELAYED_INIT: OFF
-- TRACY_MANUAL_LIFETIME: OFF
-- TRACY_FIBERS: OFF
-- TRACY_NO_CRASH_HANDLER: OFF
-- TRACY_TIMER_FALLBACK: OFF
-- TRACY_LIBUNWIND_BACKTRACE: OFF
-- TRACY_SYMBOL_OFFLINE_RESOLVE: OFF
-- TRACY_LIBBACKTRACE_ELF_DYNLOAD_SUPPORT: OFF
-- TRACY_DEBUGINFOD: OFF
-- TRACY_VERBOSE: OFF
-- TRACY_DEMANGLE: OFF
-- Found Python: /opt/homebrew/Frameworks/Python.framework/Versions/3.13/bin/python3.13 (found suitable version "3.13.1", minimum required is "3.6") found components: Interpreter Development Development.Module Development.Embed
-- pybind11 v2.11.1 
-- Performing Test HAS_FLTO
-- Performing Test HAS_FLTO - Success
-- Performing Test HAS_FLTO_THIN
-- Performing Test HAS_FLTO_THIN - Success
-- Configuring done (4.6s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/phsilva/dev/tracy/build-client
```

