### PR TITLE
Provide Lua hook function for automatic Lua instrumentation.

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -2002,15 +2002,11 @@ Even if Tracy is disabled, you still have to pay the no-op function call cost. T
 
 \subsubsection{Automatic instrumentation}
 
-Lua code can be automatically instrumented by using the \texttt{tracy::LuaHook(lua\_State*, lua\_Debug*)} function as or within a lua hook.
-The Lua hook must have the \texttt{LUA\_HOOKCALL} and \texttt{LUA\_HOOKRET} event mask set.
-You may either directly set the function as your hook or chain it to your existing hook.
+Lua code can be automatically instrumented by using Lua hooks. The \texttt{tracy::LuaHook(lua\_State*, lua\_Debug*)} function may be used as or within a Lua hook. There is a small performance impact from using Lua hooks since the Lua VM will be required to invoke the hook function.
 
-Use \texttt{lua\_sethook(L, tracy::LuaHook, LUA\_MASKCALL | LUA\_MASKRET, 0)} if you do not already have a Lua hook set.
+The Lua hook must have the \texttt{LUA\_HOOKCALL} and \texttt{LUA\_HOOKRET} event mask set. You may either directly set the function as your hook or chain it to your existing hook.
 
-If you already have a Lua hook, directly use \texttt{tracy::LuaHook(L, ar)} within the hook.
-
-Note that since lua will have to invoke the hook for every function call and return. There may be a small performance penalty.
+Use \texttt{lua\_sethook(L, tracy::LuaHook, LUA\_MASKCALL | LUA\_MASKRET, 0)} if you do not already have a Lua hook set or directly call \texttt{tracy::LuaHook(L, ar)} within your hook if you already have one set.
 
 \subsection{C API}
 \label{capi}

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -2000,6 +2000,18 @@ Cost of performing Lua call stack capture is presented in table~\ref{CallstackTi
 
 Even if Tracy is disabled, you still have to pay the no-op function call cost. To prevent that, you may want to use the \texttt{tracy::LuaRemove(char* script)} function, which will replace instrumentation calls with white-space. This function does nothing if the profiler is enabled.
 
+\subsubsection{Automatic instrumentation}
+
+Lua code can be automatically instrumented by using the \texttt{tracy::LuaHook(lua\_State*, lua\_Debug*)} function as or within a lua hook.
+The Lua hook must have the \texttt{LUA\_HOOKCALL} and \texttt{LUA\_HOOKRET} event mask set.
+You may either directly set the function as your hook or chain it to your existing hook.
+
+Use \texttt{lua\_sethook(L, tracy::LuaHook, LUA\_MASKCALL | LUA\_MASKRET, 0)} if you do not already have a Lua hook set.
+
+If you already have a Lua hook, directly use \texttt{tracy::LuaHook(L, ar)} within the hook.
+
+Note that since lua will have to invoke the hook for every function call and return. There may be a small performance penalty.
+
 \subsection{C API}
 \label{capi}
 


### PR DESCRIPTION
This patch implements automatic function instrumentation for Lua scripting. This mean we no longer have to manually instrument Lua code (you still have the option to if you want). Instead by using [The Debug Interface](https://www.lua.org/manual/5.4/manual.html#4.7) we can have the Lua VM invoke a callback when a function is entered or exited.

```cpp
#include <lua.hpp>
#include <tracy/Tracy.hpp>
#include <tracy/TracyLua.hpp>

lua_state* L = luaL_newstate();

// Set the hook, `LUA_MASKCALL` and `LUA_MASKRET` *MUST* be set
// If you already have a hook, you can directly invoke `tracy::LuaHook` in your own hook function.
lua_sethook(L, tracy::LuaHook, LUA_MASKCALL | LUA_MASKRET, 0);
```

With this hook function the following trace can be produced without editing *any* Lua code.
![image](https://github.com/user-attachments/assets/20be5dd9-1d2b-40f8-807d-1af1db2de6bc)

Some things to make note of:
* I'm unsure if collecting Lua callstacks is of any use here via `SendLuaCallstack` since the debug interface informs us of all function calls anyways.
* We need to be weary if the Lua VM debug API is opened for scripts. If so the script could change the hook function during runtime to get a mismatched begin/end zone. Typically for game scripts you wouldn't want to load this library anyhow.