### PR TITLE
Collect dispatches and counter values with Rocprofv3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
 endif()
 
 find_package(Threads REQUIRED)
-find_package(rocprofiler-sdk REQUIRED PATHS "/opt/rocm/lib/cmake")
+find_package(rocprofiler-sdk PATHS "/opt/rocm/lib/cmake")
 
 set(TRACY_PUBLIC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/public)
 
@@ -56,8 +56,11 @@ target_link_libraries(
     PUBLIC
         Threads::Threads
         ${CMAKE_DL_LIBS}
-        rocprofiler-sdk::rocprofiler-sdk
 )
+if(rocprofiler-sdk_FOUND)
+    target_compile_definitions(TracyClient PUBLIC TRACY_ROCPROF)
+    target_link_libraries(TracyClient PUBLIC rocprofiler-sdk::rocprofiler-sdk)
+endif()
 
 if(TRACY_Fortran)
     add_library(TracyClientF90 ${TRACY_VISIBILITY} "${TRACY_PUBLIC_DIR}/TracyClient.F90")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ else()
 endif()
 
 find_package(Threads REQUIRED)
+find_package(rocprofiler-sdk REQUIRED PATHS "/opt/rocm/lib/cmake")
 
 set(TRACY_PUBLIC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/public)
 
@@ -55,6 +56,7 @@ target_link_libraries(
     PUBLIC
         Threads::Threads
         ${CMAKE_DL_LIBS}
+        rocprofiler-sdk::rocprofiler-sdk
 )
 
 if(TRACY_Fortran)

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -41,7 +41,8 @@ constexpr const char* GpuContextNames[] = {
     "Direct3D 11",
     "Metal",
     "Custom",
-    "CUDA"
+    "CUDA",
+    "Rocprof"
 };
 
 struct MemoryPage;

--- a/profiler/src/profiler/TracyView_ZoneInfo.cpp
+++ b/profiler/src/profiler/TracyView_ZoneInfo.cpp
@@ -1580,16 +1580,15 @@ void View::DrawGpuInfoWindow()
         }
 
         TextFocused( "Query ID:", RealToString( ev.query_id ) );
-        for( int i = 0; i < ev.note_count; i++ )
+        for( auto& p : ev.notes )
         {
-            auto id = ev.note_ids[i];
-            if( ctx->notes.count( id ) )
+            if( ctx->notes.count( p.first ) )
             {
-                TextFocused( m_worker.GetString( ctx->notes.at( id ) ), RealToString( ev.note_vals[i] ) );
+                TextFocused( m_worker.GetString( ctx->notes.at( p.first ) ), RealToString( p.second ) );
             }
             else
             {
-                TextFocused( RealToString( ev.note_ids[i] ), RealToString( ev.note_vals[i] ) );
+                TextFocused( RealToString( p.first ), RealToString( p.second ) );
             }
         }
 
@@ -2061,16 +2060,15 @@ void View::ZoneTooltip( const GpuEvent& ev )
     }
 
     TextFocused( "Query ID:", RealToString( ev.query_id ) );
-    for( int i = 0; i < ev.note_count; i++ )
+    for( auto& p : ev.notes )
     {
-        auto id = ev.note_ids[i];
-        if( ctx->notes.count( id ) )
+        if( ctx->notes.count( p.first ) )
         {
-            TextFocused( m_worker.GetString( ctx->notes.at( id ) ), RealToString( ev.note_vals[i] ) );
+            TextFocused( m_worker.GetString( ctx->notes.at( p.first ) ), RealToString( p.second ) );
         }
         else
         {
-            TextFocused( RealToString( ev.note_ids[i] ), RealToString( ev.note_vals[i] ) );
+            TextFocused( RealToString( p.first ), RealToString( p.second ) );
         }
     }
 

--- a/profiler/src/profiler/TracyView_ZoneInfo.cpp
+++ b/profiler/src/profiler/TracyView_ZoneInfo.cpp
@@ -1581,7 +1581,12 @@ void View::DrawGpuInfoWindow()
 
         TextFocused( "Query ID:", RealToString(ev.query_id) );
         for (int i = 0; i < ev.note_count; i++ ) {
-          TextFocused( RealToString(ev.note_ids[i]), RealToString(ev.note_vals[i]) );
+          auto id = ev.note_ids[i];
+          if (ctx->notes.count(id)) {
+            TextFocused( m_worker.GetString( ctx->notes.at(id) ), RealToString(ev.note_vals[i]) );
+          } else {
+            TextFocused( RealToString(ev.note_ids[i]), RealToString(ev.note_vals[i]) );
+          }
         }
 
         ImGui::Separator();
@@ -2053,7 +2058,12 @@ void View::ZoneTooltip( const GpuEvent& ev )
 
     TextFocused( "Query ID:", RealToString(ev.query_id) );
     for (int i = 0; i < ev.note_count; i++ ) {
-      TextFocused( RealToString(ev.note_ids[i]), RealToString(ev.note_vals[i]) );
+      auto id = ev.note_ids[i];
+      if (ctx->notes.count(id)) {
+        TextFocused( m_worker.GetString( ctx->notes.at(id) ), RealToString(ev.note_vals[i]) );
+      } else {
+        TextFocused( RealToString(ev.note_ids[i]), RealToString(ev.note_vals[i]) );
+      }
     }
 
     ImGui::EndTooltip();

--- a/profiler/src/profiler/TracyView_ZoneInfo.cpp
+++ b/profiler/src/profiler/TracyView_ZoneInfo.cpp
@@ -1579,6 +1579,11 @@ void View::DrawGpuInfoWindow()
             TextFocused( "Delay to execution:", TimeToString( AdjustGpuTime( ev.GpuStart(), begin, drift ) - ev.CpuStart() ) );
         }
 
+        TextFocused( "Query ID:", RealToString(ev.query_id) );
+        for (int i = 0; i < ev.note_count; i++ ) {
+          TextFocused( RealToString(ev.note_ids[i]), RealToString(ev.note_vals[i]) );
+        }
+
         ImGui::Separator();
 
         std::vector<const GpuEvent*> zoneTrace;
@@ -2044,6 +2049,11 @@ void View::ZoneTooltip( const GpuEvent& ev )
         }
         const auto drift = GpuDrift( ctx );
         TextFocused( "Delay to execution:", TimeToString( AdjustGpuTime( ev.GpuStart(), begin, drift ) - ev.CpuStart() ) );
+    }
+
+    TextFocused( "Query ID:", RealToString(ev.query_id) );
+    for (int i = 0; i < ev.note_count; i++ ) {
+      TextFocused( RealToString(ev.note_ids[i]), RealToString(ev.note_vals[i]) );
     }
 
     ImGui::EndTooltip();

--- a/profiler/src/profiler/TracyView_ZoneInfo.cpp
+++ b/profiler/src/profiler/TracyView_ZoneInfo.cpp
@@ -1579,14 +1579,18 @@ void View::DrawGpuInfoWindow()
             TextFocused( "Delay to execution:", TimeToString( AdjustGpuTime( ev.GpuStart(), begin, drift ) - ev.CpuStart() ) );
         }
 
-        TextFocused( "Query ID:", RealToString(ev.query_id) );
-        for (int i = 0; i < ev.note_count; i++ ) {
-          auto id = ev.note_ids[i];
-          if (ctx->notes.count(id)) {
-            TextFocused( m_worker.GetString( ctx->notes.at(id) ), RealToString(ev.note_vals[i]) );
-          } else {
-            TextFocused( RealToString(ev.note_ids[i]), RealToString(ev.note_vals[i]) );
-          }
+        TextFocused( "Query ID:", RealToString( ev.query_id ) );
+        for( int i = 0; i < ev.note_count; i++ )
+        {
+            auto id = ev.note_ids[i];
+            if( ctx->notes.count( id ) )
+            {
+                TextFocused( m_worker.GetString( ctx->notes.at( id ) ), RealToString( ev.note_vals[i] ) );
+            }
+            else
+            {
+                TextFocused( RealToString( ev.note_ids[i] ), RealToString( ev.note_vals[i] ) );
+            }
         }
 
         ImGui::Separator();
@@ -2056,14 +2060,18 @@ void View::ZoneTooltip( const GpuEvent& ev )
         TextFocused( "Delay to execution:", TimeToString( AdjustGpuTime( ev.GpuStart(), begin, drift ) - ev.CpuStart() ) );
     }
 
