### PR TITLE
Replace sprintf with snprintf

### DIFF
--- a/profiler/src/Filters.cpp
+++ b/profiler/src/Filters.cpp
@@ -77,7 +77,7 @@ bool Filters::FailPort( uint16_t port )
 {
     if( !m_portFilter.IsActive() ) return false;
     char buf[32];
-    sprintf( buf, "%" PRIu16, port );
+    snprintf( buf, sizeof(buf), "%" PRIu16, port );
     return !m_portFilter.PassFilter( buf );
 }
 

--- a/profiler/src/HttpRequest.cpp
+++ b/profiler/src/HttpRequest.cpp
@@ -29,9 +29,9 @@ static const char* GetOsInfo()
     if( !RtlGetVersion )
     {
 #  ifdef __MINGW32__
-        sprintf( buf, "Windows (MingW)" );
+        snprintf( buf, sizeof(buf), "Windows (MingW)" );
 #  else
-        sprintf( buf, "Windows" );
+        snprintf( buf, sizeof(buf), "Windows" );
 #  endif
     }
     else
@@ -40,17 +40,17 @@ static const char* GetOsInfo()
         RtlGetVersion( &ver );
 
 #  ifdef __MINGW32__
-        sprintf( buf, "Windows %i.%i.%i (MingW)", (int)ver.dwMajorVersion, (int)ver.dwMinorVersion, (int)ver.dwBuildNumber );
+        snprintf( buf, sizeof(buf), "Windows %i.%i.%i (MingW)", (int)ver.dwMajorVersion, (int)ver.dwMinorVersion, (int)ver.dwBuildNumber );
 #  else
         auto WineGetVersion = (t_WineGetVersion)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "wine_get_version" );
         auto WineGetBuildId = (t_WineGetBuildId)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "wine_get_build_id" );
         if( WineGetVersion && WineGetBuildId )
         {
-            sprintf( buf, "Windows %i.%i.%i (Wine %s [%s])", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber, WineGetVersion(), WineGetBuildId() );
+            snprintf( buf, sizeof(buf), "Windows %i.%i.%i (Wine %s [%s])", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber, WineGetVersion(), WineGetBuildId() );
         }
         else
         {
-            sprintf( buf, "Windows %i.%i.%i", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber );
+            snprintf( buf, sizeof(buf), "Windows %i.%i.%i", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber );
         }
 #  endif
     }
@@ -58,30 +58,30 @@ static const char* GetOsInfo()
     struct utsname utsName;
     uname( &utsName );
 #  if defined __ANDROID__
-    sprintf( buf, "Linux %s (Android)", utsName.release );
+    snprintf( buf, sizeof(buf), "Linux %s (Android)", utsName.release );
 #  else
-    sprintf( buf, "Linux %s", utsName.release );
+    snprintf( buf, sizeof(buf), "Linux %s", utsName.release );
 #  endif
 #elif defined __APPLE__
 #  if TARGET_OS_IPHONE == 1
-    sprintf( buf, "Darwin (iOS)" );
+    snprintf( buf, sizeof(buf), "Darwin (iOS)" );
 #  elif TARGET_OS_MAC == 1
-    sprintf( buf, "Darwin (OSX)" );
+    snprintf( buf, sizeof(buf), "Darwin (OSX)" );
 #  else
-    sprintf( buf, "Darwin (unknown)" );
+    snprintf( buf, sizeof(buf), "Darwin (unknown)" );
 #  endif
 #elif defined __DragonFly__
-    sprintf( buf, "BSD (DragonFly)" );
+    snprintf( buf, sizeof(buf), "BSD (DragonFly)" );
 #elif defined __FreeBSD__
-    sprintf( buf, "BSD (FreeBSD)" );
+    snprintf( buf, sizeof(buf), "BSD (FreeBSD)" );
 #elif defined __NetBSD__
-    sprintf( buf, "BSD (NetBSD)" );
+    snprintf( buf, sizeof(buf), "BSD (NetBSD)" );
 #elif defined __OpenBSD__
-    sprintf( buf, "BSD (OpenBSD)" );
+    snprintf( buf, sizeof(buf), "BSD (OpenBSD)" );
 #elif defined __QNX__
-    sprintf( buf, "QNX" );
+    snprintf( buf, sizeof(buf), "QNX" );
 #else
-    sprintf( buf, "unknown" );
+    snprintf( buf, sizeof(buf), "unknown" );
 #endif
     return buf;
 }
