### PR TITLE
Time to string exact

### DIFF
--- a/server/TracyPrint.cpp
+++ b/server/TracyPrint.cpp
@@ -246,7 +246,11 @@ const char* TimeToStringExact( int64_t _ns )
     bufsel = ( bufsel + 1 ) % Pool;
 
     uint64_t ns;
-    if( _ns < 0 )
+    if( _ns == std::numeric_limits<int64_t>::min() )
+    {
+        ns = -(_ns + 1) + 1;
+    }
+    else if( _ns < 0 )
     {
         *buf = '-';
         buf++;

--- a/server/TracyPrint.cpp
+++ b/server/TracyPrint.cpp
@@ -71,7 +71,7 @@ static inline void PrintSmallInt( char*& buf, uint64_t v )
 
 static inline void PrintSmallInt0( char*& buf, uint64_t v )
 {
-    assert( v < uint64_t(1000ll) );
+    assert( v < 1000 );
     if( v >= 100 )
     {
         memcpy( buf, IntTable100 + v/10*2, 2 );
@@ -157,13 +157,13 @@ static inline void PrintSecondsFrac( char*& buf, uint64_t v )
 
 uint64_t _int64_abs( int64_t x )
 {
-    if( x == std::numeric_limits<int64_t>::min() )
+    if( x < 0 )
     {
-        return -(x + 1) + 1;
-    }
-    else if( x < 0 )
-    {
-        return -x;
+        // `-x` does not work if `x` is `std::numeric_limits<int64_t>::min()`,
+        // see https://github.com/wolfpld/tracy/pull/1040
+        // This works though:
+        // https://graphics.stanford.edu/~seander/bithacks.html#IntegerAbs
+        return -(uint64_t)x;
     }
     else
     {

--- a/server/TracyPrint.cpp
+++ b/server/TracyPrint.cpp
@@ -71,7 +71,7 @@ static inline void PrintSmallInt( char*& buf, uint64_t v )
 
 static inline void PrintSmallInt0( char*& buf, uint64_t v )
 {
-    assert( v < 1000 );
+    assert( v < uint64_t(1000ll) );
     if( v >= 100 )
     {
         memcpy( buf, IntTable100 + v/10*2, 2 );
@@ -155,6 +155,22 @@ static inline void PrintSecondsFrac( char*& buf, uint64_t v )
     }
 }
 
+uint64_t _int64_abs( int64_t x )
+{
+    if( x == std::numeric_limits<int64_t>::min() )
+    {
+        return -(x + 1) + 1;
+    }
+    else if( x < 0 )
+    {
+        return -x;
+    }
+    else
+    {
+        return x;
+    }
+}
+
 const char* TimeToString( int64_t _ns )
 {
     enum { Pool = 8 };
@@ -164,16 +180,11 @@ const char* TimeToString( int64_t _ns )
     char* bufstart = buf;
     bufsel = ( bufsel + 1 ) % Pool;
 
-    uint64_t ns;
+    uint64_t ns = _int64_abs(_ns);
     if( _ns < 0 )
     {
         *buf = '-';
         buf++;
-        ns = -_ns;
-    }
-    else
-    {
-        ns = _ns;
     }
 
     if( ns < 1000 )
@@ -245,20 +256,11 @@ const char* TimeToStringExact( int64_t _ns )
     char* bufstart = buf;
     bufsel = ( bufsel + 1 ) % Pool;
 
-    uint64_t ns;
-    if( _ns == std::numeric_limits<int64_t>::min() )
-    {
-        ns = -(_ns + 1) + 1;
-    }
-    else if( _ns < 0 )
+    uint64_t ns = _int64_abs(_ns);
+    if( _ns < 0 )
     {
         *buf = '-';
         buf++;
-        ns = -_ns;
-    }
-    else
-    {
-        ns = _ns;
     }
 
     const char* numStart = buf;


### PR DESCRIPTION
On my system, I am getting a segmentation fault. The issue is that all these are evaluated to `false`
https://github.com/wolfpld/tracy/blob/a03c7580b9101df3225937524e09a9a885d5464a/server/TracyPrint.cpp#L262
https://github.com/wolfpld/tracy/blob/a03c7580b9101df3225937524e09a9a885d5464a/server/TracyPrint.cpp#L285
https://github.com/wolfpld/tracy/blob/a03c7580b9101df3225937524e09a9a885d5464a/server/TracyPrint.cpp#L297
https://github.com/wolfpld/tracy/blob/a03c7580b9101df3225937524e09a9a885d5464a/server/TracyPrint.cpp#L306
and then the errors occurs in
https://github.com/wolfpld/tracy/blob/a03c7580b9101df3225937524e09a9a885d5464a/server/TracyPrint.cpp#L72-L91
Here is a minimal reproducer
```c++
#include <stdio.h>
#include <stdint.h>
#include <iostream>
#include <limits>

void ko(int64_t _ns)
{
    std::cout << "KO" << std::endl;
    std::cout << _ns << std::endl;
    uint64_t ns;
    if( _ns < 0 )
    {
        ns = -_ns;
    }
    else
    {
        ns = _ns;
    }
    std::cout << ns << std::endl;
    std::cout << 1000ll << std::endl;
    std::cout << (ns >= 1000ll) << std::endl;
}

void ok(int64_t _ns)
{
    std::cout << "OK" << std::endl;
    std::cout << _ns << std::endl;
    uint64_t ns;
    if( _ns == std::numeric_limits<int64_t>::min() )
    {
        ns = -(_ns + 1) + 1;
    }
    else if( _ns < 0 )
    {
        ns = -_ns;
    }
    else
    {
        ns = _ns;
    }
    std::cout << ns << std::endl;
    std::cout << 1000ll << std::endl;
    std::cout << (ns >= 1000ll) << std::endl;
}

int main() {
    ko(-9223372036854775808ULL);
    ok(-9223372036854775808ULL);
    return 0;
}
```
Then I can reproduce the issue with `g++` with `-O2` or `-O3` but not `clang++`
```
$ g++ -O3 main.cpp && ./a.out
KO
-9223372036854775808
9223372036854775808
1000
0
OK
-9223372036854775808
9223372036854775808
1000
1
$ g++ -O1 main.cpp && ./a.out
KO
-9223372036854775808
9223372036854775808
1000
1
OK
-9223372036854775808
9223372036854775808
1000
1
$ clang++ -O3 main.cpp && ./a.out
KO
-9223372036854775808
9223372036854775808
1000
1
OK
-9223372036854775808
9223372036854775808
1000
1
```
The way I understand the issue is that `-_ns` does not fit in `int64_t` even though it fits in `uint64_t`.
So the idea is to first convert to `uint64_t` and then do `+1`.
My gcc version is
```
$ g++ --version
g++ (GCC) 15.1.1 20250425
$ uname -a
Linux Precision5570 6.14.4-arch1-2 #1 SMP PREEMPT_DYNAMIC Tue, 29 Apr 2025 09:23:13 +0000 x86_64 GNU/Linux
```