-    TextFocused( "Query ID:", RealToString(ev.query_id) );
-    for (int i = 0; i < ev.note_count; i++ ) {
-      auto id = ev.note_ids[i];
-      if (ctx->notes.count(id)) {
-        TextFocused( m_worker.GetString( ctx->notes.at(id) ), RealToString(ev.note_vals[i]) );
-      } else {
-        TextFocused( RealToString(ev.note_ids[i]), RealToString(ev.note_vals[i]) );
-      }
+    TextFocused( "Query ID:", RealToString( ev.query_id ) );
+    for( int i = 0; i < ev.note_count; i++ )
+    {
+        auto id = ev.note_ids[i];
+        if( ctx->notes.count( id ) )
+        {
+            TextFocused( m_worker.GetString( ctx->notes.at( id ) ), RealToString( ev.note_vals[i] ) );
+        }
+        else
+        {
+            TextFocused( RealToString( ev.note_ids[i] ), RealToString( ev.note_vals[i] ) );
+        }
     }
 
     ImGui::EndTooltip();

--- a/public/TracyClient.cpp
+++ b/public/TracyClient.cpp
@@ -31,6 +31,7 @@
 #include "client/TracyAlloc.cpp"
 #include "client/TracyOverride.cpp"
 #include "client/TracyKCore.cpp"
+#include "client/TracyRocprof.cpp"
 
 #if defined(TRACY_HAS_CALLSTACK)
 #  if TRACY_HAS_CALLSTACK == 2 || TRACY_HAS_CALLSTACK == 3 || TRACY_HAS_CALLSTACK == 4 || TRACY_HAS_CALLSTACK == 6

--- a/public/TracyClient.cpp
+++ b/public/TracyClient.cpp
@@ -31,7 +31,10 @@
 #include "client/TracyAlloc.cpp"
 #include "client/TracyOverride.cpp"
 #include "client/TracyKCore.cpp"
+
+#ifdef TRACY_ROCPROF
 #include "client/TracyRocprof.cpp"
+#endif
 
 #if defined(TRACY_HAS_CALLSTACK)
 #  if TRACY_HAS_CALLSTACK == 2 || TRACY_HAS_CALLSTACK == 3 || TRACY_HAS_CALLSTACK == 4 || TRACY_HAS_CALLSTACK == 6

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -2358,6 +2358,10 @@ static void FreeAssociatedMemory( const QueueItem& item )
         tracy_free( (void*)ptr );
         break;
 #endif
+    case QueueType::GpuAnnotationName:
+        ptr = MemRead<uint64_t>( &item.gpuAnnotationNameFat.ptr );
+        tracy_free( (void*)ptr );
+        break;
 #ifdef TRACY_ON_DEMAND
     case QueueType::MessageAppInfo:
     case QueueType::GpuContextName:
@@ -2572,6 +2576,12 @@ Profiler::DequeueStatus Profiler::Dequeue( moodycamel::ConsumerToken& token )
 #ifndef TRACY_ON_DEMAND
                         tracy_free_fast( (void*)ptr );
 #endif
+                        break;
+                    case QueueType::GpuAnnotationName:
+                        ptr = MemRead<uint64_t>( &item->gpuAnnotationNameFat.ptr );
+                        size = MemRead<uint16_t>( &item->gpuAnnotationNameFat.size );
+                        SendSingleString( (const char*)ptr, size );
+                        tracy_free_fast( (void*)ptr );
                         break;
                     case QueueType::PlotDataInt:
                     case QueueType::PlotDataFloat:
@@ -2929,6 +2939,14 @@ Profiler::DequeueStatus Profiler::DequeueSerial()
 #ifndef TRACY_ON_DEMAND
                     tracy_free_fast( (void*)ptr );
 #endif
+                    break;
+                }
+                case QueueType::GpuAnnotationName:
+                {
+                    ptr = MemRead<uint64_t>( &item->gpuAnnotationNameFat.ptr );
+                    uint16_t size = MemRead<uint16_t>( &item->gpuAnnotationNameFat.size );
+                    SendSingleString( (const char*)ptr, size );
+                    tracy_free_fast( (void*)ptr );
                     break;
                 }
 #ifdef TRACY_FIBERS

--- a/public/client/TracyRocprof.cpp
+++ b/public/client/TracyRocprof.cpp
@@ -102,7 +102,7 @@ uint8_t gpu_context_allocate( ToolData* data )
         tracy::MemWrite( &item->gpuNewContext.period, timestamp_period );
         tracy::MemWrite( &item->gpuNewContext.context, context_id );
         tracy::MemWrite( &item->gpuNewContext.flags, context_flags );
-        tracy::MemWrite( &item->gpuNewContext.type, tracy::GpuContextType::Vulkan );
+        tracy::MemWrite( &item->gpuNewContext.type, tracy::GpuContextType::Rocprof );
         tracy::Profiler::QueueSerialFinish();
     }
 

--- a/public/client/TracyRocprof.cpp
+++ b/public/client/TracyRocprof.cpp
@@ -366,8 +366,6 @@ void dispatch_callback( rocprofiler_dispatch_counting_service_data_t dispatch_da
     *config = profile;
 }
 