@@ -91,10 +91,10 @@ void HttpRequest( const char* server, const char* resource, int port, const std:
     tracy::Socket sock;
     if( !sock.ConnectBlocking( server, port ) ) return;
     char request[4096];
-    const auto len = sprintf( request, "GET %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: Tracy Profiler %i.%i.%i (%s) [%s]\r\nConnection: close\r\nCache-Control: no-cache, no-store, must-revalidate\r\n\r\n", resource, server, tracy::Version::Major, tracy::Version::Minor, tracy::Version::Patch, GetOsInfo(), tracy::GitRef );
+    const auto len = snprintf( request, sizeof(request), "GET %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: Tracy Profiler %i.%i.%i (%s) [%s]\r\nConnection: close\r\nCache-Control: no-cache, no-store, must-revalidate\r\n\r\n", resource, server, tracy::Version::Major, tracy::Version::Minor, tracy::Version::Patch, GetOsInfo(), tracy::GitRef );
     sock.Send( request, len );
     char response[4096];
-    const auto sz = sock.ReadUpTo( response, 4096 );
+    const auto sz = sock.ReadUpTo( response, sizeof(response) );
     if( sz < 13 ) return;
     if( memcmp( response, "HTTP/1.1 200", 12 ) != 0 ) return;
     auto hdr = response + 13;

--- a/profiler/src/main.cpp
+++ b/profiler/src/main.cpp
@@ -134,7 +134,7 @@ static float smoothstep( float x )
 static void SetWindowTitleCallback( const char* title )
 {
     char tmp[1024];
-    sprintf( tmp, "%s - Tracy Profiler %i.%i.%i", title, tracy::Version::Major, tracy::Version::Minor, tracy::Version::Patch );
+    snprintf( tmp, sizeof(tmp), "%s - Tracy Profiler %i.%i.%i", title, tracy::Version::Major, tracy::Version::Minor, tracy::Version::Patch );
     bptr->SetTitle( tmp );
     s_customTitle = true;
 }
@@ -282,7 +282,7 @@ static void ScaleChanged( float scale )
 
 int main( int argc, char** argv )
 {
-    sprintf( title, "Tracy Profiler %i.%i.%i", tracy::Version::Major, tracy::Version::Minor, tracy::Version::Patch );
+    snprintf( title, sizeof(title), "Tracy Profiler %i.%i.%i", tracy::Version::Major, tracy::Version::Minor, tracy::Version::Patch );
 
     std::unique_ptr<tracy::FileRead> initFileOpen;
 #ifdef __EMSCRIPTEN__
@@ -699,7 +699,7 @@ static void DrawContents()
         style.Colors[ImGuiCol_WindowBg] = ImVec4( 0.129f, 0.137f, 0.11f, 1.f );
         ImGui::Begin( "Get started", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoCollapse );
         char buf[128];
-        sprintf( buf, "Tracy Profiler %i.%i.%i", tracy::Version::Major, tracy::Version::Minor, tracy::Version::Patch );
+        snprintf( buf, sizeof(buf), "Tracy Profiler %i.%i.%i", tracy::Version::Major, tracy::Version::Minor, tracy::Version::Patch );
         ImGui::PushFont( s_bigFont );
         tracy::TextCentered( buf );
         ImGui::PopFont();
@@ -1140,7 +1140,7 @@ static void DrawContents()
                 if( ImGui::IsItemHovered( ImGuiHoveredFlags_AllowWhenDisabled ) )
                 {
                     char portstr[32];
-                    sprintf( portstr, "%" PRIu16, v.second.port );
+                    snprintf( portstr, sizeof(portstr), "%" PRIu16, v.second.port );
                     ImGui::BeginTooltip();
                     if( badProto )
                     {

--- a/profiler/src/profiler/TracyImGui.cpp
+++ b/profiler/src/profiler/TracyImGui.cpp
@@ -92,7 +92,7 @@ void DrawHistogramMinMaxLabel( ImDrawList* draw, int64_t tmin, int64_t tmax, ImV
     draw->AddText( wpos + ImVec2( w-1-maxsz, ty15 ), 0x66FFFFFF, maxtxt );
 
     char range[64];
-    sprintf( range, ICON_FA_LEFT_LONG " %s " ICON_FA_RIGHT_LONG, TimeToString( tmax - tmin ) );
+    snprintf( range, sizeof(range), ICON_FA_LEFT_LONG " %s " ICON_FA_RIGHT_LONG, TimeToString( tmax - tmin ) );
 
     const auto rsz = ImGui::CalcTextSize( range ).x;
     draw->AddText( wpos + ImVec2( round( (w-1-rsz) * 0.5 ), ty15 ), 0x66FFFFFF, range );

--- a/profiler/src/profiler/TracySourceView.cpp
+++ b/profiler/src/profiler/TracySourceView.cpp
@@ -973,7 +973,7 @@ bool SourceView::Disassemble( uint64_t symAddr, const Worker& worker )
                 if( sit == m_sourceFiles.end() ) m_sourceFiles.emplace( idx, srcline );
             }
             char tmp[16];
-            sprintf( tmp, "%" PRIu32, mLineMax );
+            snprintf( tmp, sizeof(tmp), "%" PRIu32, mLineMax );
             m_maxLine = strlen( tmp ) + 1;
         }
         cs_free( insn, cnt );
@@ -1197,7 +1197,7 @@ void SourceView::RenderSymbolView( Worker& worker, View& view )
         else
         {
             char tmp[16];
-            sprintf( tmp, "0x%" PRIx64, m_baseAddr );
+            snprintf( tmp, sizeof(tmp), "0x%" PRIx64, m_baseAddr );
             TextFocused( ICON_FA_PUZZLE_PIECE " Symbol:", tmp );
         }
     }
@@ -2107,13 +2107,13 @@ void SourceView::RenderSymbolSourceView( const AddrStatData& as, Worker& worker,
         const auto ts = ImGui::CalcTextSize( " " ).x;
         const auto lineCount = lines.size();
         char buf[32];
-        sprintf( buf, "%zu", lineCount );
+        snprintf( buf, sizeof(buf), "%zu", lineCount );
         const auto maxLine = strlen( buf );
         auto lx = ts * maxLine + ty + round( ts*0.4f );
         if( as.ipTotalSrc.local + as.ipTotalSrc.ext != 0 ) lx += ts * 7 + ty;
         if( !m_asm.empty() )
         {
-            sprintf( buf, "%zu", m_asm.size() );
+            snprintf( buf, sizeof(buf), "%zu", m_asm.size() );
             const auto maxAsm = strlen( buf ) + 1;
             lx += ts * maxAsm + ty;
         }
@@ -2509,10 +2509,10 @@ uint64_t SourceView::RenderSymbolAsmView( const AddrStatData& as, Worker& worker
     int maxAddrLenRel;
     {
         char tmp[32], tmp2[32];
-        sprintf( tmp, "%" PRIx64, m_baseAddr + m_codeLen );
+        snprintf( tmp, sizeof(tmp), "%" PRIx64, m_baseAddr + m_codeLen );
         maxAddrLen = strlen( tmp );
-        sprintf( tmp, "%zu", m_asm.size() );
-        sprintf( tmp2, "+%" PRIu32, m_codeLen );
+        snprintf( tmp, sizeof(tmp), "%zu", m_asm.size() );
+        snprintf( tmp2, sizeof(tmp2), "+%" PRIu32, m_codeLen );
         maxAddrLenRel = std::max( strlen( tmp ) + 3, strlen( tmp2 ) );      // +3: [-123]
     }
 
@@ -2605,14 +2605,14 @@ uint64_t SourceView::RenderSymbolAsmView( const AddrStatData& as, Worker& worker
                         UnsetFont();
                         ImGui::BeginTooltip();
                         char tmp[32];
-                        sprintf( tmp, "+%" PRIu64, v.first - m_baseAddr );
+                        snprintf( tmp, sizeof(tmp), "+%" PRIu64, v.first - m_baseAddr );
                         TextFocused( "Jump target:", tmp );
                         ImGui::SameLine();
-                        sprintf( tmp, "(0x%" PRIx64 ")", v.first );
+                        snprintf( tmp, sizeof(tmp), "(0x%" PRIx64 ")", v.first );
                         TextDisabledUnformatted( tmp );
                         auto lit = m_locMap.find( v.first );
                         assert( lit != m_locMap.end() );
-                        sprintf( tmp, ".L%" PRIu32, lit->second );
+                        snprintf( tmp, sizeof(tmp), ".L%" PRIu32, lit->second );
                         TextFocused( "Jump label:", tmp );
                         uint32_t srcline;
                         const auto srcidx = worker.GetLocationForAddress( v.first, srcline );
@@ -2771,7 +2771,7 @@ uint64_t SourceView::RenderSymbolAsmView( const AddrStatData& as, Worker& worker
                         SmallColorBox( 0 );
                         ImGui::SameLine();
                         char buf[32];
-                        sprintf( buf, "0x%" PRIx64, src );
+                        snprintf( buf, sizeof(buf), "0x%" PRIx64, src );
                         if( ImGui::MenuItem( buf ) )
                         {
                             m_targetAddr = src;
@@ -3447,9 +3447,9 @@ void SourceView::RenderLine( const Tokenizer::Line& line, int lineNum, const Add
     {
         char tmp[32], buf[32];
         const auto lineCount = m_source.get().size();
-        sprintf( tmp, "%zu", lineCount );
+        snprintf( tmp, sizeof(tmp), "%zu", lineCount );
         const auto maxLine = strlen( tmp );
-        sprintf( tmp, "%i", lineNum );
+        snprintf( tmp, sizeof(tmp), "%i", lineNum );
         const auto linesz = strlen( tmp );
         memset( buf, ' ', maxLine - linesz );
         memcpy( buf + maxLine - linesz, tmp, linesz+1 );
@@ -3460,11 +3460,11 @@ void SourceView::RenderLine( const Tokenizer::Line& line, int lineNum, const Add
     if( !m_asm.empty() )
     {
         char buf[32];
-        sprintf( buf, "%zu", m_asm.size() );
+        snprintf( buf, sizeof(buf), "%zu", m_asm.size() );
         const auto maxAsm = strlen( buf ) + 1;
         if( match > 0 )
         {
-            sprintf( buf, "@%" PRIu32, match );
+            snprintf( buf, sizeof(buf), "@%" PRIu32, match );
             const auto asmsz = strlen( buf );
             TextDisabledUnformatted( buf );
             ImGui::SameLine( 0, 0 );
@@ -3800,15 +3800,15 @@ void SourceView::RenderAsmLine( AsmLine& line, const AddrStat& ipcnt, const Addr
     char buf[256];
     if( m_asmCountBase >= 0 )
     {
-        sprintf( buf, "[%i]", int( asmIdx - m_asmCountBase ) );
+        snprintf( buf, sizeof(buf), "[%i]", int( asmIdx - m_asmCountBase ) );
     }
     else if( m_asmRelative )
     {
-        sprintf( buf, "+%" PRIu64, line.addr - m_baseAddr );
+        snprintf( buf, sizeof(buf), "+%" PRIu64, line.addr - m_baseAddr );
     }
     else
     {
-        sprintf( buf, "%" PRIx64, line.addr );
+        snprintf( buf, sizeof(buf), "%" PRIx64, line.addr );
     }
     const auto asz = strlen( buf );
     if( m_asmRelative )
@@ -3889,11 +3889,11 @@ void SourceView::RenderAsmLine( AsmLine& line, const AddrStat& ipcnt, const Addr
             const auto fnsz = strlen( fileName );
             if( fnsz < MaxSourceLength - m_maxLine )
             {
-                sprintf( buf, "%s:%i", fileName, srcline );
+                snprintf( buf, sizeof(buf), "%s:%i", fileName, srcline );
             }
             else
             {
-                sprintf( buf, "\xe2\x80\xa6%s:%i", fileName+fnsz-(MaxSourceLength-1-1-m_maxLine), srcline );
+                snprintf( buf, sizeof(buf), "\xe2\x80\xa6%s:%i", fileName+fnsz-(MaxSourceLength-1-1-m_maxLine), srcline );
             }
             TextDisabledUnformatted( buf );
             if( ImGui::IsItemHovered() )
@@ -4577,7 +4577,7 @@ void SourceView::RenderAsmLine( AsmLine& line, const AddrStat& ipcnt, const Addr
                     ImGui::TextUnformatted( jumpName );
                 }
                 char tmp[32];
-                sprintf( tmp, "+%" PRIu32, jumpOffset );
+                snprintf( tmp, sizeof(tmp), "+%" PRIu32, jumpOffset );
                 TextFocused( "Jump target:", tmp );
                 uint32_t srcline;
                 const auto srcidx = worker.GetLocationForAddress( line.jumpAddr, srcline );
@@ -5657,7 +5657,7 @@ void SourceView::Save( const Worker& worker, size_t start, size_t stop )
         if( sz < 5 || memcmp( fn + sz - 4, ".asm", 4 ) != 0 )
         {
             char tmp[1024];
-            sprintf( tmp, "%s.asm", fn );
+            snprintf( tmp, sizeof(tmp), "%s.asm", fn );
             f = fopen( tmp, "wb" );
         }
         else
@@ -5678,7 +5678,7 @@ void SourceView::Save( const Worker& worker, size_t start, size_t stop )
             }
             else
             {
-                sprintf( tmp, "0x%" PRIx64, m_baseAddr );
+                snprintf( tmp, sizeof(tmp), "0x%" PRIx64, m_baseAddr );
                 symName = tmp;
             }
         }

--- a/profiler/src/profiler/TracyStorage.cpp
+++ b/profiler/src/profiler/TracyStorage.cpp
@@ -186,7 +186,7 @@ const char* GetSavePath( const char* program, uint64_t time, const char* file, b
     }
 
     // 604800 = 7 days
-    sz += sprintf( buf+sz, "/tracy/user/%c/%s/%" PRIu64 "/%" PRIu64 "/", tmp[0], tmp, uint64_t( time / 604800 ), time );
+    sz += snprintf( buf+sz, MaxPath - sz, "/tracy/user/%c/%s/%" PRIu64 "/%" PRIu64 "/", tmp[0], tmp, uint64_t( time / 604800 ), time );
 
     if( create )
     {

--- a/profiler/src/profiler/TracyTimelineItemGpu.cpp
+++ b/profiler/src/profiler/TracyTimelineItemGpu.cpp
@@ -27,11 +27,11 @@ const char* TimelineItemGpu::HeaderLabel() const
     static char buf[4096];
     if( m_gpu->name.Active() )
     {
-        sprintf( buf, "%s", m_worker.GetString( m_gpu->name ) );
+        snprintf( buf, sizeof(buf), "%s", m_worker.GetString( m_gpu->name ) );
     }
     else
     {
-        sprintf( buf, "%s context %i", GpuContextNames[(int)m_gpu->type], m_idx );
+        snprintf( buf, sizeof(buf), "%s context %i", GpuContextNames[(int)m_gpu->type], m_idx );
     }
     return buf;
 }
@@ -46,7 +46,7 @@ void TimelineItemGpu::HeaderTooltip( const char* label ) const
         ( m_gpu->type == GpuContextType::Metal );
 
     char buf[64];
-    sprintf( buf, "%s context %i", GpuContextNames[(int)m_gpu->type], m_idx );
+    snprintf( buf, sizeof(buf), "%s context %i", GpuContextNames[(int)m_gpu->type], m_idx );
 
     ImGui::BeginTooltip();
     if( m_gpu->name.Active() ) TextFocused( "Name:", m_worker.GetString( m_gpu->name ) );
@@ -134,7 +134,7 @@ void TimelineItemGpu::HeaderExtraContents( const TimelineContext& ctx, int offse
         const auto ty = ImGui::GetTextLineHeight();
 
         char buf[64];
-        sprintf( buf, "%s context %i", GpuContextNames[(int)m_gpu->type], m_idx );
+        snprintf( buf, sizeof(buf), "%s context %i", GpuContextNames[(int)m_gpu->type], m_idx );
         draw->AddText( ctx.wpos + ImVec2( ty * 1.5f + labelWidth, offset ), HeaderColorInactive(), buf );
     }
 }

--- a/profiler/src/profiler/TracyTimelineItemPlot.cpp
+++ b/profiler/src/profiler/TracyTimelineItemPlot.cpp
@@ -39,13 +39,13 @@ const char* TimelineItemPlot::HeaderLabel() const
         }
         else
         {
-            sprintf( tmp, ICON_FA_MEMORY " %s", m_worker.GetString( m_plot->name ) );
+            snprintf( tmp, sizeof(tmp), ICON_FA_MEMORY " %s", m_worker.GetString( m_plot->name ) );
             return tmp;
         }
     case PlotType::SysTime:
         return ICON_FA_GAUGE_HIGH " CPU usage";
     case PlotType::Power:
-        sprintf( tmp, ICON_FA_BOLT " %s", m_worker.GetString( m_plot->name ) );
+        snprintf( tmp, sizeof(tmp), ICON_FA_BOLT " %s", m_worker.GetString( m_plot->name ) );
         return tmp;
     default:
         assert( false );
@@ -96,7 +96,7 @@ void TimelineItemPlot::HeaderExtraContents( const TimelineContext& ctx, int offs
     const auto ty = ImGui::GetTextLineHeight();
 
     char tmp[128];
-    sprintf( tmp, "(y-range: %s, visible data points: %s)", FormatPlotValue( m_plot->rMax - m_plot->rMin, m_plot->format ), RealToString( m_plot->num ) );
+    snprintf( tmp, sizeof(tmp), "(y-range: %s, visible data points: %s)", FormatPlotValue( m_plot->rMax - m_plot->rMin, m_plot->format ), RealToString( m_plot->num ) );
     draw->AddText( ctx.wpos + ImVec2( ty * 1.5f + labelWidth, offset ), 0xFF226E6E, tmp );
 }
 

--- a/profiler/src/profiler/TracyUtility.cpp
+++ b/profiler/src/profiler/TracyUtility.cpp
@@ -175,10 +175,10 @@ const char* FormatPlotValue( double val, PlotValueFormatting format )
         return MemSizeToString( val );
         break;
     case PlotValueFormatting::Percentage:
-        sprintf( buf, "%.2f%%", val );
+        snprintf( buf, sizeof(buf), "%.2f%%", val );
         break;
     case PlotValueFormatting::Watt:
-        sprintf( buf, "%s W", RealToString( val ) );
+        snprintf( buf, sizeof(buf), "%s W", RealToString( val ) );
         break;
     default:
         assert( false );

--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -460,7 +460,7 @@ bool View::Draw()
                             ImGui::Text( "%i", fidx++ );
                             ImGui::TableNextColumn();
                             char buf[32];
-                            sprintf( buf, "%p", (void*)m_worker.GetCanonicalPointer( entry ) );
+                            snprintf( buf, sizeof(buf), "%p", (void*)m_worker.GetCanonicalPointer( entry ) );
                             ImGui::TextUnformatted( buf );
                             if( ImGui::IsItemHovered() )
                             {
@@ -685,7 +685,7 @@ bool View::DrawImpl()
     {
         bool keepOpen = true;
         char tmp[2048];
-        sprintf( tmp, "%s###Connection", m_worker.GetAddr().c_str() );
+        snprintf( tmp, sizeof(tmp), "%s###Connection", m_worker.GetAddr().c_str() );
         ImGui::Begin( tmp, &keepOpen, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoCollapse );
         ImGui::PushFont( m_bigFont );
         TextCentered( ICON_FA_WIFI );
@@ -721,7 +721,7 @@ bool View::DrawImpl()
         const auto dst = m_dstFileBytes.load( std::memory_order_relaxed );
         m_notificationTime = 4;
         char buf[1024];
-        sprintf( buf, "Trace size %s (%.2f%% ratio)", MemSizeToString( dst ), 100.f * dst / src );
+        snprintf( buf, sizeof(buf), "Trace size %s (%.2f%% ratio)", MemSizeToString( dst ), 100.f * dst / src );
         m_notificationText = buf;
         m_acb();
     }
@@ -805,7 +805,7 @@ bool View::DrawImpl()
     }
 #else
     char tmp[2048];
-    sprintf( tmp, "%s###Profiler", m_worker.GetCaptureName().c_str() );
+    snprintf( tmp, sizeof(tmp), "%s###Profiler", m_worker.GetCaptureName().c_str() );
     ImGui::SetNextWindowSize( ImVec2( 1550, 800 ), ImGuiCond_FirstUseEver );
     ImGui::Begin( tmp, keepOpenPtr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus );
 #endif

--- a/profiler/src/profiler/TracyView_Callstack.cpp
+++ b/profiler/src/profiler/TracyView_Callstack.cpp
@@ -37,7 +37,7 @@ void View::DrawCallstackTable( uint32_t callstack, bool globalEntriesButton )
             auto frameData = m_worker.GetCallstackFrame( entry );
             if( !frameData )
             {
-                sprintf( buf, "%3i. %p\n", fidx++, (void*)m_worker.GetCanonicalPointer( entry ) );
+                snprintf( buf, sizeof(buf), "%3i. %p\n", fidx++, (void*)m_worker.GetCanonicalPointer( entry ) );
             }
             else
             {
@@ -66,29 +66,29 @@ void View::DrawCallstackTable( uint32_t callstack, bool globalEntriesButton )
 
                     if( f == fsz-1 )
                     {
-                        ptr += sprintf( ptr, "%3i. ", fidx++ );
+                        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "%3i. ", fidx++ );
                     }
                     else
                     {
-                        ptr += sprintf( ptr, "inl. " );
+                        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "inl. " );
                     }
-                    ptr += sprintf( ptr, "%s  ", txt );
+                    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "%s  ", txt );
                     txt = m_worker.GetString( frame.file );
                     if( frame.line == 0 )
                     {
-                        ptr += sprintf( ptr, "(%s)", txt );
+                        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "(%s)", txt );
                     }
                     else
                     {
-                        ptr += sprintf( ptr, "(%s:%" PRIu32 ")", txt, frame.line );
+                        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "(%s:%" PRIu32 ")", txt, frame.line );
                     }
                     if( frameData->imageName.Active() )
                     {
-                        ptr += sprintf( ptr, " %s\n", m_worker.GetString( frameData->imageName ) );
+                        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), " %s\n", m_worker.GetString( frameData->imageName ) );
                     }
                     else
                     {
-                        ptr += sprintf( ptr, "\n" );
+                        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "\n" );
                     }
                 }
             }
@@ -166,7 +166,7 @@ void View::DrawCallstackTable( uint32_t callstack, bool globalEntriesButton )
                 ImGui::Text( "%i", fidx++ );
                 ImGui::TableNextColumn();
                 char buf[32];
-                sprintf( buf, "%p", (void*)m_worker.GetCanonicalPointer( entry ) );
+                snprintf( buf, sizeof(buf), "%p", (void*)m_worker.GetCanonicalPointer( entry ) );
                 ImGui::TextUnformatted( buf );
                 if( ImGui::IsItemClicked() )
                 {
@@ -294,7 +294,7 @@ void View::DrawCallstackTable( uint32_t callstack, bool globalEntriesButton )
                             if( ImGui::IsItemClicked() )
                             {
                                 char tmp[32];
-                                sprintf( tmp, "0x%" PRIx64, addr );
+                                snprintf( tmp, sizeof(tmp), "0x%" PRIx64, addr );
                                 ImGui::SetClipboardText( tmp );
                             }
                         }
@@ -310,7 +310,7 @@ void View::DrawCallstackTable( uint32_t callstack, bool globalEntriesButton )
                             if( ImGui::IsItemClicked() )
                             {
                                 char tmp[32];
-                                sprintf( tmp, "0x%" PRIx64, frame.symAddr );
+                                snprintf( tmp, sizeof(tmp), "0x%" PRIx64, frame.symAddr );
                                 ImGui::SetClipboardText( tmp );
                             }
                         }

