### PR TITLE
Fix Clear button behavior in Find Zone

### DIFF
--- a/profiler/src/profiler/TracyView_FindZone.cpp
+++ b/profiler/src/profiler/TracyView_FindZone.cpp
@@ -307,6 +307,7 @@ void View::DrawFindZone()
 
     if( ImGui::Button( ICON_FA_BAN " Clear" ) )
     {
+        m_findZone.pattern[0] = '\0';
         m_findZone.Reset();
     }
     ImGui::SameLine();


### PR DESCRIPTION
Previously, clicking the Clear button in the find zone search only reset the search results but did not clear the search text in the input field.
This PR updates the behavior so that the text input is also cleared when the Clear button is clicked

![Before clicking](https://github.com/user-attachments/assets/cf6df634-573d-4a32-93d8-20f76808bbf4)
![After clicking](https://github.com/user-attachments/assets/1af9d145-4cf0-49a1-97ec-ee99f5ca2e1e)