-using kernel_symbol_data_t = rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
-
 void tool_callback_tracing_callback( rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data,
                                      void* callback_data )
 {

--- a/public/client/TracyRocprof.cpp
+++ b/public/client/TracyRocprof.cpp
@@ -1,17 +1,17 @@
-#include <rocprofiler-sdk/registration.h>
-#include <rocprofiler-sdk/rocprofiler.h>
 #include "TracyProfiler.hpp"
 #include "TracyThread.hpp"
 #include "tracy/TracyC.h"
+#include <rocprofiler-sdk/registration.h>
+#include <rocprofiler-sdk/rocprofiler.h>
 
 #include <iostream>
-#include <vector>
-#include <set>
 #include <mutex>
+#include <set>
 #include <shared_mutex>
 #include <sstream>
-#include <unordered_map>
 #include <time.h>
+#include <unordered_map>
+#include <vector>
 
 #define ROCPROFILER_CALL( result, msg )                                                                                \
     {                                                                                                                  \
@@ -50,28 +50,28 @@ struct ToolData
     std::unordered_map<rocprofiler_dispatch_id_t, int64_t> launch_start_times;
     std::unordered_map<rocprofiler_dispatch_id_t, int64_t> launch_end_times;
     std::unordered_map<rocprofiler_dispatch_id_t, uint16_t> dispatch_query_id;
-    std::set<std::string> counter_names = {"SQ_WAVES", "GL2C_MISS", "GL2C_HIT"};
+    std::set<std::string> counter_names = { "SQ_WAVES", "GL2C_MISS", "GL2C_HIT" };
     std::unique_ptr<tracy::Thread> cal_thread;
-    std::mutex    mut{};
+    std::mutex mut{};
 };
 
 using namespace tracy;
 
-rocprofiler_context_id_t&
-get_client_ctx()
+rocprofiler_context_id_t& get_client_ctx()
 {
-    static rocprofiler_context_id_t ctx{0};
+    static rocprofiler_context_id_t ctx{ 0 };
     return ctx;
 }
 
-const char * CTX_NAME = "rocprofv3";
+const char* CTX_NAME = "rocprofv3";
 
-uint8_t gpu_context_allocate(ToolData * data) {
+uint8_t gpu_context_allocate( ToolData* data )
+{
 
     timespec ts;
-    clock_gettime(CLOCK_BOOTTIME, &ts);
+    clock_gettime( CLOCK_BOOTTIME, &ts );
     uint64_t cpu_timestamp = Profiler::GetTime();
-    uint64_t gpu_timestamp = ((uint64_t)ts.tv_sec * 1000000000) + ts.tv_nsec;
+    uint64_t gpu_timestamp = ( (uint64_t)ts.tv_sec * 1000000000 ) + ts.tv_nsec;
     bool is_calibrated = USE_CALIBRATION;
     float timestamp_period = 1.0f;
     data->previous_cpu_time = cpu_timestamp;
@@ -79,186 +79,193 @@ uint8_t gpu_context_allocate(ToolData * data) {
     // Allocate the process-unique GPU context ID. There's a max of 255 available;
     // if we are recreating devices a lot we may exceed that. Don't do that, or
     // wrap around and get weird (but probably still usable) numbers.
-    uint8_t context_id =
-    tracy::GetGpuCtxCounter().fetch_add(1, std::memory_order_relaxed);
-    if (context_id >= 255) {
-    context_id %= 255;
+    uint8_t context_id = tracy::GetGpuCtxCounter().fetch_add( 1, std::memory_order_relaxed );
+    if( context_id >= 255 )
+    {
+        context_id %= 255;
     }
 
     uint8_t context_flags = 0;
-    if (is_calibrated) {
-    // Tell tracy we'll be passing calibrated timestamps and not to mess with
-    // the times. We'll periodically send GpuCalibration events in case the
-    // times drift.
-    context_flags |= tracy::GpuContextCalibration;
+    if( is_calibrated )
+    {
+        // Tell tracy we'll be passing calibrated timestamps and not to mess with
+        // the times. We'll periodically send GpuCalibration events in case the
+        // times drift.
+        context_flags |= tracy::GpuContextCalibration;
     }
     {
-    auto* item = tracy::Profiler::QueueSerial();
-    tracy::MemWrite(&item->hdr.type, tracy::QueueType::GpuNewContext);
-    tracy::MemWrite(&item->gpuNewContext.cpuTime, cpu_timestamp);
-    tracy::MemWrite(&item->gpuNewContext.gpuTime, gpu_timestamp);
-    memset(&item->gpuNewContext.thread, 0, sizeof(item->gpuNewContext.thread));
-    tracy::MemWrite(&item->gpuNewContext.period, timestamp_period);
-    tracy::MemWrite(&item->gpuNewContext.context, context_id);
-    tracy::MemWrite(&item->gpuNewContext.flags, context_flags);
-    tracy::MemWrite(&item->gpuNewContext.type, tracy::GpuContextType::Vulkan);
-    tracy::Profiler::QueueSerialFinish();
+        auto* item = tracy::Profiler::QueueSerial();
+        tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuNewContext );
+        tracy::MemWrite( &item->gpuNewContext.cpuTime, cpu_timestamp );
+        tracy::MemWrite( &item->gpuNewContext.gpuTime, gpu_timestamp );
+        memset( &item->gpuNewContext.thread, 0, sizeof( item->gpuNewContext.thread ) );
+        tracy::MemWrite( &item->gpuNewContext.period, timestamp_period );
+        tracy::MemWrite( &item->gpuNewContext.context, context_id );
+        tracy::MemWrite( &item->gpuNewContext.flags, context_flags );
+        tracy::MemWrite( &item->gpuNewContext.type, tracy::GpuContextType::Vulkan );
+        tracy::Profiler::QueueSerialFinish();
     }
 
     // Send the name of the context along.
     // NOTE: Tracy will unconditionally free the name so we must clone it here.
     // Since internally Tracy will use its own rpmalloc implementation we must
     // make sure we allocate from the same source.
-    size_t name_length = strlen(CTX_NAME);
-    char* cloned_name = (char*)tracy::tracy_malloc(name_length);
-    memcpy(cloned_name, CTX_NAME, name_length);
+    size_t name_length = strlen( CTX_NAME );
+    char* cloned_name = (char*)tracy::tracy_malloc( name_length );
+    memcpy( cloned_name, CTX_NAME, name_length );
     {
-    auto* item = tracy::Profiler::QueueSerial();
-    tracy::MemWrite(&item->hdr.type, tracy::QueueType::GpuContextName);
-    tracy::MemWrite(&item->gpuContextNameFat.context, context_id);
-    tracy::MemWrite(&item->gpuContextNameFat.ptr, (uint64_t)cloned_name);
-    tracy::MemWrite(&item->gpuContextNameFat.size, name_length);
-    tracy::Profiler::QueueSerialFinish();
+        auto* item = tracy::Profiler::QueueSerial();
+        tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuContextName );
+        tracy::MemWrite( &item->gpuContextNameFat.context, context_id );
+        tracy::MemWrite( &item->gpuContextNameFat.ptr, (uint64_t)cloned_name );
+        tracy::MemWrite( &item->gpuContextNameFat.size, name_length );
+        tracy::Profiler::QueueSerialFinish();
     }
 
     return context_id;
 }
 
-uint64_t kernel_src_loc(ToolData *data, uint64_t kernel_id) {
+uint64_t kernel_src_loc( ToolData* data, uint64_t kernel_id )
+{
     uint64_t src_loc = 0;
-    auto _lk = std::unique_lock{data->mut};
+    auto _lk = std::unique_lock{ data->mut };
     rocprofiler_kernel_id_t kid = kernel_id;
-    if (data->client_kernels.count(kid)) {
-        auto &sym_data = data->client_kernels[kid];
-        const char * name = sym_data.kernel_name;
-        size_t name_len = strlen(name);
+    if( data->client_kernels.count( kid ) )
+    {
+        auto& sym_data = data->client_kernels[kid];
+        const char* name = sym_data.kernel_name;
+        size_t name_len = strlen( name );
         uint32_t line = 0;
-        src_loc = tracy::Profiler::AllocSourceLocation(
-            line, NULL, 0, name, name_len,
-            NULL, 0);
+        src_loc = tracy::Profiler::AllocSourceLocation( line, NULL, 0, name, name_len, NULL, 0 );
     }
     return src_loc;
 }
 
-void record_interval(ToolData *data, rocprofiler_timestamp_t start_timestamp,
-    rocprofiler_timestamp_t end_timestamp,
-    uint64_t src_loc, rocprofiler_dispatch_id_t dispatch_id) {
+void record_interval( ToolData* data, rocprofiler_timestamp_t start_timestamp, rocprofiler_timestamp_t end_timestamp,
+                      uint64_t src_loc, rocprofiler_dispatch_id_t dispatch_id )
+{
 
     uint16_t query_id = 0;
     uint8_t context_id = data->context_id;
 
     {
-        auto _lk = std::unique_lock{data->mut};
+        auto _lk = std::unique_lock{ data->mut };
         query_id = data->query_id;
         data->query_id++;
-        if (dispatch_id != UINT64_MAX)
-          data->dispatch_query_id[dispatch_id] = query_id;
+        if( dispatch_id != UINT64_MAX ) data->dispatch_query_id[dispatch_id] = query_id;
     }
 
     uint64_t cpu_start_time = 0, cpu_end_time = 0;
-    if (dispatch_id == UINT64_MAX) {
+    if( dispatch_id == UINT64_MAX )
+    {
         cpu_start_time = tracy::Profiler::GetTime();
         cpu_end_time = tracy::Profiler::GetTime();
-    } else {
-        auto _lk = std::unique_lock{data->mut};
-        cpu_start_time = data->launch_start_times.at(dispatch_id);
-        cpu_end_time = data->launch_end_times.at(dispatch_id);
-        data->launch_start_times.erase(dispatch_id);
-        data->launch_end_times.erase(dispatch_id);
+    }
+    else
+    {
+        auto _lk = std::unique_lock{ data->mut };
+        cpu_start_time = data->launch_start_times.at( dispatch_id );
+        cpu_end_time = data->launch_end_times.at( dispatch_id );
+        data->launch_start_times.erase( dispatch_id );
+        data->launch_end_times.erase( dispatch_id );
     }
 
-    if (src_loc != 0) {
+    if( src_loc != 0 )
+    {
         {
-        auto* item = tracy::Profiler::QueueSerial();
-        tracy::MemWrite(&item->hdr.type,
-                        tracy::QueueType::GpuZoneBeginAllocSrcLocSerial);
-        tracy::MemWrite(&item->gpuZoneBegin.cpuTime, cpu_start_time);
-        tracy::MemWrite(&item->gpuZoneBegin.srcloc, (uint64_t)src_loc);
-        tracy::MemWrite(&item->gpuZoneBegin.thread, tracy::GetThreadHandle());
-        tracy::MemWrite(&item->gpuZoneBegin.queryId, query_id);
-        tracy::MemWrite(&item->gpuZoneBegin.context, context_id);
-        tracy::Profiler::QueueSerialFinish();
-        }
-    } else {
-        static const  ___tracy_source_location_data src_loc = {NULL, NULL, NULL, 0, 0};
-        {
-        auto* item = tracy::Profiler::QueueSerial();
-        tracy::MemWrite(&item->hdr.type, tracy::QueueType::GpuZoneBeginSerial);
-        tracy::MemWrite(&item->gpuZoneBegin.cpuTime, cpu_start_time);
-        tracy::MemWrite(&item->gpuZoneBegin.srcloc, (uint64_t)&src_loc);
-        tracy::MemWrite(&item->gpuZoneBegin.thread, tracy::GetThreadHandle());
-        tracy::MemWrite(&item->gpuZoneBegin.queryId, query_id);
-        tracy::MemWrite(&item->gpuZoneBegin.context, context_id);
-        tracy::Profiler::QueueSerialFinish();
+            auto* item = tracy::Profiler::QueueSerial();
+            tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneBeginAllocSrcLocSerial );
+            tracy::MemWrite( &item->gpuZoneBegin.cpuTime, cpu_start_time );
+            tracy::MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)src_loc );
+            tracy::MemWrite( &item->gpuZoneBegin.thread, tracy::GetThreadHandle() );
+            tracy::MemWrite( &item->gpuZoneBegin.queryId, query_id );
+            tracy::MemWrite( &item->gpuZoneBegin.context, context_id );
+            tracy::Profiler::QueueSerialFinish();
         }
     }
-
+    else
     {
-    auto*  item = tracy::Profiler::QueueSerial();
-    tracy::MemWrite(&item->hdr.type, tracy::QueueType::GpuTime);
-    tracy::MemWrite(&item->gpuTime.gpuTime, start_timestamp);
-    tracy::MemWrite(&item->gpuTime.queryId, query_id);
-    tracy::MemWrite(&item->gpuTime.context, context_id);
-    tracy::Profiler::QueueSerialFinish();
+        static const ___tracy_source_location_data src_loc = { NULL, NULL, NULL, 0, 0 };
+        {
+            auto* item = tracy::Profiler::QueueSerial();
+            tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneBeginSerial );
+            tracy::MemWrite( &item->gpuZoneBegin.cpuTime, cpu_start_time );
+            tracy::MemWrite( &item->gpuZoneBegin.srcloc, (uint64_t)&src_loc );
+            tracy::MemWrite( &item->gpuZoneBegin.thread, tracy::GetThreadHandle() );
+            tracy::MemWrite( &item->gpuZoneBegin.queryId, query_id );
+            tracy::MemWrite( &item->gpuZoneBegin.context, context_id );
+            tracy::Profiler::QueueSerialFinish();
+        }
     }
 
     {
-    auto* item = tracy::Profiler::QueueSerial();
-    tracy::MemWrite(&item->hdr.type, tracy::QueueType::GpuZoneEndSerial);
-    tracy::MemWrite(&item->gpuZoneEnd.cpuTime, cpu_end_time);
-    tracy::MemWrite(&item->gpuZoneEnd.thread, tracy::GetThreadHandle());
-    tracy::MemWrite(&item->gpuZoneEnd.queryId, query_id);
-    tracy::MemWrite(&item->gpuZoneEnd.context, context_id);
-    tracy::Profiler::QueueSerialFinish();
+        auto* item = tracy::Profiler::QueueSerial();
+        tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuTime );
+        tracy::MemWrite( &item->gpuTime.gpuTime, start_timestamp );
+        tracy::MemWrite( &item->gpuTime.queryId, query_id );
+        tracy::MemWrite( &item->gpuTime.context, context_id );
+        tracy::Profiler::QueueSerialFinish();
     }
 
     {
-    auto* item = tracy::Profiler::QueueSerial();
-    tracy::MemWrite(&item->hdr.type, tracy::QueueType::GpuTime);
-    tracy::MemWrite(&item->gpuTime.gpuTime, end_timestamp);
-    tracy::MemWrite(&item->gpuTime.queryId, query_id);
-    tracy::MemWrite(&item->gpuTime.context, context_id);
-    tracy::Profiler::QueueSerialFinish();
+        auto* item = tracy::Profiler::QueueSerial();
+        tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneEndSerial );
+        tracy::MemWrite( &item->gpuZoneEnd.cpuTime, cpu_end_time );
+        tracy::MemWrite( &item->gpuZoneEnd.thread, tracy::GetThreadHandle() );
+        tracy::MemWrite( &item->gpuZoneEnd.queryId, query_id );
+        tracy::MemWrite( &item->gpuZoneEnd.context, context_id );
+        tracy::Profiler::QueueSerialFinish();
+    }
+
+    {
+        auto* item = tracy::Profiler::QueueSerial();
+        tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuTime );
+        tracy::MemWrite( &item->gpuTime.gpuTime, end_timestamp );
+        tracy::MemWrite( &item->gpuTime.queryId, query_id );
+        tracy::MemWrite( &item->gpuTime.context, context_id );
+        tracy::Profiler::QueueSerialFinish();
     }
 }
 
-void
-record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
-                rocprofiler_record_counter_t*                record_data,
-                size_t                                       record_count,
-                rocprofiler_user_data_t  /*user_data*/ ,
-                void* callback_data)
+void record_callback( rocprofiler_dispatch_counting_service_data_t dispatch_data,
+                      rocprofiler_record_counter_t* record_data, size_t record_count,
+                      rocprofiler_user_data_t /*user_data*/, void* callback_data )
 {
-    assert(callback_data != nullptr);
-    ToolData * data = static_cast<ToolData*>(callback_data);
-    if (!data->init) return;
+    assert( callback_data != nullptr );
+    ToolData* data = static_cast<ToolData*>( callback_data );
+    if( !data->init ) return;
 
     std::unordered_map<rocprofiler_counter_instance_id_t, double> sums;
-    for(size_t i = 0; i < record_count; ++i) {
+    for( size_t i = 0; i < record_count; ++i )
+    {
         auto _counter_id = rocprofiler_counter_id_t{};
-        ROCPROFILER_CALL(rocprofiler_query_record_counter_id(record_data[i].id, &_counter_id),
-                         "query record counter id");
+        ROCPROFILER_CALL( rocprofiler_query_record_counter_id( record_data[i].id, &_counter_id ),
+                          "query record counter id" );
         sums[_counter_id.handle] += record_data[i].counter_value;
     }
 
     uint16_t query_id = 0;
     {
-      auto _lk = std::unique_lock{data->mut};
-      if (data->dispatch_query_id.count(dispatch_data.dispatch_info.dispatch_id)) {
-        query_id = data->dispatch_query_id[dispatch_data.dispatch_info.dispatch_id];
-      } else {
-        fprintf(stderr, "oops\n");
-      }
+        auto _lk = std::unique_lock{ data->mut };
+        if( data->dispatch_query_id.count( dispatch_data.dispatch_info.dispatch_id ) )
+        {
+            query_id = data->dispatch_query_id[dispatch_data.dispatch_info.dispatch_id];
+        }
+        else
+        {
+            fprintf( stderr, "oops\n" );
+        }
     }
 
-    for( auto& p: sums ) {
-      auto* item = tracy::Profiler::QueueSerial();
-      tracy::MemWrite(&item->hdr.type, tracy::QueueType::GpuZoneAnnotation);
-      tracy::MemWrite(&item->zoneAnnotation.noteId, p.first);
-      tracy::MemWrite(&item->zoneAnnotation.queryId, query_id);
-      tracy::MemWrite(&item->zoneAnnotation.value, p.second);
-      tracy::MemWrite(&item->zoneAnnotation.context, data->context_id);
-      tracy::Profiler::QueueSerialFinish();
+    for( auto& p : sums )
+    {
+        auto* item = tracy::Profiler::QueueSerial();
+        tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuZoneAnnotation );
+        tracy::MemWrite( &item->zoneAnnotation.noteId, p.first );
+        tracy::MemWrite( &item->zoneAnnotation.queryId, query_id );
+        tracy::MemWrite( &item->zoneAnnotation.value, p.second );
+        tracy::MemWrite( &item->zoneAnnotation.context, data->context_id );
+        tracy::Profiler::QueueSerialFinish();
     }
 }
 
@@ -268,15 +275,13 @@ record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
  * for this dispatch (dispatch_packet). This example function creates a profile
  * to collect the counter SQ_WAVES for all kernel dispatch packets.
  */
-void
-dispatch_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
-                  rocprofiler_profile_config_id_t*             config,
-                  rocprofiler_user_data_t* /*user_data*/,
-                  void* callback_data)
+void dispatch_callback( rocprofiler_dispatch_counting_service_data_t dispatch_data,
+                        rocprofiler_profile_config_id_t* config, rocprofiler_user_data_t* /*user_data*/,
+                        void* callback_data )
 {
-    assert(callback_data != nullptr);
-    ToolData * data = static_cast<ToolData*>(callback_data);
-    if (!data->init) return;
+    assert( callback_data != nullptr );
+    ToolData* data = static_cast<ToolData*>( callback_data );
+    if( !data->init ) return;
 
     /**
      * This simple example uses the same profile counter set for all agents.
@@ -285,12 +290,12 @@ dispatch_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
      * set for the agent. If we have, return it. Otherwise, construct a new profile counter
      * set.
      */
-    static std::shared_mutex                                             m_mutex       = {};
+    static std::shared_mutex m_mutex = {};
     static std::unordered_map<uint64_t, rocprofiler_profile_config_id_t> profile_cache = {};
 
-    auto search_cache = [&]() {
-        if(auto pos = profile_cache.find(dispatch_data.dispatch_info.agent_id.handle);
-           pos != profile_cache.end())
+    auto search_cache = [&]()
+    {
+        if( auto pos = profile_cache.find( dispatch_data.dispatch_info.agent_id.handle ); pos != profile_cache.end() )
         {
             *config = pos->second;
             return true;
@@ -299,122 +304,127 @@ dispatch_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
     };
 
     {
-        auto rlock = std::shared_lock{m_mutex};
-        if(search_cache()) return;
+        auto rlock = std::shared_lock{ m_mutex };
+        if( search_cache() ) return;
     }
 
-    auto wlock = std::unique_lock{m_mutex};
-    if(search_cache()) return;
+    auto wlock = std::unique_lock{ m_mutex };
+    if( search_cache() ) return;
 
     // GPU Counter IDs
     std::vector<rocprofiler_counter_id_t> gpu_counters;
 
     // Iterate through the agents and get the counters available on that agent
-    ROCPROFILER_CALL(rocprofiler_iterate_agent_supported_counters(
-                         dispatch_data.dispatch_info.agent_id,
-                         [](rocprofiler_agent_id_t,
-                            rocprofiler_counter_id_t* counters,
-                            size_t                    num_counters,
-                            void*                     user_data) {
-                             std::vector<rocprofiler_counter_id_t>* vec =
-                                 static_cast<std::vector<rocprofiler_counter_id_t>*>(user_data);
-                             for(size_t i = 0; i < num_counters; i++)
-                             {
-                                 vec->push_back(counters[i]);
-                             }
-                             return ROCPROFILER_STATUS_SUCCESS;
-                         },
-                         static_cast<void*>(&gpu_counters)),
-                     "Could not fetch supported counters");
+    ROCPROFILER_CALL(
+        rocprofiler_iterate_agent_supported_counters(
+            dispatch_data.dispatch_info.agent_id,
+            []( rocprofiler_agent_id_t, rocprofiler_counter_id_t* counters, size_t num_counters, void* user_data )
+            {
+                std::vector<rocprofiler_counter_id_t>* vec =
+                    static_cast<std::vector<rocprofiler_counter_id_t>*>( user_data );
+                for( size_t i = 0; i < num_counters; i++ )
+                {
+                    vec->push_back( counters[i] );
+                }
+                return ROCPROFILER_STATUS_SUCCESS;
+            },
+            static_cast<void*>( &gpu_counters ) ),
+        "Could not fetch supported counters" );
 
     std::vector<rocprofiler_counter_id_t> collect_counters;
     // Look for the counters contained in counters_to_collect in gpu_counters
-    for(auto& counter : gpu_counters)
+    for( auto& counter : gpu_counters )
     {
         rocprofiler_counter_info_v0_t info;
         ROCPROFILER_CALL(
-            rocprofiler_query_counter_info(
-                counter, ROCPROFILER_COUNTER_INFO_VERSION_0, static_cast<void*>(&info)),
-            "Could not query info");
-        if(data->counter_names.count(std::string(info.name)) > 0)
+            rocprofiler_query_counter_info( counter, ROCPROFILER_COUNTER_INFO_VERSION_0, static_cast<void*>( &info ) ),
+            "Could not query info" );
+        if( data->counter_names.count( std::string( info.name ) ) > 0 )
         {
             std::clog << "Counter: " << counter.handle << " " << info.name << "\n";
-            collect_counters.push_back(counter);
+            collect_counters.push_back( counter );
 
-            size_t name_length = strlen(info.name);
-            char* cloned_name = (char*)tracy::tracy_malloc(name_length);
-            memcpy(cloned_name, info.name, name_length);
+            size_t name_length = strlen( info.name );
+            char* cloned_name = (char*)tracy::tracy_malloc( name_length );
+            memcpy( cloned_name, info.name, name_length );
             {
-              auto* item = tracy::Profiler::QueueSerial();
-              tracy::MemWrite(&item->hdr.type, tracy::QueueType::GpuAnnotationName);
-              tracy::MemWrite(&item->gpuAnnotationNameFat.context, data->context_id);
-              tracy::MemWrite(&item->gpuAnnotationNameFat.noteId, counter.handle);
-              tracy::MemWrite(&item->gpuAnnotationNameFat.ptr, (uint64_t)cloned_name);
-              tracy::MemWrite(&item->gpuAnnotationNameFat.size, name_length);
-              tracy::Profiler::QueueSerialFinish();
+                auto* item = tracy::Profiler::QueueSerial();
+                tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuAnnotationName );
+                tracy::MemWrite( &item->gpuAnnotationNameFat.context, data->context_id );
+                tracy::MemWrite( &item->gpuAnnotationNameFat.noteId, counter.handle );
+                tracy::MemWrite( &item->gpuAnnotationNameFat.ptr, (uint64_t)cloned_name );
+                tracy::MemWrite( &item->gpuAnnotationNameFat.size, name_length );
+                tracy::Profiler::QueueSerialFinish();
             }
         }
     }
 
     // Create a colleciton profile for the counters
-    rocprofiler_profile_config_id_t profile = {.handle = 0};
-    ROCPROFILER_CALL(rocprofiler_create_profile_config(dispatch_data.dispatch_info.agent_id,
-                                                       collect_counters.data(),
-                                                       collect_counters.size(),
-                                                       &profile),
-                     "Could not construct profile cfg");
+    rocprofiler_profile_config_id_t profile = { .handle = 0 };
+    ROCPROFILER_CALL( rocprofiler_create_profile_config( dispatch_data.dispatch_info.agent_id, collect_counters.data(),
+                                                         collect_counters.size(), &profile ),
+                      "Could not construct profile cfg" );
 
-    profile_cache.emplace(dispatch_data.dispatch_info.agent_id.handle, profile);
+    profile_cache.emplace( dispatch_data.dispatch_info.agent_id.handle, profile );
     // Return the profile to collect those counters for this dispatch
     *config = profile;
 }
 
 using kernel_symbol_data_t = rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
 