--- a/profiler/src/profiler/TracyView_ConnectionState.cpp
+++ b/profiler/src/profiler/TracyView_ConnectionState.cpp
@@ -27,11 +27,11 @@ bool View::DrawConnection()
         char buf[64];
         if( mbps < 0.1f )
         {
-            sprintf( buf, "%6.2f Kbps", mbps * 1000.f );
+            snprintf( buf, sizeof(buf), "%6.2f Kbps", mbps * 1000.f );
         }
         else
         {
-            sprintf( buf, "%6.2f Mbps", mbps );
+            snprintf( buf, sizeof(buf), "%6.2f Mbps", mbps );
         }
         ImGui::Dummy( ImVec2( cs, 0 ) );
         ImGui::SameLine();
@@ -126,7 +126,7 @@ bool View::DrawConnection()
             if( sz < 7 || memcmp( fn + sz - 6, ".tracy", 6 ) != 0 )
             {
                 char tmp[1024];
-                sprintf( tmp, "%s.tracy", fn );
+                snprintf( tmp, sizeof(tmp), "%s.tracy", fn );
                 m_filenameStaging = tmp;
             }
             else

--- a/profiler/src/profiler/TracyView_CpuData.cpp
+++ b/profiler/src/profiler/TracyView_CpuData.cpp
@@ -343,16 +343,16 @@ bool View::DrawCpuData( const TimelineContext& ctx, const std::vector<CpuUsageDr
             auto& topo = m_worker.GetCpuTopology();
             if( topo.size() > 1 )
             {
-                sprintf( buf, "[%i:%i:%i] CPU %i", tt->package, tt->die, tt->core, i );
+                snprintf( buf, sizeof(buf), "[%i:%i:%i] CPU %i", tt->package, tt->die, tt->core, i );
             }
             else
             {
-                sprintf( buf, "[%i:%i] CPU %i", tt->die, tt->core, i );
+                snprintf( buf, sizeof(buf), "[%i:%i] CPU %i", tt->die, tt->core, i );
             }
         }
         else
         {
-            sprintf( buf, "CPU %i", i );
+            snprintf( buf, sizeof(buf), "CPU %i", i );
         }
         const auto txtx = ImGui::CalcTextSize( buf ).x;
         DrawTextSuperContrast( draw, wpos + ImVec2( ty, offset-1 ), 0xFFDD88DD, buf );

