### PR TITLE
Add TracyMetal.hmm to the installed headers list in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ set(tracy_includes
     ${TRACY_PUBLIC_DIR}/tracy/TracyD3D11.hpp
     ${TRACY_PUBLIC_DIR}/tracy/TracyD3D12.hpp
     ${TRACY_PUBLIC_DIR}/tracy/TracyLua.hpp
+    ${TRACY_PUBLIC_DIR}/tracy/TracyMetal.hmm
     ${TRACY_PUBLIC_DIR}/tracy/TracyOpenCL.hpp
     ${TRACY_PUBLIC_DIR}/tracy/TracyOpenGL.hpp
     ${TRACY_PUBLIC_DIR}/tracy/TracyVulkan.hpp)


### PR DESCRIPTION
When installing tracy with CMake, the new TracyMetal.hmm was not included in the list of headers to copy, this PR fixes it.

Reproduction (on posix-y shells, tested on macOS):
```
cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
cmake --build build/ --config Release --parallel
mkdir testinstall
cmake --install build --config Release --prefix "$(pwd)/testinstall" -v
```