-void
-tool_callback_tracing_callback(rocprofiler_callback_tracing_record_t record,
-                               rocprofiler_user_data_t*              user_data,
-                               void*                                 callback_data)
+void tool_callback_tracing_callback( rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data,
+                                     void* callback_data )
 {
-    assert(callback_data != nullptr);
-    ToolData * data = static_cast<ToolData*>(callback_data);
-    if (!data->init) return;
+    assert( callback_data != nullptr );
+    ToolData* data = static_cast<ToolData*>( callback_data );
+    if( !data->init ) return;
 
-    if(record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
-            record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER)
+    if( record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
+        record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER )
     {
-        auto* sym_data = static_cast<kernel_symbol_data_t*>(record.payload);
+        auto* sym_data = static_cast<kernel_symbol_data_t*>( record.payload );
 
-        if(record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD)
+        if( record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD )
         {
-            auto _lk = std::unique_lock{data->mut};
-            data->client_kernels.emplace(sym_data->kernel_id, *sym_data);
+            auto _lk = std::unique_lock{ data->mut };
+            data->client_kernels.emplace( sym_data->kernel_id, *sym_data );
         }
-        else if(record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD)
+        else if( record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD )
         {
-            auto _lk = std::unique_lock{data->mut};
-            data->client_kernels.erase(sym_data->kernel_id);
+            auto _lk = std::unique_lock{ data->mut };
+            data->client_kernels.erase( sym_data->kernel_id );
         }
-    } else if (record.kind == ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) {
-        auto* rdata = static_cast<rocprofiler_callback_tracing_kernel_dispatch_data_t*>(record.payload);
-        if (record.operation == ROCPROFILER_KERNEL_DISPATCH_ENQUEUE) {
-            if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
-                auto _lk = std::unique_lock{data->mut};
-                data->launch_start_times.emplace(rdata->dispatch_info.dispatch_id, tracy::Profiler::GetTime());
-            } else if (record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) {
-                auto _lk = std::unique_lock{data->mut};
-                data->launch_end_times.emplace(rdata->dispatch_info.dispatch_id, tracy::Profiler::GetTime());
+    }
+    else if( record.kind == ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH )
+    {
+        auto* rdata = static_cast<rocprofiler_callback_tracing_kernel_dispatch_data_t*>( record.payload );
+        if( record.operation == ROCPROFILER_KERNEL_DISPATCH_ENQUEUE )
+        {
+            if( record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER )
+            {
+                auto _lk = std::unique_lock{ data->mut };
+                data->launch_start_times.emplace( rdata->dispatch_info.dispatch_id, tracy::Profiler::GetTime() );
             }
-        } else if (record.operation == ROCPROFILER_KERNEL_DISPATCH_COMPLETE) {
-            uint64_t src_loc = kernel_src_loc(data, rdata->dispatch_info.kernel_id);
-            record_interval(data, rdata->start_timestamp, rdata->end_timestamp, src_loc, rdata->dispatch_info.dispatch_id);
+            else if( record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT )
+            {
+                auto _lk = std::unique_lock{ data->mut };
+                data->launch_end_times.emplace( rdata->dispatch_info.dispatch_id, tracy::Profiler::GetTime() );
+            }
         }
-    } else if (record.kind == ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY &&
-        record.operation != ROCPROFILER_MEMORY_COPY_NONE &&
-        record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) {
-        auto* rdata = static_cast<rocprofiler_callback_tracing_memory_copy_data_t*>(record.payload);
-        const char * name = nullptr;
-        switch(record.operation) {
+        else if( record.operation == ROCPROFILER_KERNEL_DISPATCH_COMPLETE )
+        {
+            uint64_t src_loc = kernel_src_loc( data, rdata->dispatch_info.kernel_id );
+            record_interval( data, rdata->start_timestamp, rdata->end_timestamp, src_loc,
+                             rdata->dispatch_info.dispatch_id );
+        }
+    }
+    else if( record.kind == ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY &&
+             record.operation != ROCPROFILER_MEMORY_COPY_NONE && record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT )
+    {
+        auto* rdata = static_cast<rocprofiler_callback_tracing_memory_copy_data_t*>( record.payload );
+        const char* name = nullptr;
+        switch( record.operation )
+        {
         case ROCPROFILER_MEMORY_COPY_DEVICE_TO_DEVICE:
             name = "DeviceToDeviceCopy";
             break;
@@ -428,57 +438,59 @@ tool_callback_tracing_callback(rocprofiler_callback_tracing_record_t record,
             name = "HostToHostCopy";
             break;
         }
-        size_t name_len = strlen(name);
-        uint64_t src_loc = tracy::Profiler::AllocSourceLocation(
-            0, NULL, 0, name, name_len,
-            NULL, 0);
-        record_interval(data, rdata->start_timestamp, rdata->end_timestamp, src_loc, UINT64_MAX);
+        size_t name_len = strlen( name );
+        uint64_t src_loc = tracy::Profiler::AllocSourceLocation( 0, NULL, 0, name, name_len, NULL, 0 );
+        record_interval( data, rdata->start_timestamp, rdata->end_timestamp, src_loc, UINT64_MAX );
     }
 }
 
-void calibration_thread(void * ptr) {
-    while (!TracyIsStarted);
-    ToolData * data = static_cast<ToolData*>(ptr);
-    data->context_id = gpu_context_allocate(data);
-    const char* user_counters = GetEnvVar("TRACY_ROCPROF_COUNTERS");
-    if (user_counters) {
-      data->counter_names.clear();
-      std::stringstream ss(user_counters);
-      std::string counter;
-      while (std::getline(ss, counter, ','))
-        data->counter_names.insert(counter);
+void calibration_thread( void* ptr )
+{
+    while( !TracyIsStarted )
+        ;
+    ToolData* data = static_cast<ToolData*>( ptr );
+    data->context_id = gpu_context_allocate( data );
+    const char* user_counters = GetEnvVar( "TRACY_ROCPROF_COUNTERS" );
+    if( user_counters )
+    {
+        data->counter_names.clear();
+        std::stringstream ss( user_counters );
+        std::string counter;
+        while( std::getline( ss, counter, ',' ) ) data->counter_names.insert( counter );
     }
     data->init = true;
 
 #if USE_CALIBRATION
-    while (data->init) {
+    while( data->init )
+    {
         timespec ts;
         // HSA performs a linear interpolation of GPU time to CLOCK_BOOTTIME. However, this is
         // subject to network time updates and can drift relative to tracy's clock.
-        clock_gettime(CLOCK_BOOTTIME, &ts);
+        clock_gettime( CLOCK_BOOTTIME, &ts );
         int64_t cpu_timestamp = Profiler::GetTime();
         int64_t gpu_timestamp = ts.tv_nsec + ts.tv_sec * 1e9L;
 
-        if (cpu_timestamp > data->previous_cpu_time) {
+        if( cpu_timestamp > data->previous_cpu_time )
+        {
             auto* item = tracy::Profiler::QueueSerial();
-            tracy::MemWrite(&item->hdr.type, tracy::QueueType::GpuCalibration);
-            tracy::MemWrite(&item->gpuCalibration.gpuTime, gpu_timestamp);
-            tracy::MemWrite(&item->gpuCalibration.cpuTime, cpu_timestamp);
-            tracy::MemWrite(&item->gpuCalibration.cpuDelta, cpu_timestamp - data->previous_cpu_time);
-            tracy::MemWrite(&item->gpuCalibration.context, data->context_id);
+            tracy::MemWrite( &item->hdr.type, tracy::QueueType::GpuCalibration );
+            tracy::MemWrite( &item->gpuCalibration.gpuTime, gpu_timestamp );
+            tracy::MemWrite( &item->gpuCalibration.cpuTime, cpu_timestamp );
+            tracy::MemWrite( &item->gpuCalibration.cpuDelta, cpu_timestamp - data->previous_cpu_time );
+            tracy::MemWrite( &item->gpuCalibration.context, data->context_id );
             tracy::Profiler::QueueSerialFinish();
             data->previous_cpu_time = cpu_timestamp;
         }
 
-        sleep(1);
+        sleep( 1 );
     }
 #endif
 }
 
 int tool_init( rocprofiler_client_finalize_t fini_func, void* user_data )
 {
-    ToolData * data = static_cast<ToolData*>(user_data);
-    data->cal_thread = std::make_unique<tracy::Thread>(calibration_thread, data);
+    ToolData* data = static_cast<ToolData*>( user_data );
+    data->cal_thread = std::make_unique<tracy::Thread>( calibration_thread, data );
 
     ROCPROFILER_CALL( rocprofiler_create_context( &get_client_ctx() ), "context creation failed" );
 
@@ -486,44 +498,33 @@ int tool_init( rocprofiler_client_finalize_t fini_func, void* user_data )
                                                                                 user_data, record_callback, user_data ),
                       "Could not setup counting service" );
 
-    rocprofiler_tracing_operation_t ops[] = {ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER};
-    ROCPROFILER_CALL(
-        rocprofiler_configure_callback_tracing_service(get_client_ctx(),
-                                                       ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT,
-                                                       ops,
-                                                       1,
-                                                       tool_callback_tracing_callback,
-                                                       user_data),
-        "callback tracing service failed to configure");
+    rocprofiler_tracing_operation_t ops[] = { ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER };
+    ROCPROFILER_CALL( rocprofiler_configure_callback_tracing_service( get_client_ctx(),
+                                                                      ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT, ops, 1,
+                                                                      tool_callback_tracing_callback, user_data ),
+                      "callback tracing service failed to configure" );
 
-    rocprofiler_tracing_operation_t ops2[] = {ROCPROFILER_KERNEL_DISPATCH_COMPLETE, ROCPROFILER_KERNEL_DISPATCH_ENQUEUE};
+    rocprofiler_tracing_operation_t ops2[] = { ROCPROFILER_KERNEL_DISPATCH_COMPLETE,
+                                               ROCPROFILER_KERNEL_DISPATCH_ENQUEUE };
     ROCPROFILER_CALL(
-        rocprofiler_configure_callback_tracing_service(get_client_ctx(),
-                                                        ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
-                                                        ops2,
-                                                        2,
-                                                        tool_callback_tracing_callback,
-                                                        user_data),
-        "callback tracing service failed to configure");
+        rocprofiler_configure_callback_tracing_service( get_client_ctx(), ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
+                                                        ops2, 2, tool_callback_tracing_callback, user_data ),
+        "callback tracing service failed to configure" );
 
-    ROCPROFILER_CALL(
-        rocprofiler_configure_callback_tracing_service(get_client_ctx(),
-                                                        ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY,
-                                                        nullptr,
-                                                        0,
-                                                        tool_callback_tracing_callback,
-                                                        user_data),
-        "callback tracing service failed to configure");
-
+    ROCPROFILER_CALL( rocprofiler_configure_callback_tracing_service( get_client_ctx(),
+                                                                      ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY, nullptr,
+                                                                      0, tool_callback_tracing_callback, user_data ),
+                      "callback tracing service failed to configure" );
 
     ROCPROFILER_CALL( rocprofiler_start_context( get_client_ctx() ), "start context" );
     return 0;
 }
 
-void tool_fini( void* tool_data_v ) {
-    rocprofiler_stop_context(get_client_ctx());
+void tool_fini( void* tool_data_v )
+{
+    rocprofiler_stop_context( get_client_ctx() );
 
-    ToolData * data = static_cast<ToolData*>(tool_data_v);
+    ToolData* data = static_cast<ToolData*>( tool_data_v );
     data->init = false;
     data->cal_thread.reset();
 }

--- a/public/client/TracyRocprof.cpp
+++ b/public/client/TracyRocprof.cpp
@@ -247,14 +247,10 @@ void record_callback( rocprofiler_dispatch_counting_service_data_t dispatch_data
     uint16_t query_id = 0;
     {
         auto _lk = std::unique_lock{ data->mut };
-        if( data->dispatch_query_id.count( dispatch_data.dispatch_info.dispatch_id ) )
-        {
-            query_id = data->dispatch_query_id[dispatch_data.dispatch_info.dispatch_id];
-        }
-        else
-        {
-            fprintf( stderr, "oops\n" );
-        }
+        // An assumption is made here that the counter values are supplied after the dispatch
+        // complete callback.
+        assert( data->dispatch_query_id.count( dispatch_data.dispatch_info.dispatch_id ) );
+        query_id = data->dispatch_query_id[dispatch_data.dispatch_info.dispatch_id];
     }
 
     for( auto& p : sums )

--- a/public/common/TracyProtocol.hpp
+++ b/public/common/TracyProtocol.hpp
@@ -9,7 +9,7 @@ namespace tracy
 
 constexpr unsigned Lz4CompressBound( unsigned isize ) { return isize + ( isize / 255 ) + 16; }
 
-enum : uint32_t { ProtocolVersion = 75 };
+enum : uint32_t { ProtocolVersion = 76 };
 enum : uint16_t { BroadcastVersion = 3 };
 
 using lz4sz_t = uint32_t;

--- a/public/common/TracyQueue.hpp
+++ b/public/common/TracyQueue.hpp
@@ -450,10 +450,10 @@ struct QueueGpuZoneEnd
 
 struct QueueGpuZoneAnnotation
 {
-  int64_t noteId;
-  double value;
-  uint16_t queryId;
-  uint8_t context;
+    int64_t noteId;
+    double value;
+    uint16_t queryId;
+    uint8_t context;
 };
 
 struct QueueGpuTime
@@ -491,14 +491,14 @@ struct QueueGpuContextNameFat : public QueueGpuContextName
 
 struct QueueGpuAnnotationName
 {
-  int64_t noteId;
-  uint8_t context;
+    int64_t noteId;
+    uint8_t context;
 };
 
 struct QueueGpuAnnotationNameFat : public QueueGpuAnnotationName
 {
-  uint64_t ptr;
-  uint16_t size;
+    uint64_t ptr;
+    uint16_t size;
 };
 
 struct QueueMemNamePayload

--- a/public/common/TracyQueue.hpp
+++ b/public/common/TracyQueue.hpp
@@ -61,6 +61,7 @@ enum class QueueType : uint8_t
     ThreadWakeup,
     GpuTime,
     GpuContextName,
+    GpuAnnotationName,
     CallstackFrameSize,
     SymbolInformation,
     ExternalNameMetadata,
@@ -488,6 +489,18 @@ struct QueueGpuContextNameFat : public QueueGpuContextName
     uint16_t size;
 };
 
+struct QueueGpuAnnotationName
+{
+  int64_t noteId;
+  uint8_t context;
+};
+
+struct QueueGpuAnnotationNameFat : public QueueGpuAnnotationName
+{
+  uint64_t ptr;
+  uint16_t size;
+};
+
 struct QueueMemNamePayload
 {
     uint64_t name;
@@ -765,6 +778,8 @@ struct QueueItem
         QueueGpuTimeSync gpuTimeSync;
         QueueGpuContextName gpuContextName;
         QueueGpuContextNameFat gpuContextNameFat;
+        QueueGpuAnnotationName gpuAnnotationName;
+        QueueGpuAnnotationNameFat gpuAnnotationNameFat;
         QueueMemAlloc memAlloc;
         QueueMemFree memFree;
         QueueMemDiscard memDiscard;
@@ -859,6 +874,7 @@ static constexpr size_t QueueDataSize[] = {
     sizeof( QueueHeader ) + sizeof( QueueThreadWakeup ),
     sizeof( QueueHeader ) + sizeof( QueueGpuTime ),
     sizeof( QueueHeader ) + sizeof( QueueGpuContextName ),
+    sizeof( QueueHeader ) + sizeof( QueueGpuAnnotationName ),
     sizeof( QueueHeader ) + sizeof( QueueCallstackFrameSize ),
     sizeof( QueueHeader ) + sizeof( QueueSymbolInformation ),
     sizeof( QueueHeader ),                                  // ExternalNameMetadata - not for wire transfer

--- a/public/common/TracyQueue.hpp
+++ b/public/common/TracyQueue.hpp
@@ -408,7 +408,8 @@ enum class GpuContextType : uint8_t
     Direct3D11,
     Metal,
     Custom,
-    CUDA
+    CUDA,
+    Rocprof
 };
 
 enum GpuContextFlags : uint8_t

--- a/public/common/TracyQueue.hpp
+++ b/public/common/TracyQueue.hpp
@@ -453,6 +453,7 @@ struct QueueGpuZoneAnnotation
 {
     int64_t noteId;
     double value;
+    uint32_t thread;
     uint16_t queryId;
     uint8_t context;
 };

--- a/public/common/TracyQueue.hpp
+++ b/public/common/TracyQueue.hpp
@@ -111,6 +111,7 @@ enum class QueueType : uint8_t
     SecondStringData,
     MemNamePayload,
     ThreadGroupHint,
+    GpuZoneAnnotation,
     StringData,
     ThreadName,
     PlotName,
@@ -331,7 +332,7 @@ struct QueuePlotDataInt : public QueuePlotDataBase
     int64_t val;
 };
 
-struct QueuePlotDataFloat : public QueuePlotDataBase 
+struct QueuePlotDataFloat : public QueuePlotDataBase
 {
     float val;
 };
@@ -446,6 +447,14 @@ struct QueueGpuZoneEnd
     uint8_t context;
 };
 
+struct QueueGpuZoneAnnotation
+{
+  int64_t noteId;
+  double value;
+  uint16_t queryId;
+  uint8_t context;
+};
+
 struct QueueGpuTime
 {
     int64_t gpuTime;
@@ -467,7 +476,7 @@ struct QueueGpuTimeSync
     int64_t cpuTime;
     uint8_t context;
 };
-    
+
 struct QueueGpuContextName
 {
     uint8_t context;
@@ -789,6 +798,7 @@ struct QueueItem
         QueueSourceCodeNotAvailable sourceCodeNotAvailable;
         QueueFiberEnter fiberEnter;
         QueueFiberLeave fiberLeave;
+        QueueGpuZoneAnnotation zoneAnnotation;
     };
 };
 #pragma pack( pop )
@@ -900,6 +910,7 @@ static constexpr size_t QueueDataSize[] = {
     sizeof( QueueHeader ),                                  // second string data
     sizeof( QueueHeader ) + sizeof( QueueMemNamePayload ),
     sizeof( QueueHeader ) + sizeof( QueueThreadGroupHint ),
+    sizeof( QueueHeader ) + sizeof( QueueGpuZoneAnnotation ), // GPU zone annotation
     // keep all QueueStringTransfer below
     sizeof( QueueHeader ) + sizeof( QueueStringTransfer ),  // string data
     sizeof( QueueHeader ) + sizeof( QueueStringTransfer ),  // thread name

--- a/server/TracyEvent.hpp
+++ b/server/TracyEvent.hpp
@@ -412,6 +412,10 @@ struct GpuEvent
     uint64_t _gpuStart_child1;
     uint64_t _gpuEnd_child2;
     Int24 callstack;
+    uint16_t query_id;
+    int64_t note_ids[10];
+    double note_vals[10];
+    uint8_t note_count;
 };
 
 enum { GpuEventSize = sizeof( GpuEvent ) };

--- a/server/TracyEvent.hpp
+++ b/server/TracyEvent.hpp
@@ -778,6 +778,7 @@ struct GpuCtxData
     uint32_t overflowMul;
     StringIdx name;
     unordered_flat_map<uint64_t, GpuCtxThreadData> threadData;
+    unordered_flat_map<int64_t, StringIdx> notes;
     short_ptr<GpuEvent> query[64*1024];
 };
 

--- a/server/TracyEvent.hpp
+++ b/server/TracyEvent.hpp
@@ -413,9 +413,7 @@ struct GpuEvent
     uint64_t _gpuEnd_child2;
     Int24 callstack;
     uint16_t query_id;
-    int64_t note_ids[10];
-    double note_vals[10];
-    uint8_t note_count;
+    unordered_flat_map<int64_t, double> notes;
 };
 
 enum { GpuEventSize = sizeof( GpuEvent ) };

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -6051,9 +6051,6 @@ void Worker::ProcessGpuZoneAnnotation( const QueueGpuZoneAnnotation& ev )
     zone->note_ids[zone->note_count] = ev.noteId;
     zone->note_vals[zone->note_count] = ev.value;
     zone->note_count++;
-
-    if (ctx->notes.contains(ev.noteId))
-      fprintf(stderr, "%s: %f\n", GetString(ctx->notes[ev.noteId]), ev.value);
 }
 
 MemEvent* Worker::ProcessMemAllocImpl( MemData& memdata, const QueueMemAlloc& ev )

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -1107,12 +1107,12 @@ Worker::Worker( FileRead& f, EventType::Type eventMask, bool bgTasks, bool allow
         f.Read7( ctx->thread, calibration, ctx->count, ctx->period, ctx->type, ctx->name, ctx->overflow );
         uint64_t notesz;
         f.Read( notesz );
-        for ( uint64_t i=0; i<notesz; i++ )
+        for( uint64_t i = 0; i < notesz; i++ )
         {
-          decltype(ctx->notes)::key_type key;
-          decltype(ctx->notes)::mapped_type value;
-          f.Read2( key, value );
-          ctx->notes[key] = value;
+            decltype( ctx->notes )::key_type key;
+            decltype( ctx->notes )::mapped_type value;
+            f.Read2( key, value );
+            ctx->notes[key] = value;
         }
         ctx->hasCalibration = calibration;
         ctx->hasPeriod = ctx->period != 1.f;
@@ -6042,15 +6042,16 @@ void Worker::ProcessGpuZoneAnnotation( const QueueGpuZoneAnnotation& ev )
     auto ctx = m_gpuCtxMap[ev.context];
     assert( ctx );
     // TODO: Get thread ID properly
-    // TODO: Search for the query from the back
     assert( ctx->threadData.size() );
-    auto & timeline = ctx->threadData.begin()->second.timeline;
+    auto& timeline = ctx->threadData.begin()->second.timeline;
     assert( timeline.size() );
     ssize_t i = timeline.size() - 1;
-    for ( ; i >= 0 ; i--) {
-      if( timeline[i]->query_id == ev.queryId ) {
-        break;
-      }
+    for( ; i >= 0; i-- )
+    {
+        if( timeline[i]->query_id == ev.queryId )
+        {
+            break;
+        }
     }
     auto& zone = timeline[i];
     assert( zone->note_count < 10 );
@@ -7834,10 +7835,10 @@ void Worker::ReadTimeline( FileRead& f, Vector<short_ptr<GpuEvent>>& _vec, uint6
         refGpuTime += tgpu;
         zone->SetCpuEnd( refTime );
         zone->SetGpuEnd( refGpuTime );
-        f.Read(zone->query_id);
-        f.Read(zone->note_count);
-        f.Read(zone->note_ids);
-        f.Read(zone->note_vals);
+        f.Read( zone->query_id );
+        f.Read( zone->note_count );
+        f.Read( zone->note_ids );
+        f.Read( zone->note_vals );
     }
     while( ++zone != end );
 }
@@ -8179,8 +8180,8 @@ void Worker::Write( FileWrite& f, bool fiDict )
         f.Write( &sz, sizeof( sz ) );
         for( auto& p : ctx->notes )
         {
-          f.Write( &p.first, sizeof( p.first ) );
-          f.Write( &p.second, sizeof( p.second ) );
+            f.Write( &p.first, sizeof( p.first ) );
+            f.Write( &p.second, sizeof( p.second ) );
         }
         sz = ctx->threadData.size();
         f.Write( &sz, sizeof( sz ) );
@@ -8568,10 +8569,10 @@ void Worker::WriteTimelineImpl( FileWrite& f, const V& vec, int64_t& refTime, in
 
         WriteTimeOffset( f, refTime, v.CpuEnd() );
         WriteTimeOffset( f, refGpuTime, v.GpuEnd() );
-        f.Write( &v.query_id , sizeof(v.query_id) );
-        f.Write( &v.note_count , sizeof(v.note_count) );
-        f.Write( &v.note_ids , sizeof(v.note_ids) );
-        f.Write( &v.note_vals , sizeof(v.note_vals) );
+        f.Write( &v.query_id, sizeof( v.query_id ) );
+        f.Write( &v.note_count, sizeof( v.note_count ) );
+        f.Write( &v.note_ids, sizeof( v.note_ids ) );
+        f.Write( &v.note_vals, sizeof( v.note_vals ) );
     }
 }
 

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -6044,9 +6044,15 @@ void Worker::ProcessGpuZoneAnnotation( const QueueGpuZoneAnnotation& ev )
     // TODO: Get thread ID properly
     // TODO: Search for the query from the back
     assert( ctx->threadData.size() );