--- a/profiler/src/profiler/TracyView_FindZone.cpp
+++ b/profiler/src/profiler/TracyView_FindZone.cpp
@@ -77,7 +77,7 @@ void View::DrawZoneList( int id, const Vector<short_ptr<ZoneEvent>>& zones )
 {
     const auto zsz = zones.size();
     char buf[32];
-    sprintf( buf, "%i##zonelist", id );
+    snprintf( buf, sizeof(buf), "%i##zonelist", id );
     if( !ImGui::BeginTable( buf, 3, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Resizable | ImGuiTableFlags_Hideable | ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2( 0, ImGui::GetTextLineHeightWithSpacing() * std::min<size_t>( zsz + 1, 15 ) ) ) )
     {
         ImGui::TreePop();

--- a/profiler/src/profiler/TracyView_FrameTimeline.cpp
+++ b/profiler/src/profiler/TracyView_FrameTimeline.cpp
@@ -59,7 +59,7 @@ void View::DrawTimelineFramesHeader()
             auto txt = TimeToStringExact( m_vd.zvStart );
             if( m_vd.zvStart >= 0 )
             {
-                sprintf( buf, "+%s", txt );
+                snprintf( buf, sizeof(buf), "+%s", txt );
                 txt = buf;
             }
             draw->AddText( wpos + ImVec2( x, ty05 ), 0x66FFFFFF, txt );
@@ -253,7 +253,7 @@ void View::DrawTimelineFrames( const FrameData& frames )
         if( fsz - 7 <= tx )
         {
             static char tmp[256];
-            sprintf( tmp, "%s (%s)", RealToString( i ), TimeToString( ftime ) );
+            snprintf( tmp, sizeof(tmp), "%s (%s)", RealToString( i ), TimeToString( ftime ) );
             buf = tmp;
             tx = ImGui::CalcTextSize( buf ).x;
         }

--- a/profiler/src/profiler/TracyView_Locks.cpp
+++ b/profiler/src/profiler/TracyView_Locks.cpp
@@ -20,11 +20,11 @@ void View::DrawLockHeader( uint32_t id, const LockMap& lockmap, const SourceLoca
     char buf[1024];
     if( lockmap.customName.Active() )
     {
-        sprintf( buf, "%" PRIu32 ": %s", id, m_worker.GetString( lockmap.customName ) );
+        snprintf( buf, sizeof(buf), "%" PRIu32 ": %s", id, m_worker.GetString( lockmap.customName ) );
     }
     else
     {
-        sprintf( buf, "%" PRIu32 ": %s", id, m_worker.GetString( srcloc.function ) );
+        snprintf( buf, sizeof(buf), "%" PRIu32 ": %s", id, m_worker.GetString( srcloc.function ) );
     }
     ImGui::PushFont( m_smallFont );
     DrawTextContrast( draw, wpos + ImVec2( 0, offset ), 0xFF8888FF, buf );

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -119,7 +119,7 @@ void View::DrawOptions()
                 {
                     char buf[64];
                     auto& item = (TimelineItemGpu&)( m_tc.GetItem( gpuData[i] ) );
-                    sprintf( buf, "%s context %i", GpuContextNames[(int)gpuData[i]->type], item.GetIdx() );
+                    snprintf( buf, sizeof(buf), "%s context %i", GpuContextNames[(int)gpuData[i]->type], item.GetIdx() );
                     ImGui::PushFont( m_smallFont );
                     ImGui::TextUnformatted( buf );
                     ImGui::PopFont();
@@ -360,11 +360,11 @@ void View::DrawOptions()
                         char buf[1024];
                         if( l.second->customName.Active() )
                         {
-                            sprintf( buf, "%" PRIu32 ": %s", l.first, m_worker.GetString( l.second->customName ) );
+                            snprintf( buf, sizeof(buf), "%" PRIu32 ": %s", l.first, m_worker.GetString( l.second->customName ) );
                         }
                         else
                         {
-                            sprintf( buf, "%" PRIu32 ": %s", l.first, m_worker.GetString( m_worker.GetSourceLocation( l.second->srcloc ).function ) );
+                            snprintf( buf, sizeof(buf), "%" PRIu32 ": %s", l.first, m_worker.GetString( m_worker.GetSourceLocation( l.second->srcloc ).function ) );
                         }
                         SmallCheckbox( buf, &Vis( l.second ) );
                         if( ImGui::IsItemHovered() )
@@ -447,11 +447,11 @@ void View::DrawOptions()
                         char buf[1024];
                         if( l.second->customName.Active() )
                         {
-                            sprintf( buf, "%" PRIu32 ": %s", l.first, m_worker.GetString( l.second->customName ) );
+                            snprintf( buf, sizeof(buf), "%" PRIu32 ": %s", l.first, m_worker.GetString( l.second->customName ) );
                         }
                         else
                         {
-                            sprintf( buf, "%" PRIu32 ": %s", l.first, m_worker.GetString( m_worker.GetSourceLocation( l.second->srcloc ).function ) );
+                            snprintf( buf, sizeof(buf), "%" PRIu32 ": %s", l.first, m_worker.GetString( m_worker.GetSourceLocation( l.second->srcloc ).function ) );
                         }
                         SmallCheckbox( buf, &Vis( l.second ) );
                         if( ImGui::IsItemHovered() )
@@ -534,11 +534,11 @@ void View::DrawOptions()
                         char buf[1024];
                         if( l.second->customName.Active() )
                         {
-                            sprintf( buf, "%" PRIu32 ": %s", l.first, m_worker.GetString( l.second->customName ) );
+                            snprintf( buf, sizeof(buf), "%" PRIu32 ": %s", l.first, m_worker.GetString( l.second->customName ) );
                         }
                         else
                         {
-                            sprintf( buf, "%" PRIu32 ": %s", l.first, m_worker.GetString( m_worker.GetSourceLocation( l.second->srcloc ).function ) );
+                            snprintf( buf, sizeof(buf), "%" PRIu32 ": %s", l.first, m_worker.GetString( m_worker.GetSourceLocation( l.second->srcloc ).function ) );
                         }
                         SmallCheckbox( buf, &Vis( l.second ) );
                         if( ImGui::IsItemHovered() )

--- a/profiler/src/profiler/TracyView_Samples.cpp
+++ b/profiler/src/profiler/TracyView_Samples.cpp
@@ -1095,7 +1095,7 @@ void View::DrawSampleParents()
                                 if( ImGui::IsItemClicked() )
                                 {
                                     char tmp[32];
-                                    sprintf( tmp, "0x%" PRIx64, addr );
+                                    snprintf( tmp, sizeof(tmp), "0x%" PRIx64, addr );
                                     ImGui::SetClipboardText( tmp );
                                 }
                             }
@@ -1109,7 +1109,7 @@ void View::DrawSampleParents()
                             if( ImGui::IsItemClicked() )
                             {
                                 char tmp[32];
-                                sprintf( tmp, "0x%" PRIx64, frame.symAddr );
+                                snprintf( tmp, sizeof(tmp), "0x%" PRIx64, frame.symAddr );
                                 ImGui::SetClipboardText( tmp );
                             }
                             break;

--- a/profiler/src/profiler/TracyView_TraceInfo.cpp
+++ b/profiler/src/profiler/TracyView_TraceInfo.cpp
@@ -710,7 +710,7 @@ void View::DrawInfo()
             float ttsz = 0;
             for( auto& package : topology )
             {
-                sprintf( buf, ICON_FA_BOX " Package %" PRIu32, package.first );
+                snprintf( buf, sizeof(buf), ICON_FA_BOX " Package %" PRIu32, package.first );
                 ImGui::PushFont( m_smallFont );
                 const auto psz = ImGui::CalcTextSize( buf ).x;
                 if( psz > ptsz ) ptsz = psz;
@@ -719,13 +719,13 @@ void View::DrawInfo()
                 size_t mt = 0;
                 for( auto& die : package.second )
                 {
-                    sprintf( buf, ICON_FA_DICE_D6 " Die %" PRIu32, die.first );
+                    snprintf( buf, sizeof(buf), ICON_FA_DICE_D6 " Die %" PRIu32, die.first );
                     const auto dsz = ImGui::CalcTextSize( buf ).x;
                     if( dsz > dtsz ) dtsz = dsz;
 
                     for( auto& core : die.second )
                     {
-                        sprintf( buf, ICON_FA_MICROCHIP "%" PRIu32, core.first );
+                        snprintf( buf, sizeof(buf), ICON_FA_MICROCHIP "%" PRIu32, core.first );
                         const auto csz = ImGui::CalcTextSize( buf ).x;
                         if( csz > ctsz ) ctsz = csz;
 
@@ -734,7 +734,7 @@ void View::DrawInfo()
 
                         for( auto& thread : core.second )
                         {
-                            sprintf( buf, ICON_FA_SHUFFLE "%" PRIu32, thread );
+                            snprintf( buf, sizeof(buf), ICON_FA_SHUFFLE "%" PRIu32, thread );
                             const auto tsz = ImGui::CalcTextSize( buf ).x;
                             if( tsz > ttsz ) ttsz = tsz;
                         }
@@ -757,7 +757,7 @@ void View::DrawInfo()
             for( auto& package : tsort )
             {
                 if( package->first != 0 ) dpos.y += ty;
-                sprintf( buf, ICON_FA_BOX " Package %" PRIu32, package->first );
+                snprintf( buf, sizeof(buf), ICON_FA_BOX " Package %" PRIu32, package->first );
                 draw->AddText( dpos, 0xFFFFFFFF, buf );
                 dpos.y += ty;
 
@@ -768,7 +768,7 @@ void View::DrawInfo()
                 for( auto& die : dsort )
                 {
                     dpos.y += small;
-                    sprintf( buf, ICON_FA_DICE_D6 " Die %" PRIu32, die->first );
+                    snprintf( buf, sizeof(buf), ICON_FA_DICE_D6 " Die %" PRIu32, die->first );
                     draw->AddText( dpos, 0xFFFFFFFF, buf );
                     dpos.y += ty;
 
@@ -792,13 +792,13 @@ void View::DrawInfo()
                     int ll = cpl;
                     for( auto& core : csort )
                     {
-                        sprintf( buf, ICON_FA_MICROCHIP "%" PRIu32, core->first );
+                        snprintf( buf, sizeof(buf), ICON_FA_MICROCHIP "%" PRIu32, core->first );
                         draw->AddText( cpos, 0xFFFFFFFF, buf );
                         draw->AddRect( cpos + ImVec2( 0, ty ), cpos + ImVec2( inCoreWidth + small, inCoreHeight + small ), 0xFFFFFFFF );
 
                         for( int i=0; i<core->second.size(); i++ )
                         {
-                            sprintf( buf, ICON_FA_SHUFFLE "%" PRIu32, core->second[i] );
+                            snprintf( buf, sizeof(buf), ICON_FA_SHUFFLE "%" PRIu32, core->second[i] );
                             draw->AddText( cpos + ImVec2( margin + i * ( margin + ttsz ), ty + small ), 0xFFFFFFFF, buf );
                         }
 

--- a/profiler/src/profiler/TracyView_Utility.cpp
+++ b/profiler/src/profiler/TracyView_Utility.cpp
@@ -785,20 +785,20 @@ const char* View::GetFrameText( const FrameData& fd, int i, uint64_t ftime ) con
     {
         if( i == 0 )
         {
-            sprintf( buf, "Tracy init (%s)", TimeToString( ftime ) );
+            snprintf( buf, sizeof(buf), "Tracy init (%s)", TimeToString( ftime ) );
         }
         else if( i != 1 || !m_worker.IsOnDemand() )
         {
-            sprintf( buf, "Frame %s (%s)", RealToString( fnum ), TimeToString( ftime ) );
+            snprintf( buf, sizeof(buf), "Frame %s (%s)", RealToString( fnum ), TimeToString( ftime ) );
         }
         else
         {
-            sprintf( buf, "Missed frames (%s)", TimeToString( ftime ) );
+            snprintf( buf, sizeof(buf), "Missed frames (%s)", TimeToString( ftime ) );
         }
     }
     else
     {
-        sprintf( buf, "%s %s (%s)", GetFrameSetName( fd ), RealToString( fnum ), TimeToString( ftime ) );
+        snprintf( buf, sizeof(buf), "%s %s (%s)", GetFrameSetName( fd ), RealToString( fnum ), TimeToString( ftime ) );
     }
     return buf;
 }
@@ -822,7 +822,7 @@ const char* View::GetFrameSetName( const FrameData& fd, const Worker& worker )
     {
         char* buf = bufpool[bufsel];
         bufsel = ( bufsel + 1 ) % Pool;
-        sprintf( buf, "[%" PRIu32 "] Vsync", uint32_t( fd.name ) );
+        snprintf( buf, sizeof(buf), "[%" PRIu32 "] Vsync", uint32_t( fd.name ) );
         return buf;
     }
     else

--- a/profiler/src/profiler/TracyView_ZoneInfo.cpp
+++ b/profiler/src/profiler/TracyView_ZoneInfo.cpp
@@ -394,7 +394,7 @@ void View::DrawZoneInfoWindow()
                 if( srcloc.name.active )
                 {
                     char tmp[1024];
-                    sprintf( tmp, "%s (%s)", m_worker.GetString( m_worker.GetZoneExtra( ev ).name ), m_worker.GetString( srcloc.name ) );
+                    snprintf( tmp, sizeof(tmp), "%s (%s)", m_worker.GetString( m_worker.GetZoneExtra( ev ).name ), m_worker.GetString( srcloc.name ) );
                     ImGui::SetClipboardText( tmp );
                 }
                 else

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -427,7 +427,7 @@ void View::DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineD
             if( !frame )
             {
                 char symName[64];
-                sprintf( symName, "0x%" PRIx64, m_worker.GetCanonicalPointer( ghostKey.frame ) );
+                snprintf( symName, sizeof(symName), "0x%" PRIx64, m_worker.GetCanonicalPointer( ghostKey.frame ) );
                 const auto tsz = ImGui::CalcTextSize( symName );
 
                 const auto accentColor = HighlightColor( color );

--- a/profiler/src/profiler/TracyWeb.cpp
+++ b/profiler/src/profiler/TracyWeb.cpp
@@ -19,13 +19,13 @@ void OpenWebpage( const char* url )
     ShellExecuteA( nullptr, nullptr, url, nullptr, nullptr, 0 );
 #elif defined __APPLE__
     char buf[1024];
-    sprintf( buf, "open %s", url );
+    snprintf( buf, sizeof(buf), "open %s", url );
     system( buf );
 #elif defined __EMSCRIPTEN__
     EM_ASM( { window.open( UTF8ToString( $0 ), '_blank' ) }, url );
 #else
     char buf[1024];
-    sprintf( buf, "xdg-open %s", url );
+    snprintf( buf, sizeof(buf), "xdg-open %s", url );
     system( buf );
 #endif
 }

--- a/public/client/TracyArmCpuTable.hpp
+++ b/public/client/TracyArmCpuTable.hpp
@@ -29,7 +29,7 @@ static const char* DecodeArmImplementer( uint32_t v )
     case 0xc0: return "Ampere Computing";
     default: break;
     }
-    sprintf( buf, "0x%x", v );
+    snprintf( buf, sizeof(buf), "0x%x", v );
     return buf;
 }
 
@@ -249,7 +249,7 @@ static const char* DecodeArmPart( uint32_t impl, uint32_t part )
         }
     default: break;
     }
-    sprintf( buf, " 0x%x", part );
+    snprintf( buf, sizeof(buf), " 0x%x", part );
     return buf;
 }
 

--- a/public/client/TracyCallstack.cpp
+++ b/public/client/TracyCallstack.cpp
@@ -1169,7 +1169,7 @@ static int CallstackDataCb( void* /*data*/, uintptr_t pc, uintptr_t lowaddr, con
         else
         {
             char buf[32];
-            const auto offlen = sprintf( buf, " + %td", symoff );
+            const auto offlen = snprintf( buf, sizeof(buf), " + %td", symoff );
             const auto namelen = std::min<size_t>( strlen( symname ), std::numeric_limits<uint16_t>::max() - offlen );
             auto name = (char*)tracy_malloc_fast( namelen + offlen + 1 );
             memcpy( name, symname, namelen );
@@ -1392,7 +1392,7 @@ CallstackEntryData DecodeCallstackPtr( uint64_t ptr )
     else
     {
         char buf[32];
-        const auto offlen = sprintf( buf, " + %td", symoff );
+        const auto offlen = snprintf( buf, sizeof(buf), " + %td", symoff );
         const auto namelen = std::min<size_t>( strlen( symname ), std::numeric_limits<uint16_t>::max() - offlen );
         auto name = (char*)tracy_malloc( namelen + offlen + 1 );
         memcpy( name, symname, namelen );

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -515,9 +515,9 @@ static const char* GetHostInfo()
     if( !GetVersion )
     {
 #  ifdef __MINGW32__
-        ptr += sprintf( ptr, "OS: Windows (MingW)\n" );
+        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: Windows (MingW)\n" );
 #  else
-        ptr += sprintf( ptr, "OS: Windows\n" );
+        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: Windows\n" );
 #  endif
     }
     else
@@ -526,17 +526,17 @@ static const char* GetHostInfo()
         GetVersion( &ver );
 
 #  ifdef __MINGW32__
-        ptr += sprintf( ptr, "OS: Windows %i.%i.%i (MingW)\n", (int)ver.dwMajorVersion, (int)ver.dwMinorVersion, (int)ver.dwBuildNumber );
+        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: Windows %i.%i.%i (MingW)\n", (int)ver.dwMajorVersion, (int)ver.dwMinorVersion, (int)ver.dwBuildNumber );
 #  else
         auto WineGetVersion = (t_WineGetVersion)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "wine_get_version" );
         auto WineGetBuildId = (t_WineGetBuildId)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "wine_get_build_id" );
         if( WineGetVersion && WineGetBuildId )
         {
-            ptr += sprintf( ptr, "OS: Windows %lu.%lu.%lu (Wine %s [%s])\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber, WineGetVersion(), WineGetBuildId() );
+            ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: Windows %lu.%lu.%lu (Wine %s [%s])\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber, WineGetVersion(), WineGetBuildId() );
         }
         else
         {
-            ptr += sprintf( ptr, "OS: Windows %lu.%lu.%lu\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber );
+            ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: Windows %lu.%lu.%lu\n", ver.dwMajorVersion, ver.dwMinorVersion, ver.dwBuildNumber );
         }
 #  endif
     }
@@ -544,44 +544,44 @@ static const char* GetHostInfo()
     struct utsname utsName;
     uname( &utsName );
 #  if defined __ANDROID__
-    ptr += sprintf( ptr, "OS: Linux %s (Android)\n", utsName.release );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: Linux %s (Android)\n", utsName.release );
 #  else
-    ptr += sprintf( ptr, "OS: Linux %s\n", utsName.release );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: Linux %s\n", utsName.release );
 #  endif
 #elif defined __APPLE__
 #  if TARGET_OS_IPHONE == 1
-    ptr += sprintf( ptr, "OS: Darwin (iOS)\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: Darwin (iOS)\n" );
 #  elif TARGET_OS_MAC == 1
-    ptr += sprintf( ptr, "OS: Darwin (OSX)\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: Darwin (OSX)\n" );
 #  else
-    ptr += sprintf( ptr, "OS: Darwin (unknown)\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: Darwin (unknown)\n" );
 #  endif
 #elif defined __DragonFly__
-    ptr += sprintf( ptr, "OS: BSD (DragonFly)\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: BSD (DragonFly)\n" );
 #elif defined __FreeBSD__
-    ptr += sprintf( ptr, "OS: BSD (FreeBSD)\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: BSD (FreeBSD)\n" );
 #elif defined __NetBSD__
-    ptr += sprintf( ptr, "OS: BSD (NetBSD)\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: BSD (NetBSD)\n" );
 #elif defined __OpenBSD__
-    ptr += sprintf( ptr, "OS: BSD (OpenBSD)\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: BSD (OpenBSD)\n" );
 #elif defined __QNX__
-    ptr += sprintf( ptr, "OS: QNX\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: QNX\n" );
 #else
-    ptr += sprintf( ptr, "OS: unknown\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "OS: unknown\n" );
 #endif
 
 #if defined _MSC_VER
 #  if defined __clang__
-    ptr += sprintf( ptr, "Compiler: MSVC clang-cl %i.%i.%i\n", __clang_major__, __clang_minor__, __clang_patchlevel__ );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Compiler: MSVC clang-cl %i.%i.%i\n", __clang_major__, __clang_minor__, __clang_patchlevel__ );
 #  else
-    ptr += sprintf( ptr, "Compiler: MSVC %i\n", _MSC_VER );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Compiler: MSVC %i\n", _MSC_VER );
 #  endif
 #elif defined __clang__
-    ptr += sprintf( ptr, "Compiler: clang %i.%i.%i\n", __clang_major__, __clang_minor__, __clang_patchlevel__ );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Compiler: clang %i.%i.%i\n", __clang_major__, __clang_minor__, __clang_patchlevel__ );
 #elif defined __GNUC__
-    ptr += sprintf( ptr, "Compiler: gcc %i.%i.%i\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__ );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Compiler: gcc %i.%i.%i\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__ );
 #else
-    ptr += sprintf( ptr, "Compiler: unknown\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Compiler: unknown\n" );
 #endif
 
 #if defined _WIN32
@@ -598,7 +598,7 @@ static const char* GetHostInfo()
     GetUserNameA( user, &userSz );
 #  endif
 
-    ptr += sprintf( ptr, "User: %s@%s\n", user, hostname );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "User: %s@%s\n", user, hostname );
 #else
     char hostname[_POSIX_HOST_NAME_MAX]{};
     char user[_POSIX_LOGIN_NAME_MAX]{};
@@ -618,19 +618,19 @@ static const char* GetHostInfo()
     getlogin_r( user, _POSIX_LOGIN_NAME_MAX );
 #  endif
 
-    ptr += sprintf( ptr, "User: %s@%s\n", user, hostname );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "User: %s@%s\n", user, hostname );
 #endif
 
 #if defined __i386 || defined _M_IX86
-    ptr += sprintf( ptr, "Arch: x86\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Arch: x86\n" );
 #elif defined __x86_64__ || defined _M_X64
-    ptr += sprintf( ptr, "Arch: x64\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Arch: x64\n" );
 #elif defined __aarch64__
-    ptr += sprintf( ptr, "Arch: ARM64\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Arch: ARM64\n" );
 #elif defined __ARM_ARCH
-    ptr += sprintf( ptr, "Arch: ARM\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Arch: ARM\n" );
 #else
-    ptr += sprintf( ptr, "Arch: unknown\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Arch: unknown\n" );
 #endif
 
 #if defined __i386 || defined _M_IX86 || defined __x86_64__ || defined _M_X64
@@ -643,7 +643,7 @@ static const char* GetHostInfo()
         memcpy( modelPtr, regs, sizeof( regs ) ); modelPtr += sizeof( regs );
     }
 
-    ptr += sprintf( ptr, "CPU: %s\n", cpuModel );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "CPU: %s\n", cpuModel );
 #elif defined __linux__ && defined __ARM_ARCH
     bool cpuFound = false;
     FILE* fcpuinfo = fopen( "/proc/cpuinfo", "rb" );
@@ -686,12 +686,12 @@ static const char* GetHostInfo()
         if( impl != 0 || var != 0 || part != 0 || rev != 0 )
         {
             cpuFound = true;
-            ptr += sprintf( ptr, "CPU: %s%s r%ip%i\n", DecodeArmImplementer( impl ), DecodeArmPart( impl, part ), var, rev );
+            ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "CPU: %s%s r%ip%i\n", DecodeArmImplementer( impl ), DecodeArmPart( impl, part ), var, rev );
         }
     }
     if( !cpuFound )
     {
-        ptr += sprintf( ptr, "CPU: unknown\n" );
+        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "CPU: unknown\n" );
     }
 #elif defined __APPLE__ && TARGET_OS_IPHONE == 1
     {
@@ -699,45 +699,45 @@ static const char* GetHostInfo()
         sysctlbyname( "hw.machine", nullptr, &sz, nullptr, 0 );
         auto str = (char*)tracy_malloc( sz );
         sysctlbyname( "hw.machine", str, &sz, nullptr, 0 );
-        ptr += sprintf( ptr, "Device: %s\n", DecodeIosDevice( str ) );
+        ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Device: %s\n", DecodeIosDevice( str ) );
         tracy_free( str );
     }
 #else
