### PR TITLE
Change meson install settings to correctly copy directory hierarchy

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -206,7 +206,7 @@ tracy = library('tracy', tracy_src, tracy_header_files,
     override_options    : override_options,
     install             : true)
 
-install_headers(includes, subdir : 'tracy')
+install_headers(includes, subdir : 'tracy/tracy')
 install_headers(common_includes, subdir : 'tracy/common')
 install_headers(client_includes, subdir : 'tracy/client')
 

--- a/meson.build
+++ b/meson.build
@@ -150,6 +150,7 @@ client_includes = [
     'public/client/TracyDebug.hpp',
     'public/client/TracyDxt1.hpp',
     'public/client/TracyFastVector.hpp',
+    'public/client/TracyKCore.hpp',
     'public/client/TracyLock.hpp',
     'public/client/TracyProfiler.hpp',
     'public/client/TracyRingBuffer.hpp',


### PR DESCRIPTION
This, similar to https://github.com/wolfpld/tracy/pull/986#event-16356986891, fix the installation path of tracy when using `meson.build`.
 It add also the missing `TracyKCore.hpp` header in the `client_includes`. 