### PR TITLE
[Draft] Making callstack symbol queries faster by deprioritizing external name queries

### DIFF
--- a/profiler/src/profiler/TracyView_NotificationArea.cpp
+++ b/profiler/src/profiler/TracyView_NotificationArea.cpp
@@ -48,6 +48,21 @@ void View::DrawNotificationArea()
             {
                 ImGui::BeginTooltip();
                 TextFocused( "Query backlog:", RealToString( sqs ) );
+                #define ShowTooltipText(metric) TextFocused(#metric":", RealToString(m_worker.metric));
+                ShowTooltipText(m_pendingCallstackFrames);
+                ShowTooltipText(m_data.callstackFrameMap.size());
+                ShowTooltipText(m_pendingCallstackSubframes);
+                ShowTooltipText(m_pendingExternalNames);
+                ShowTooltipText(m_pendingFibers);
+                ShowTooltipText(m_pendingFileStrings.size());
+                ShowTooltipText(m_pendingSourceLocation);
+                ShowTooltipText(m_pendingSourceLocationPayload);
+                ShowTooltipText(m_pendingStrings);
+                ShowTooltipText(m_pendingSymbolCode);
+                ShowTooltipText(m_pendingSymbols.size());
+                ShowTooltipText(m_pendingThreadHints.size());
+                ShowTooltipText(m_pendingThreads);
+                #undef ShowTooltipText
                 ImGui::EndTooltip();
             }
         }

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -1006,6 +1006,7 @@ private:
     bool m_inconsistentSamples;
     bool m_allowStringModification = false;
 
+public:
     short_ptr<GpuCtxData> m_gpuCtxMap[256];
     uint32_t m_pendingCallstackId = 0;
     int16_t m_pendingSourceLocationPayload = 0;


### PR DESCRIPTION
Currently, `SymbolQueueItemType::ExternalName` queries are quite lengthy to process, and when they bundle up in the request queue, they can delay responding to other symbol queries considerably.
Given that external name queries (i.e., name of threads belonging to other processes) are generally not as relevant to the profiling session, it makes sense to defer their processing and to respond to more relevant queries first.