-    ptr += sprintf( ptr, "CPU: unknown\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "CPU: unknown\n" );
 #endif
 #ifdef __ANDROID__
     char deviceModel[PROP_VALUE_MAX+1];
     char deviceManufacturer[PROP_VALUE_MAX+1];
     __system_property_get( "ro.product.model", deviceModel );
     __system_property_get( "ro.product.manufacturer", deviceManufacturer );
-    ptr += sprintf( ptr, "Device: %s %s\n", deviceManufacturer, deviceModel );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "Device: %s %s\n", deviceManufacturer, deviceModel );
 #endif
 
-    ptr += sprintf( ptr, "CPU cores: %i\n", std::thread::hardware_concurrency() );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "CPU cores: %i\n", std::thread::hardware_concurrency() );
 
 #if defined _WIN32
     MEMORYSTATUSEX statex;
     statex.dwLength = sizeof( statex );
     GlobalMemoryStatusEx( &statex );
 #  ifdef _MSC_VER
-    ptr += sprintf( ptr, "RAM: %I64u MB\n", statex.ullTotalPhys / 1024 / 1024 );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "RAM: %I64u MB\n", statex.ullTotalPhys / 1024 / 1024 );
 #  else
-    ptr += sprintf( ptr, "RAM: %llu MB\n", statex.ullTotalPhys / 1024 / 1024 );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "RAM: %llu MB\n", statex.ullTotalPhys / 1024 / 1024 );
 #  endif
 #elif defined __linux__
     struct sysinfo sysInfo;
     sysinfo( &sysInfo );
