### PR TITLE
Add clipboard button for user text in ZoneInfo

### DIFF
--- a/profiler/src/profiler/TracyView_ZoneInfo.cpp
+++ b/profiler/src/profiler/TracyView_ZoneInfo.cpp
@@ -447,7 +447,14 @@ void View::DrawZoneInfoWindow()
         }
         if( m_worker.HasZoneExtra( ev ) && m_worker.GetZoneExtra( ev ).text.Active() )
         {
-            TextFocused( "User text:", m_worker.GetString( m_worker.GetZoneExtra( ev ).text ) );
+            TextDisabledUnformatted( "User text:" );
+            ImGui::SameLine();
+            if( ClipboardButton( 4 ) )
+            {
+                ImGui::SetClipboardText( m_worker.GetString( m_worker.GetZoneExtra( ev ).text ) );
+            }
+            ImGui::SameLine();
+            ImGui::TextUnformatted( m_worker.GetString( m_worker.GetZoneExtra( ev ).text ) );
         }
 
         ImGui::Separator();


### PR DESCRIPTION
Found this small change helpful, especially when dealing with longer user texts / cross referencing data.
![image](https://github.com/user-attachments/assets/3a5149e7-c024-49d2-9ebc-fdf5b9699dcd)
