### PR TITLE
Fix FiberEnter start time always being processed as 0

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -7075,7 +7075,7 @@ void Worker::ProcessFiberEnter( const QueueFiberEnter& ev )
     }
     auto& data = cit->second->v;
     auto& item = data.push_next();
-    item.SetCpu( t );
+    item.SetStart( t );
     item.SetCpu( 0 );
     item.SetWakeup( t );
     item.SetWakeupCpu( 0 );


### PR DESCRIPTION
Fibers have not been displaying correctly in the profiler since release 0.12. It looks like the issue was introduced in 31859042bd3715f9e8e8e63e68e51da32e1cd9c1 from https://github.com/wolfpld/tracy/pull/1021, which reworks `ProcessFiberEnter` into incorrectly calling `item.SetCpu( t )` rather than `item.SetStart( t )`. As a result, every fiber context switch in the profiler has a start time of 0, meaning all of them are visualized as starting at the beginning of the program. Most scopes within a fiber are actually invisible due to the combined darkening from all of the overlapping inactive context switches.

#### Current behavior
![Screenshot 2025-07-01 230224](https://github.com/user-attachments/assets/57693d74-b5d9-47fc-bdd0-ff7b5bb2a9b1)

#### Fixed behavior
![Screenshot 2025-07-01 230025](https://github.com/user-attachments/assets/29e3f973-f538-4d01-88af-3b5fe34e3d28)