-    ptr += sprintf( ptr, "RAM: %lu MB\n", sysInfo.totalram / 1024 / 1024 );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "RAM: %lu MB\n", sysInfo.totalram / 1024 / 1024 );
 #elif defined __APPLE__
     size_t memSize;
     size_t sz = sizeof( memSize );
     sysctlbyname( "hw.memsize", &memSize, &sz, nullptr, 0 );
-    ptr += sprintf( ptr, "RAM: %zu MB\n", memSize / 1024 / 1024 );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "RAM: %zu MB\n", memSize / 1024 / 1024 );
 #elif defined BSD
     size_t memSize;
     size_t sz = sizeof( memSize );
     sysctlbyname( "hw.physmem", &memSize, &sz, nullptr, 0 );
-    ptr += sprintf( ptr, "RAM: %zu MB\n", memSize / 1024 / 1024 );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "RAM: %zu MB\n", memSize / 1024 / 1024 );
 #elif defined __QNX__
     struct asinfo_entry *entries = SYSPAGE_ENTRY(asinfo);
     size_t count = SYSPAGE_ENTRY_SIZE(asinfo) / sizeof(struct asinfo_entry);
@@ -752,9 +752,9 @@ static const char* GetHostInfo()
         }
     }
     memSize = memSize / 1024 / 1024;
