### PR TITLE
Add tooltip to Limit Range checkboxes: Ctrl+drag

### DIFF
--- a/profiler/src/profiler/TracySourceView.cpp
+++ b/profiler/src/profiler/TracySourceView.cpp
@@ -1616,12 +1616,8 @@ void SourceView::RenderSymbolView( Worker& worker, View& view )
                     view.m_statRange.max = vd.zvEnd;
                 }
             }
-            if( ImGui::IsItemHovered( ) )
-            {
-                ImGui::BeginTooltip( );
-                ImGui::TextDisabled( ICON_FA_COMPUTER_MOUSE " Ctrl + drag on timeline to set the range" );
-                ImGui::EndTooltip( );
-            }
+            TooltipIfHovered( ICON_FA_COMPUTER_MOUSE " Ctrl + drag on timeline to set the range" );
+
             if( view.m_statRange.active )
             {
                 ImGui::SameLine();

--- a/profiler/src/profiler/TracyView_ContextSwitch.cpp
+++ b/profiler/src/profiler/TracyView_ContextSwitch.cpp
@@ -460,12 +460,8 @@ void View::DrawWaitStacks()
             m_waitStackRange.max = m_vd.zvEnd;
         }
     }
-    if( ImGui::IsItemHovered( ) )
-    {
-        ImGui::BeginTooltip( );
-        ImGui::TextDisabled( ICON_FA_COMPUTER_MOUSE " Ctrl + drag on timeline to set the range" );
-        ImGui::EndTooltip( );
-    }
+    TooltipIfHovered( ICON_FA_COMPUTER_MOUSE " Ctrl + drag on timeline to set the range" );
+
     if( m_waitStackRange.active )
     {
         ImGui::SameLine();

--- a/profiler/src/profiler/TracyView_FindZone.cpp
+++ b/profiler/src/profiler/TracyView_FindZone.cpp
@@ -323,12 +323,8 @@ void View::DrawFindZone()
             m_findZone.range.max = m_vd.zvEnd;
         }
     }
-    if( ImGui::IsItemHovered( ) )
-    {
-        ImGui::BeginTooltip( );
-        ImGui::TextDisabled( ICON_FA_COMPUTER_MOUSE " Ctrl + drag on timeline to set the range" );
-        ImGui::EndTooltip( );
-    }
+    TooltipIfHovered( ICON_FA_COMPUTER_MOUSE " Ctrl + drag on timeline to set the range" );
+
     if( m_findZone.range.active )
     {
         ImGui::SameLine();

--- a/profiler/src/profiler/TracyView_Memory.cpp
+++ b/profiler/src/profiler/TracyView_Memory.cpp
@@ -246,12 +246,8 @@ void View::DrawMemory()
             m_memInfo.range.max = m_vd.zvEnd;
         }
     }
-    if( ImGui::IsItemHovered( ) )
-    {
-        ImGui::BeginTooltip( );
-        ImGui::TextDisabled( ICON_FA_COMPUTER_MOUSE " Ctrl + drag on timeline to set the range" );
-        ImGui::EndTooltip( );
-    }
+    TooltipIfHovered( ICON_FA_COMPUTER_MOUSE " Ctrl + drag on timeline to set the range" );
+
     if( m_memInfo.range.active )
     {
         ImGui::SameLine();

--- a/profiler/src/profiler/TracyView_Statistics.cpp
+++ b/profiler/src/profiler/TracyView_Statistics.cpp
@@ -543,12 +543,8 @@ void View::DrawStatistics()
                 m_statRange.max = m_vd.zvEnd;
             }
         }
-        if( ImGui::IsItemHovered( ) )
-        {
-            ImGui::BeginTooltip( );
-            ImGui::TextDisabled( ICON_FA_COMPUTER_MOUSE " Ctrl + drag on timeline to set the range" );
-            ImGui::EndTooltip( );
-        }
+        TooltipIfHovered( ICON_FA_COMPUTER_MOUSE " Ctrl + drag on timeline to set the range" );
+
         if( m_statRange.active )
         {
             ImGui::SameLine();


### PR DESCRIPTION
This PR adds a tooltip to the “Limit range” checkboxes in the Find Zone panel.
When the user hovers over the checkbox, the tooltip displays the message:

![image](https://github.com/user-attachments/assets/2e7846f2-3745-40b1-b14a-3f2b0b2c7883)

This clarifies an alternative way to select the zone range, improving discoverability and user experience.