### PR TITLE
Let CMake discover python3 and make it required

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -189,8 +189,9 @@ if(NOT DEFINED GIT_REV)
     set(GIT_REV "HEAD")
 endif()
 
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_custom_target(git-ref
-    COMMAND python3 ${CMAKE_CURRENT_LIST_DIR}/../extra/git-ref.py ${GIT_REV}
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/../extra/git-ref.py ${GIT_REV}
     BYPRODUCTS GitRef.hpp
 )
 add_dependencies(${PROJECT_NAME} git-ref)


### PR DESCRIPTION
Since since it is needed to build, we might as well enforce it through CMake to get a better error message and help finding the correct python executable since python3 may actually be only named python on windows for example.