-    ptr += sprintf( ptr, "RAM: %llu MB\n", memSize);
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "RAM: %llu MB\n", memSize);
 #else
-    ptr += sprintf( ptr, "RAM: unknown\n" );
+    ptr += snprintf( ptr, sizeof(buf) - (ptr - buf), "RAM: unknown\n" );
 #endif
 
     return buf;
@@ -815,45 +815,45 @@ LONG WINAPI CrashFilter( PEXCEPTION_POINTERS pExp )
     switch( ec )
     {
     case EXCEPTION_ACCESS_VIOLATION:
-        msgPtr += sprintf( msgPtr, "Exception EXCEPTION_ACCESS_VIOLATION (0x%x). ", ec );
+        msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Exception EXCEPTION_ACCESS_VIOLATION (0x%x). ", ec );
         switch( pExp->ExceptionRecord->ExceptionInformation[0] )
         {
         case 0:
-            msgPtr += sprintf( msgPtr, "Read violation at address 0x%" PRIxPTR ".", pExp->ExceptionRecord->ExceptionInformation[1] );
+            msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Read violation at address 0x%" PRIxPTR ".", pExp->ExceptionRecord->ExceptionInformation[1] );
             break;
         case 1:
-            msgPtr += sprintf( msgPtr, "Write violation at address 0x%" PRIxPTR ".", pExp->ExceptionRecord->ExceptionInformation[1] );
+            msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Write violation at address 0x%" PRIxPTR ".", pExp->ExceptionRecord->ExceptionInformation[1] );
             break;
         case 8:
-            msgPtr += sprintf( msgPtr, "DEP violation at address 0x%" PRIxPTR ".", pExp->ExceptionRecord->ExceptionInformation[1] );
+            msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "DEP violation at address 0x%" PRIxPTR ".", pExp->ExceptionRecord->ExceptionInformation[1] );
             break;
         default:
             break;
         }
         break;
     case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
-        msgPtr += sprintf( msgPtr, "Exception EXCEPTION_ARRAY_BOUNDS_EXCEEDED (0x%x). ", ec );
+        msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Exception EXCEPTION_ARRAY_BOUNDS_EXCEEDED (0x%x). ", ec );
         break;
     case EXCEPTION_DATATYPE_MISALIGNMENT:
-        msgPtr += sprintf( msgPtr, "Exception EXCEPTION_DATATYPE_MISALIGNMENT (0x%x). ", ec );
+        msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Exception EXCEPTION_DATATYPE_MISALIGNMENT (0x%x). ", ec );
         break;
     case EXCEPTION_FLT_DIVIDE_BY_ZERO:
-        msgPtr += sprintf( msgPtr, "Exception EXCEPTION_FLT_DIVIDE_BY_ZERO (0x%x). ", ec );
+        msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Exception EXCEPTION_FLT_DIVIDE_BY_ZERO (0x%x). ", ec );
         break;
     case EXCEPTION_ILLEGAL_INSTRUCTION:
-        msgPtr += sprintf( msgPtr, "Exception EXCEPTION_ILLEGAL_INSTRUCTION (0x%x). ", ec );
+        msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Exception EXCEPTION_ILLEGAL_INSTRUCTION (0x%x). ", ec );
         break;
     case EXCEPTION_IN_PAGE_ERROR:
-        msgPtr += sprintf( msgPtr, "Exception EXCEPTION_IN_PAGE_ERROR (0x%x). ", ec );
+        msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Exception EXCEPTION_IN_PAGE_ERROR (0x%x). ", ec );
         break;
     case EXCEPTION_INT_DIVIDE_BY_ZERO:
-        msgPtr += sprintf( msgPtr, "Exception EXCEPTION_INT_DIVIDE_BY_ZERO (0x%x). ", ec );
+        msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Exception EXCEPTION_INT_DIVIDE_BY_ZERO (0x%x). ", ec );
         break;
     case EXCEPTION_PRIV_INSTRUCTION:
-        msgPtr += sprintf( msgPtr, "Exception EXCEPTION_PRIV_INSTRUCTION (0x%x). ", ec );
+        msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Exception EXCEPTION_PRIV_INSTRUCTION (0x%x). ", ec );
         break;
     case EXCEPTION_STACK_OVERFLOW:
-        msgPtr += sprintf( msgPtr, "Exception EXCEPTION_STACK_OVERFLOW (0x%x). ", ec );
+        msgPtr += snprintf( msgPtr, sizeof(s_crashText) - (msgPtr - s_crashText), "Exception EXCEPTION_STACK_OVERFLOW (0x%x). ", ec );
         break;
     default:
         return EXCEPTION_CONTINUE_SEARCH;
