### PR TITLE
Remove wp_viewport_set_source call in Wayland backend

### DIFF
--- a/profiler/src/BackendWayland.cpp
+++ b/profiler/src/BackendWayland.cpp
@@ -1139,7 +1139,6 @@ void Backend::NewFrame( int& w, int& h )
         wl_egl_window_resize( s_eglWin, s_width * s_maxScale / 120, s_height * s_maxScale / 120, 0, 0 );
         if( s_fracSurf )
         {
-            wp_viewport_set_source( s_viewport, 0, 0, wl_fixed_from_double( s_width * s_maxScale / 120. ), wl_fixed_from_double( s_height * s_maxScale / 120. ) );
             wp_viewport_set_destination( s_viewport, s_width, s_height );
         }
     }


### PR DESCRIPTION
There seems to be some sort of race condition between setting the egl buffer size and the viewport size, causing the viewport source size to be larger than the current buffer size, and leading to a crash. It turns out setting the viewport source size is unnecessary anyway, so we can just avoid it.
Fixes #905