### PR TITLE
add a sanity check to fuchsia importer

### DIFF
--- a/import/src/import-fuchsia.cpp
+++ b/import/src/import-fuchsia.cpp
@@ -188,6 +188,12 @@ std::pair<bool, Record> read_next_record(std::vector<uint8_t> const &input, size
   CHECK_BOUND(offset + 8*len_word);
 
   Record r{(uint64_t *)&input[offset], len_word, header};
+
+  if (len_word == 0) {
+    fprintf(stderr, "warning: invalid record with length=0 at offset %" PRIu64 "\n", offset); \
+    return std::make_pair(false,Record{}); \
+  }
+
   offset += 8 * len_word;
   return std::make_pair(true, r);
 }


### PR DESCRIPTION
I've had corrupted files (multiple processes writing to one file…) and the importer enters an infinite loop instead of failing cleanly. This makes the failure quick and clean.