@@ -3989,7 +3989,7 @@ void Profiler::ReportTopology()
     for( int i=0; i<numcpus; i++ )
     {
         char path[1024];
-        sprintf( path, "%s%i/topology/physical_package_id", basePath, i );
+        snprintf( path, sizeof(path), "%s%i/topology/physical_package_id", basePath, i );
         char buf[1024];
         FILE* f = fopen( path, "rb" );
         if( !f )
@@ -4003,7 +4003,7 @@ void Profiler::ReportTopology()
         cpuData[i].package = uint32_t( atoi( buf ) );
         cpuData[i].thread = i;
 
-        sprintf( path, "%s%i/topology/core_id", basePath, i );
+        snprintf( path, sizeof(path), "%s%i/topology/core_id", basePath, i );
         f = fopen( path, "rb" );
         if( f )
         {
@@ -4013,7 +4013,7 @@ void Profiler::ReportTopology()
             cpuData[i].core = uint32_t( atoi( buf ) );
         }
 
-        sprintf( path, "%s%i/topology/die_id", basePath, i );
+        snprintf( path, sizeof(path), "%s%i/topology/die_id", basePath, i );
         f = fopen( path, "rb" );
         if( f )
         {

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -648,7 +648,7 @@ static bool CurrentProcOwnsThread( uint32_t tid )
     if( hv == -tid ) return false;
 
     char path[256];
-    sprintf( path, "/proc/self/task/%d", tid );
+    snprintf( path, sizeof(path), "/proc/self/task/%d", tid );
     struct stat st;
     if( stat( path, &st ) == 0 )
     {
@@ -1541,7 +1541,7 @@ void SysTraceGetExternalName( uint64_t thread, const char*& threadName, const ch
 {
     FILE* f;
     char fn[256];
-    sprintf( fn, "/proc/%" PRIu64 "/comm", thread );
+    snprintf( fn, sizeof(fn), "/proc/%" PRIu64 "/comm", thread );
     f = fopen( fn, "rb" );
     if( f )
     {
@@ -1556,7 +1556,7 @@ void SysTraceGetExternalName( uint64_t thread, const char*& threadName, const ch
         threadName = CopyString( "???", 3 );
     }
 
-    sprintf( fn, "/proc/%" PRIu64 "/status", thread );
+    snprintf( fn, sizeof(fn), "/proc/%" PRIu64 "/status", thread );
     f = fopen( fn, "rb" );
     if( f )
     {
@@ -1588,7 +1588,7 @@ void SysTraceGetExternalName( uint64_t thread, const char*& threadName, const ch
                 MemWrite( &item->tidToPid.pid, _pid );
                 TracyLfqCommit;
             }
-            sprintf( fn, "/proc/%i/comm", pid );
+            snprintf( fn, sizeof(fn), "/proc/%i/comm", pid );
             f = fopen( fn, "rb" );
             if( f )
             {

--- a/public/common/TracySocket.cpp
+++ b/public/common/TracySocket.cpp
@@ -164,7 +164,7 @@ bool Socket::Connect( const char* addr, uint16_t port )
     hints.ai_socktype = SOCK_STREAM;
 
     char portbuf[32];
-    sprintf( portbuf, "%" PRIu16, port );
+    snprintf( portbuf, sizeof(portbuf), "%" PRIu16, port );
 
     if( getaddrinfo( addr, portbuf, &hints, &res ) != 0 ) return false;
     int sock = 0;
@@ -236,7 +236,7 @@ bool Socket::ConnectBlocking( const char* addr, uint16_t port )
     hints.ai_socktype = SOCK_STREAM;
 
     char portbuf[32];
-    sprintf( portbuf, "%" PRIu16, port );
+    snprintf( portbuf, sizeof(portbuf), "%" PRIu16, port );
 
     if( getaddrinfo( addr, portbuf, &hints, &res ) != 0 ) return false;
     int sock = 0;
@@ -465,7 +465,7 @@ static int addrinfo_and_socket_for_family( uint16_t port, int ai_family, struct 
     }
 #endif
     char portbuf[32];
-    sprintf( portbuf, "%" PRIu16, port );
+    snprintf( portbuf, sizeof(portbuf), "%" PRIu16, port );
     if( getaddrinfo( nullptr, portbuf, &hints, res ) != 0 ) return -1;
     int sock = socket( (*res)->ai_family, (*res)->ai_socktype, (*res)->ai_protocol );
     if (sock == -1) freeaddrinfo( *res );
@@ -575,7 +575,7 @@ bool UdpBroadcast::Open( const char* addr, uint16_t port )
     hints.ai_socktype = SOCK_DGRAM;
 
     char portbuf[32];
-    sprintf( portbuf, "%" PRIu16, port );
+    snprintf( portbuf, sizeof(portbuf), "%" PRIu16, port );
 
     if( getaddrinfo( addr, portbuf, &hints, &res ) != 0 ) return false;
     int sock = 0;

--- a/public/common/TracySystem.cpp
+++ b/public/common/TracySystem.cpp
@@ -273,7 +273,7 @@ TRACY_API const char* GetThreadName( uint32_t id )
   int cs, fd;
   char path[32];
   snprintf( path, sizeof( path ), "/proc/self/task/%d/comm", id );
-  sprintf( buf, "%" PRIu32, id );
+  snprintf( buf, sizeof(buf), "%" PRIu32, id );
 # ifndef __ANDROID__
    pthread_setcancelstate( PTHREAD_CANCEL_DISABLE, &cs );
 # endif
@@ -300,7 +300,7 @@ TRACY_API const char* GetThreadName( uint32_t id )
     };
 #endif
 
-  sprintf( buf, "%" PRIu32, id );
+  snprintf( buf, sizeof(buf), "%" PRIu32, id );
   return buf;
 }
 

--- a/server/TracyPrint.cpp
+++ b/server/TracyPrint.cpp
@@ -362,7 +362,7 @@ const char* MemSizeToString( int64_t val )
 
     if( aval < 10000ll )
     {
-        sprintf( buf, "%" PRIi64 " bytes", val );
+        snprintf( buf, sizeof(bufpool[0]), "%" PRIi64 " bytes", val );
         return buf;
     }
 
@@ -436,7 +436,7 @@ const char* LocationToString( const char* fn, uint32_t line )
     char* buf = bufpool[bufsel];
     bufsel = ( bufsel + 1 ) % Pool;
 
-    sprintf( buf, "%s:%i", fn, line );
+    snprintf( buf, sizeof(bufpool[0]), "%s:%i", fn, line );
     return buf;
 }
 

--- a/server/TracyPrint.hpp
+++ b/server/TracyPrint.hpp
@@ -85,7 +85,7 @@ static inline char* PrintFloat( char* begin, char* end, T value, int precision )
 #ifndef NO_CHARCONV
     return std::to_chars( begin, end, value, std::chars_format::fixed, precision ).ptr;
 #else
-    return begin + sprintf( begin, "%.*f", precision, value );
+    return begin + snprintf( begin, end - begin, "%.*f", precision, value );
 #endif
 }
 
@@ -95,7 +95,7 @@ static inline char* PrintFloat( char* begin, char* end, T value )
 #ifndef NO_CHARCONV
     return std::to_chars( begin, end, value, std::chars_format::fixed ).ptr;
 #else
-    return begin + sprintf( begin, "%f", value );
+    return begin + snprintf( begin, end - begin, "%f", value );
 #endif
 }
 

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -522,11 +522,11 @@ Worker::Worker( const char* name, const char* program, const std::vector<ImportE
             int len;
             if( t.first <= std::numeric_limits<uint32_t>::max() )
             {
-                len = sprintf( buf, "%" PRIu64, t.first );
+                len = snprintf( buf, sizeof(buf), "%" PRIu64, t.first );
             }
             else
             {
-                len = sprintf( buf, "PID %" PRIu64 " TID %" PRIu64, t.first >> 32, t.first & 0xFFFFFFFF );
+                len = snprintf( buf, sizeof(buf), "PID %" PRIu64 " TID %" PRIu64, t.first >> 32, t.first & 0xFFFFFFFF );
             }
             AddThreadString( t.first, buf, len );
         }
@@ -807,7 +807,7 @@ Worker::Worker( FileRead& f, EventType::Type eventMask, bool bgTasks, bool allow
     {
         s_loadProgress.total.store( 0, std::memory_order_relaxed );
         char buf[256];
-        sprintf( buf, "Too many static source locations (%s)", RealToString( sz ) );
+        snprintf( buf, sizeof(buf), "Too many static source locations (%s)", RealToString( sz ) );
         throw LoadFailure( buf );
     }
     for( uint64_t i=0; i<sz; i++ )
@@ -830,7 +830,7 @@ Worker::Worker( FileRead& f, EventType::Type eventMask, bool bgTasks, bool allow
     {
         s_loadProgress.total.store( 0, std::memory_order_relaxed );
         char buf[256];
-        sprintf( buf, "Too many dynamic source locations (%s)", RealToString( sz ) );
+        snprintf( buf, sizeof(buf), "Too many dynamic source locations (%s)", RealToString( sz ) );
         throw LoadFailure( buf );
     }
     m_data.sourceLocationPayload.reserve_exact( sz, m_slab );
@@ -2762,7 +2762,7 @@ void Worker::Exec()
         auto lt = localtime( &date );
         strftime( dtmp, 64, "%F %T", lt );
         char tmp[1024];
-        sprintf( tmp, "%s @ %s", welcome.programName, dtmp );
+        snprintf( tmp, sizeof(tmp), "%s @ %s", welcome.programName, dtmp );
         m_captureName = tmp;
 
         m_hostInfo = welcome.hostInfo;
@@ -4970,11 +4970,11 @@ void Worker::ZoneValueFailure( uint64_t thread, uint64_t value )
     char buf[128];
     if( (int64_t)value < 0 )
     {
-        sprintf( buf, "Zone value was: %" PRIu64 " (unsigned), %" PRIi64 " (signed)", value, (int64_t)value );
+        snprintf( buf, sizeof(buf), "Zone value was: %" PRIu64 " (unsigned), %" PRIi64 " (signed)", value, (int64_t)value );
     }
     else
     {
-        sprintf( buf, "Zone value was: %" PRIu64, value );
+        snprintf( buf, sizeof(buf), "Zone value was: %" PRIu64, value );
     }
 
     m_failure = Failure::ZoneValue;
@@ -5309,7 +5309,7 @@ void Worker::ProcessZoneColor( const QueueZoneColor& ev )
 void Worker::ProcessZoneValue( const QueueZoneValue& ev )
 {
     char tmp[32];
-    const auto tsz = sprintf( tmp, "%" PRIu64 " [0x%" PRIx64 "]", ev.value, ev.value );
+    const auto tsz = snprintf( tmp, sizeof(tmp), "%" PRIu64 " [0x%" PRIx64 "]", ev.value, ev.value );
 
     auto td = RetrieveThread( m_threadCtx );
     if( !td )


### PR DESCRIPTION
On macos sprintf is marked deprecated, which will spam a lot of warnings.
```
public/client/TracyCallstack.cpp:1172:33: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the desi
gn of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
 1172 |             const auto offlen = sprintf( buf, " + %td", symoff );
      |                                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:274:1: note: 'sprintf' has been explicitly marked deprecated here
  274 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead
.")
      | ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:218:48: note: expanded from macro '__deprecated_msg'
  218 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
      |                                                       ^
```

And also it's the safer version of the two functions.