### PR TITLE
Add lock struct with condition variable to main thread

### DIFF
--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -833,7 +833,7 @@ bool View::DrawImpl()
             ImGui::EndPopup();
         }
     }
-    std::lock_guard<std::mutex> lock( m_worker.GetDataLock() );
+    Worker::MainThreadDataLockGuard lock = m_worker.ObtainLockForMainThread();
     m_worker.DoPostponedWork();
     if( !m_worker.IsDataStatic() )
     {
@@ -1435,7 +1435,7 @@ bool View::Save( const char* fn, FileCompression comp, int zlevel, bool buildDic
     m_userData.StateShouldBePreserved();
     m_saveThreadState.store( SaveThreadState::Saving, std::memory_order_relaxed );
     m_saveThread = std::thread( [this, f{std::move( f )}, buildDict] {
-        std::lock_guard<std::mutex> lock( m_worker.GetDataLock() );
+        Worker::MainThreadDataLockGuard lock = m_worker.ObtainLockForMainThread();
         m_worker.Write( *f, buildDict );
         f->Finish();
         const auto stats = f->GetCompressionStatistics();

--- a/profiler/src/profiler/TracyView_ConnectionState.cpp
+++ b/profiler/src/profiler/TracyView_ConnectionState.cpp
@@ -78,7 +78,7 @@ bool View::DrawConnection()
     }
 
     {
-        std::lock_guard<std::mutex> lock( m_worker.GetDataLock() );
+        Worker::MainThreadDataLockGuard lock = m_worker.ObtainLockForMainThread();
         ImGui::SameLine();
         TextFocused( "+", RealToString( m_worker.GetSendInFlight() ) );
         const auto sz = m_worker.GetFrameCount( *m_frames );
@@ -142,7 +142,7 @@ bool View::DrawConnection()
 
     ImGui::SameLine( 0, 2 * ty );
     const char* stopStr = ICON_FA_PLUG " Stop";
-    std::lock_guard<std::mutex> lock( m_worker.GetDataLock() );
+    Worker::MainThreadDataLockGuard lock = m_worker.ObtainLockForMainThread();
     if( !m_disconnectIssued && m_worker.IsConnected() )
     {
         if( ImGui::Button( stopStr ) )


### PR DESCRIPTION
> The links you have given do not work.

**Here are the working links, I hope this will make it clearer.**

In certain situations (notably during Tracy initialization), we observed delays caused by a form of starvation of the main thread.
The issue occurs when the worker thread quickly reacquires the mutex after releasing it — before the main thread has had a chance to wake up and acquire it itself.

This leads to a situation where the main thread is repeatedly preempted, causing noticeable lag or even temporary freezes.
Solution

To address this, we introduce a lock coordination mechanism using:
- An atomic flag: `mainThreadWantsLock`
- A condition_variable to wake the worker after the main thread is done

The `MainThreadDataLockGuard`:
- Signals that the main thread wants the lock
- Acquires the lock
- Upon destruction, clears the flag and notifies the worker thread

On the worker side:
- Before continuing processing, it checks the flag
- If the main thread is requesting the lock, it calls wait_for on the condition variable (1ms timeout), giving the main thread a chance to take the lock first

This ensures the main thread gets temporary priority when needed, reducing contention and preventing starvation.

We can see the problem by self profiling :
Before:
<img width="1395" height="183" alt="Capture d'écran 2025-07-21 093332" src="https://github.com/user-attachments/assets/966255f1-c4a0-4b33-9eef-6a38c489128d" />
After:
<img width="1213" height="217" alt="Capture d'écran 2025-07-21 093824" src="https://github.com/user-attachments/assets/59a85ccb-a805-4eea-93f0-0d98c610774e" />

This significantly improves responsiveness, especially during initialization, by ensuring the main thread is not indefinitely delayed by worker lock contention.

Before:

https://github.com/user-attachments/assets/fcaa9555-1bd5-45e0-9b72-b9c9f91dca25

After: 

https://github.com/user-attachments/assets/143cb626-f593-4e7c-a23f-4462919190c0


