### PR TITLE
Adding per-monitor DPI awareness

### DIFF
--- a/profiler/src/BackendGlfw.cpp
+++ b/profiler/src/BackendGlfw.cpp
@@ -80,6 +80,9 @@ Backend::Backend( const char* title, const std::function<void()>& redraw, const 
 #  if GLFW_VERSION_MAJOR > 3 || ( GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 4 )
     glfwWindowHint( GLFW_WIN32_KEYBOARD_MENU, 1 );
 #  endif
+#  if GLFW_VERSION_MAJOR > 3 || ( GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 3 )
+    glfwWindowHint( GLFW_SCALE_TO_MONITOR, 1 );
+#  endif
 #endif
     s_window = glfwCreateWindow( m_winPos.w, m_winPos.h, title, NULL, NULL );
     if( !s_window ) exit( 1 );
@@ -200,14 +203,10 @@ void Backend::SetTitle( const char* title )
 float Backend::GetDpiScale()
 {
 #if GLFW_VERSION_MAJOR > 3 || ( GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR >= 3 )
-    auto monitor = glfwGetWindowMonitor( s_window );
-    if( !monitor ) monitor = glfwGetPrimaryMonitor();
-    if( monitor )
-    {
-        float x, y;
-        glfwGetMonitorContentScale( monitor, &x, &y );
-        return x;
-    }
-#endif
+    float x, y;
+    glfwGetWindowContentScale( s_window, &x, &y );
+    return x;
+#else
     return 1;
+#endif
 }


### PR DESCRIPTION
This pull requests adds per monitor dpi awareness, as requested in #1034 . Specifically, if you have two monitors with different scaling set in the Windows display settings, this change will make it so the window and its contents are automatically scaled correctly according to the OS setting, when moved between monitors.

Luckily, glfw supports this directly and the changes are minimal:
- Instead of glfwGetMonitorContentScale, glfwGetWindowContentScale is used, which updates when the window is moved to a different window with different display scale setting in windows.
- By passing GLFW_SCALE_TO_MONITOR to glfwWindowHint, glfw will automatically resize the window as well. Without this the contents would be enlarged when moved to a monitor with higher scaling, but the window would stay the same size, so the UI would look more cramped.

I have only tested this change on Windows 10, where everything worked as intended.