### PR TITLE
fix vertical scroll bar lost  on macos

### DIFF
--- a/profiler/src/BackendGlfw.cpp
+++ b/profiler/src/BackendGlfw.cpp
@@ -166,6 +166,10 @@ void Backend::NewFrame( int& w, int& h )
     }
 
     glfwGetFramebufferSize( s_window, &w, &h );
+#if defined( __APPLE__ )
+    w = static_cast<int>( w / scale );
+    h = static_cast<int>( h / scale );
+#endif
     m_w = w;
     m_h = h;
 

--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -808,6 +808,7 @@ bool View::DrawImpl()
     sprintf( tmp, "%s###Profiler", m_worker.GetCaptureName().c_str() );
     ImGui::SetNextWindowSize( ImVec2( 1550, 800 ), ImGuiCond_FirstUseEver );
     ImGui::Begin( tmp, keepOpenPtr, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus );
+    ImGuiViewport* viewport = ImGui::GetMainViewport();
 #endif
 
     if( !m_staticView )


### PR DESCRIPTION
trying to fix 
- https://github.com/wolfpld/tracy/issues/631

on macos 15.5 with 4k monitor and 1920x1080 resolution

before

<img width="559" alt="Screenshot 2025-05-31 at 23 41 52" src="https://github.com/user-attachments/assets/e43c54e1-0892-4ff6-9e41-c6a7c402daf6" />

after this pr
<img width="558" alt="Screenshot 2025-05-31 at 23 42 24" src="https://github.com/user-attachments/assets/9242a723-e48c-4f37-9076-2c5c9ca1cd5d" />

