### PR TITLE
Fix vendor.cmake

### DIFF
--- a/cmake/server.cmake
+++ b/cmake/server.cmake
@@ -29,7 +29,7 @@ list(TRANSFORM TRACY_SERVER_SOURCES PREPEND "${TRACY_SERVER_DIR}/")
 
 add_library(TracyServer STATIC EXCLUDE_FROM_ALL ${TRACY_COMMON_SOURCES} ${TRACY_SERVER_SOURCES})
 target_include_directories(TracyServer PUBLIC ${TRACY_COMMON_DIR} ${TRACY_SERVER_DIR})
-target_link_libraries(TracyServer PUBLIC TracyCapstone libzstd PPQSort::PPQSort)
+target_link_libraries(TracyServer PUBLIC TracyCapstone TracyZstd TracyPPQSort)
 if(NO_STATISTICS)
     target_compile_definitions(TracyServer PUBLIC TRACY_NO_STATISTICS)
 endif()

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -214,7 +214,7 @@ endif()
 
 if(NOT EMSCRIPTEN)
     if(NOT NO_FILESELECTOR)
-        target_link_libraries(${PROJECT_NAME} PRIVATE nfd::nfd)
+        target_link_libraries(${PROJECT_NAME} PRIVATE TracyNfd)
     endif()
     if(NOT USE_WAYLAND)
         target_link_libraries(${PROJECT_NAME} PRIVATE TracyGlfw3)


### PR DESCRIPTION
Your latest releases cannot be used (without hacks and patches) with vcpkg and Homebrew because they prohibit external downloads that CPM.cmake does

pkg_check_modules(CAPSTONE **capstone**)
pkg_check_modules(GLFW **glfw3**)
pkg_check_modules(FREETYPE **freetype2**)
...
[https://github.com/Homebrew/homebrew-core/blob/badf764aab60b495bb699e23ab3b1633f588df50/Formula/t/tracy.rb](https://github.com/Homebrew/homebrew-core/blob/badf764aab60b495bb699e23ab3b1633f588df50/Formula/t/tracy.rb)
depends_on "**glfw**"
depends_on "**capstone**"
depends_on "**freetype**"

[https://github.com/microsoft/vcpkg/blob/master/ports/tracy/vcpkg.json](https://github.com/microsoft/vcpkg/blob/master/ports/tracy/vcpkg.json)
"dependencies": [
        {
          "name": "**capstone**",
          "features": [
            "arm",
            "arm64",
            "x86"
          ]
        },
        ...
        "**freetype**",
        "**glfw3**",
        ...
      ]

Please, use the same approach and check that modules are already installed:

pkg_check_modules(ZSTD zstd)
pkg_check_modules(ImGui imgui)
pkg_check_modules(NFD nativefiledialog-extended)
pkg_check_modules(PPQSORT ppqsort)

(I'm checking that these names and CMake variables are correct)