### PR TITLE
Bugfix/test on windows

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,3 +29,5 @@ endif()
 
 # copy image file in build folder
 configure_file(${CMAKE_CURRENT_LIST_DIR}/image.jpg image.jpg COPYONLY)
+
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tracy-test)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -339,10 +339,7 @@ void ArenaAllocatorTest()
 
 int main()
 {
-#ifdef _WIN32
-    signal( SIGUSR1, SignalHandler_TriggerCrash );
-    signal( SIGUSR2, SignalHandler_TriggerInstrumentationFailure );
-#else
+#ifndef _WIN32
     struct sigaction sigusr1, oldsigusr1,sigusr2, oldsigusr2 ;
     memset( &sigusr1, 0, sizeof( sigusr1 ) );
     sigusr1.sa_handler = SignalHandler_TriggerCrash;


### PR DESCRIPTION
Currently the test app wouldn't build on windows due to the fact `SIGUSR1` and `SIGUSR2` do not exist on this platform (nor in mingw).
Also made it so that the app is automatically selected as startup target when building with visual studio.