### PR TITLE
Include <chrono> explicitly in TraceyView

### DIFF
--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>


### PR DESCRIPTION
In Visual Studio 17.13 the STL team at Microsoft cleaned up internal includes of other public STL headers (most notably <chrono>) to increase build throughput for STL users, but now you need to include them yourself rather than rely on the indirect inclusion.