### PR TITLE
Add include directories for pkg-config dependencies in the profiler build

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -106,6 +106,7 @@ set(LIBS "")
 
 if(USE_WAYLAND)
     pkg_check_modules(WAYLAND REQUIRED egl wayland-egl wayland-cursor xkbcommon)
+    set(INCLUDES "${INCLUDES};${WAYLAND_INCLUDE_DIRS}")
     set(LIBS "${LIBS};${WAYLAND_LIBRARIES}")
     set(PROFILER_FILES ${PROFILER_FILES}
         src/BackendWayland.cpp


### PR DESCRIPTION
These must be added explicitly since e.g. openSUSE puts xkbcommon headers in `/usr/include/libxkbcommon/xkbcommon/xkbcommon.h` and hence fails to find the headers otherwise.