-    assert( ctx->threadData.begin()->second.timeline.size() );
-    auto & zone = ctx->threadData.begin()->second.timeline.back();
-    assert( zone->query_id == ev.queryId );
+    auto & timeline = ctx->threadData.begin()->second.timeline;
+    assert( timeline.size() );
+    ssize_t i = timeline.size() - 1;
+    for ( ; i >= 0 ; i--) {
+      if( timeline[i]->query_id == ev.queryId ) {
+        break;
+      }
+    }
+    auto& zone = timeline[i];
     assert( zone->note_count < 10 );
     zone->note_ids[zone->note_count] = ev.noteId;
     zone->note_vals[zone->note_count] = ev.value;

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -6045,9 +6045,8 @@ void Worker::ProcessGpuZoneAnnotation( const QueueGpuZoneAnnotation& ev )
 {
     auto ctx = m_gpuCtxMap[ev.context];
     assert( ctx );
-    // TODO: Get thread ID properly
-    assert( ctx->threadData.size() );
-    auto& timeline = ctx->threadData.begin()->second.timeline;
+    assert( ctx->threadData.contains( ev.thread ) );
+    auto& timeline = ctx->threadData.at( ev.thread ).timeline;
     assert( timeline.size() );
     ssize_t i = timeline.size() - 1;
     for( ; i >= 0; i-- )

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -740,6 +740,7 @@ private:
     tracy_force_inline void ProcessGpuCalibration( const QueueGpuCalibration& ev );
     tracy_force_inline void ProcessGpuTimeSync( const QueueGpuTimeSync& ev );
     tracy_force_inline void ProcessGpuContextName( const QueueGpuContextName& ev );
+    tracy_force_inline void ProcessGpuAnnotationName( const QueueGpuAnnotationName& ev );
     tracy_force_inline void ProcessGpuZoneAnnotation( const QueueGpuZoneAnnotation& ev );
     tracy_force_inline MemEvent* ProcessMemAlloc( const QueueMemAlloc& ev );
     tracy_force_inline MemEvent* ProcessMemAllocNamed( const QueueMemAlloc& ev );

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -740,6 +740,7 @@ private:
     tracy_force_inline void ProcessGpuCalibration( const QueueGpuCalibration& ev );
     tracy_force_inline void ProcessGpuTimeSync( const QueueGpuTimeSync& ev );
     tracy_force_inline void ProcessGpuContextName( const QueueGpuContextName& ev );
+    tracy_force_inline void ProcessGpuZoneAnnotation( const QueueGpuZoneAnnotation& ev );
     tracy_force_inline MemEvent* ProcessMemAlloc( const QueueMemAlloc& ev );
     tracy_force_inline MemEvent* ProcessMemAllocNamed( const QueueMemAlloc& ev );
     tracy_force_inline MemEvent* ProcessMemFree( const QueueMemFree& ev );


### PR DESCRIPTION
This uses (rocprofiler-sdk)[https://github.com/ROCm/rocprofiler-sdk] to collect the dispatch times and GPU performance counters. I had to use a potentially expensive method to attach the counter values to zones, and would like some feedback on the approach that is taken here.