### PR TITLE
Fix profiler compilation when build directory is outside the source directory

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -193,7 +193,7 @@ endif()
 find_package(Git)
 if(Git_FOUND)
     add_custom_target(git-ref
-        COMMAND ${GIT_EXECUTABLE} log -1 "--format=#pragma once %nnamespace tracy { static inline const char* GitRef = %x22%h%x22; }" ${GIT_REV} > GitRef.hpp.tmp
+        COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} log -1 "--format=#pragma once %nnamespace tracy { static inline const char* GitRef = %x22%h%x22; }" ${GIT_REV} > GitRef.hpp.tmp
         COMMAND ${CMAKE_COMMAND} -E copy_if_different GitRef.hpp.tmp GitRef.hpp
         BYPRODUCTS GitRef.hpp GitRef.hpp.tmp
         VERBATIM


### PR DESCRIPTION
Hello,

This small PR is an attempt to fix profiler compilation when the build directory is outside the source directory.

On `master`, we can easily reproduce the error with the following commands: 
```sh
cmake -S tracy/profiler -B profiler && cmake --build profiler --parallel
```

Which results in the following error:
```txt
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
make[2]: *** [CMakeFiles/git-ref.dir/build.make:70: CMakeFiles/git-ref] Error 128
make[1]: *** [CMakeFiles/Makefile2:417: CMakeFiles/git-ref.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

In this PR, I simply precise the source directory where git should be called.

Questions or changes are welcome.

And thanks a lot for your work, it’s such a pleasure to work with Tracy :)

Have a nice day,