### PR TITLE
Change cmake export settings to correctly copy directory hierarchy 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ if(TRACY_Fortran)
            FILE ${CMAKE_BINARY_DIR}/TracyTargets.cmake)
 endif()
 install(FILES ${tracy_includes}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tracy)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tracy/tracy)
 install(FILES ${client_includes}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tracy/client)
 install(FILES ${common_includes}


### PR DESCRIPTION
When you install tracy via cmake (something like cmake --build --target install) the resulting directory hierarchy differs from original inside "public" folder. Without changes in cmake file it's impossible to link against tracy built in a such way.