### PR TITLE
Add middle-click hint in FindZone tooltip

### DIFF
--- a/profiler/src/profiler/TracyView_ZoneInfo.cpp
+++ b/profiler/src/profiler/TracyView_ZoneInfo.cpp
@@ -1985,6 +1985,7 @@ void View::ZoneTooltip( const ZoneEvent& ev )
         ImGui::NewLine();
         TextColoredUnformatted( ImVec4( 0xCC / 255.f, 0xCC / 255.f, 0x22 / 255.f, 1.f ), m_worker.GetString( m_worker.GetZoneExtra( ev ).text ) );
     }
+    ImGui::TextDisabled( ICON_FA_COMPUTER_MOUSE "  Middle click: Zoom to zone" );
     ImGui::EndTooltip();
 }
 


### PR DESCRIPTION
In the "Find Zone" section, zooming to the selected zone requires a middle-click, which may not be obvious to users.
This change adds a tooltip message: "Middle click: Zoom to zone" to clarify the interaction.

![image](https://github.com/user-attachments/assets/53ff2a3b-a39b-46d4-b87e-655a21597cb3)