### PR TITLE
Fix embed dependency

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -49,7 +49,7 @@ function(Embed LIST NAME FILE)
     add_custom_command(
         OUTPUT data/${NAME}.cpp data/${NAME}.hpp
         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/embed ${NAME} ${CMAKE_CURRENT_LIST_DIR}/${FILE} data/${NAME}
-        DEPENDS data ${CMAKE_CURRENT_BINARY_DIR}/embed ${CMAKE_CURRENT_LIST_DIR}/${FILE}
+        DEPENDS data embed ${CMAKE_CURRENT_LIST_DIR}/${FILE}
     )
     list(APPEND ${LIST} data/${NAME}.cpp)
     return(PROPAGATE ${LIST})


### PR DESCRIPTION
`add_custom_command` DEPENDS can only see the output of other commands or targets names, not the targets installation through `ExternalProject_Add`. Add the `embed` target (created by `ExternalProject_Add`) as a dependency for commands using the utility