### PR TITLE
Allow to limit zone depth

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3458,6 +3458,14 @@ You will find the zones with locks and their associated threads on this combined
 
 \draw(7.5, -0.5) rectangle+(6.5, -0.5) node[midway] {Render};
 
+
+\draw[densely dotted,ultra thick,,color=lightgray] (0.11, -0.25) -- (0.11, -1.75);
+\draw(0.11, -0.25) node[circle,draw,fill,color=lightgray,inner sep=0pt,minimum size=3.5] {};
+\draw(0.11, -0.75) node[circle,draw,fill,color=lightgray,inner sep=0pt,minimum size=3.5] {};
+\draw(0.11, -1.25) node[circle,draw,fill,color=lightgray,inner sep=0pt,minimum size=3.5] {};
+\draw(0.11, -1.75) node[circle,draw,fill,color=lightgray,inner sep=0pt,minimum size=3.5] {};
+
+
 \draw(0, -2.5) node[anchor=north west] {Physics lock};
 \draw[pattern=crosshatch dots] (3.1, -2.5) rectangle+(2.5, -0.5);
 
@@ -3496,6 +3504,8 @@ Labels accompanied by the \faCaretDown{}~symbol can be collapsed out of the view
 \begin{itemize}
 \item \emph{\faEyeSlash{}~Hide} -- Hides the label along with the content associated to it. To make the label visible again, you must find it in the options menu (section~\ref{options}).
 \end{itemize}
+
+Under the \faCaretDown{}~symbol are a series of points that allow to limit the depth of the zones displayed. Hover the~\faMousePointer{}~mouse pointer over a circle to display a line visualizing the cutting point, then click the \MMB{}~middle mouse button to apply or remove a zone depth limit.
 
 \subparagraph{Zones}
 

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -244,7 +244,7 @@ private:
     void DrawTimelineFrames( const FrameData& frames );
     void DrawTimeline();
     void DrawSampleList( const TimelineContext& ctx, const std::vector<SamplesDraw>& drawList, const Vector<SampleData>& vec, int offset );
-    void DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineDraw>& drawList, int offset, uint64_t tid, const int maxDepth, const double margin );
+    void DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineDraw>& drawList, int offset, uint64_t tid, int maxDepth, double margin );
     int DrawThreadCropper( const int depth, const uint64_t tid, const float xPos, const float yPos, const float ostep, const float radius, const float margin, const bool hasCtxSwitches );
     void DrawContextSwitchList( const TimelineContext& ctx, const std::vector<ContextSwitchDraw>& drawList, const Vector<ContextSwitchData>& ctxSwitch, int offset, int endOffset, bool isFiber );
     int DispatchGpuZoneLevel( const Vector<short_ptr<GpuEvent>>& vec, bool hover, double pxns, int64_t nspx, const ImVec2& wpos, int offset, int depth, uint64_t thread, float yMin, float yMax, int64_t begin, int drift );

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -244,7 +244,8 @@ private:
     void DrawTimelineFrames( const FrameData& frames );
     void DrawTimeline();
     void DrawSampleList( const TimelineContext& ctx, const std::vector<SamplesDraw>& drawList, const Vector<SampleData>& vec, int offset );
-    void DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineDraw>& drawList, int offset, uint64_t tid );
+    void DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineDraw>& drawList, int offset, uint64_t tid, const int maxDepth, const double margin );
+    int DrawThreadCropper( const int depth, const uint64_t tid, const float yPos, const float ostep, const float radius, const float margin, const bool hasCtxSwitches );
     void DrawContextSwitchList( const TimelineContext& ctx, const std::vector<ContextSwitchDraw>& drawList, const Vector<ContextSwitchData>& ctxSwitch, int offset, int endOffset, bool isFiber );
     int DispatchGpuZoneLevel( const Vector<short_ptr<GpuEvent>>& vec, bool hover, double pxns, int64_t nspx, const ImVec2& wpos, int offset, int depth, uint64_t thread, float yMin, float yMax, int64_t begin, int drift );
     template<typename Adapter, typename V>
@@ -392,6 +393,7 @@ private:
     void Attention( bool& alreadyDone );
     void UpdateTitle();
 
+    unordered_flat_map<uint64_t, int> m_threadMaxDisplayDepth;
     unordered_flat_map<uint64_t, bool> m_visibleMsgThread;
     unordered_flat_map<uint64_t, bool> m_waitStackThread;
     unordered_flat_map<uint64_t, bool> m_flameGraphThread;

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -245,7 +245,7 @@ private:
     void DrawTimeline();
     void DrawSampleList( const TimelineContext& ctx, const std::vector<SamplesDraw>& drawList, const Vector<SampleData>& vec, int offset );
     void DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineDraw>& drawList, int offset, uint64_t tid, const int maxDepth, const double margin );
-    int DrawThreadCropper( const int depth, const uint64_t tid, const float yPos, const float ostep, const float radius, const float margin, const bool hasCtxSwitches );
+    int DrawThreadCropper( const int depth, const uint64_t tid, const float xPos, const float yPos, const float ostep, const float radius, const float margin, const bool hasCtxSwitches );
     void DrawContextSwitchList( const TimelineContext& ctx, const std::vector<ContextSwitchDraw>& drawList, const Vector<ContextSwitchData>& ctxSwitch, int offset, int endOffset, bool isFiber );
     int DispatchGpuZoneLevel( const Vector<short_ptr<GpuEvent>>& vec, bool hover, double pxns, int64_t nspx, const ImVec2& wpos, int offset, int depth, uint64_t thread, float yMin, float yMax, int64_t begin, int drift );
     template<typename Adapter, typename V>
@@ -393,7 +393,7 @@ private:
     void Attention( bool& alreadyDone );
     void UpdateTitle();
 
-    unordered_flat_map<uint64_t, int> m_threadMaxDisplayDepth;
+    unordered_flat_map<uint64_t, int> m_threadDepthLimit;
     unordered_flat_map<uint64_t, bool> m_visibleMsgThread;
     unordered_flat_map<uint64_t, bool> m_waitStackThread;
     unordered_flat_map<uint64_t, bool> m_flameGraphThread;

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -56,12 +56,12 @@ void View::DrawThread( const TimelineContext& ctx, const ThreadData& thread, con
     }
 
     const auto yPos = wpos.y + offset;
-    const float cropperWidth = ImGui::CalcTextSize(ICON_FA_CARET_DOWN).x;
-    const float cropperCircleRadius = (cropperWidth - 2.0f * GetScale() ) / 2.0f ;
+    const float cropperWidth = ImGui::CalcTextSize( ICON_FA_CARET_DOWN ).x;
+    const float cropperCircleRadius = ( cropperWidth - 2.0f * GetScale() ) / 2.0f ;
     const float cropperAdditionalMargin = cropperWidth + wpos.x; // We add the left window margin for symmetry
     
     // Display cropper if currently limited or if hovering the cropper area
-    const auto threadDepthLimitIt = m_threadDepthLimit.find(thread.id);
+    const auto threadDepthLimitIt = m_threadDepthLimit.find( thread.id );
     const bool displayCropper = ( threadDepthLimitIt != m_threadDepthLimit.end() && threadDepthLimitIt->second <= depth )
         || ( ImGui::GetMousePos().x < wpos.x + cropperAdditionalMargin );
 
@@ -663,7 +663,7 @@ int View::DrawThreadCropper( const int depth, const uint64_t tid, const float xP
     int lane = hasCtxSwitches ? -1 : 0;
     for( ; lane < depthLimit; lane++ )
     {
-        const ImVec2 center = ImVec2(cropperCenterX, CircleCenterYForLine( lane ) );
+        const ImVec2 center = ImVec2( cropperCenterX, CircleCenterYForLine( lane ) );
         const float hradius = radius + 2.0f * GetScale();
         const float dx = mousePos.x - center.x;
         const float dy = mousePos.y - center.y;

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -675,7 +675,7 @@ int View::DrawThreadCropper( const int depth, const uint64_t tid, const float xP
             if( clicked )
             {
                 const int newDepthLimit = lane + 1;
-                if( depthLimit == newDepthLimit )
+                if( isCropped && depthLimit == newDepthLimit )
                 {
                     m_threadDepthLimit.erase( tid );
                 }

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -62,9 +62,10 @@ void View::DrawThread( const TimelineContext& ctx, const ThreadData& thread, con
     
     // Display cropper if currently limited or if hovering the cropper area
     const auto threadDepthLimitIt = m_threadDepthLimit.find( thread.id );
-    const bool displayCropper = ( threadDepthLimitIt != m_threadDepthLimit.end() && threadDepthLimitIt->second <= depth )
-        || ( ImGui::GetMousePos().x < wpos.x + cropperAdditionalMargin );
-
+    const bool croppingActive = ( threadDepthLimitIt != m_threadDepthLimit.end() && threadDepthLimitIt->second <= depth );
+    const bool mouseInCropperDisplayZone = ImGui::GetMousePos().x >= 0 && ImGui::GetMousePos().x < wpos.x + cropperAdditionalMargin && ImGui::GetMousePos().y > ctx.yMin && ImGui::GetMousePos().y < ctx.yMax;
+    
+    const bool displayCropper = croppingActive || mouseInCropperDisplayZone;
     if( displayCropper )
     {
         if(depth > 0) depth = DrawThreadCropper( depth, thread.id, wpos.x, yPos, ostep, cropperCircleRadius, cropperWidth, hasCtxSwitch );
@@ -74,7 +75,8 @@ void View::DrawThread( const TimelineContext& ctx, const ThreadData& thread, con
     }
     if( !draw.empty() && yPos <= yMax && yPos + ostep * depth >= yMin )
     {
-        DrawZoneList( ctx, draw, offset, thread.id, depth, displayCropper ? cropperAdditionalMargin + GetScale() /* Ensure text has a bit of space for text */ : 0.f );
+        // Only apply margin when croppingActive to avoid text moving around when mouse is getting close to the cropper widget
+        DrawZoneList( ctx, draw, offset, thread.id, depth, croppingActive ? cropperAdditionalMargin + GetScale() /* Ensure text has a bit of space for text */ : 0.f );
     }
     offset += ostep * depth;
 

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -645,12 +645,14 @@ int View::DrawThreadCropper( const int depth, const uint64_t tid, const float xP
         return yPos + ostep * ( lane + 0.5 );
         };
 
+    const uint32_t inactiveColor = 0xFF555555;
+
     // If cropped, we want the line to continue as a hint if something is hidden, hence why no -1 for depthLimit
     const float lineEndY = std::min<int>( isCropped ? depthLimit : depth - 1, depth - 1);
     DrawLine(draw,
         ImVec2( cropperCenterX, CircleCenterYForLine( hasCtxSwitches ? -1 : 0 ) ),
         ImVec2( cropperCenterX, CircleCenterYForLine( lineEndY ) ),
-        0xFF666666, 2.0f * GetScale()
+        inactiveColor, 2.0f * GetScale()
     );
 
     // Allow to crop all the zones if we have context switches displayed
@@ -679,10 +681,10 @@ int View::DrawThreadCropper( const int depth, const uint64_t tid, const float xP
                 }
             }
         }
-        ImU32 color = 0xFF666666;
+        ImU32 color = inactiveColor;
         if( isCropped && lane == depthLimit - 1 )
         {
-            color = 0xFFFFFFFF;
+            color = 0xFF888888;
         }
         draw->AddCircleFilled( center, radius, color );
     }

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -614,9 +614,9 @@ int View::DrawThreadCropper( const int depth, const uint64_t tid, const float xP
 
     const float cropperCenterX = xPos + cropperWidth / 2.0;
     
-    const auto CircleCenterYForLine = [=]( int lane ) {
+    const auto CircleCenterYForLine = [=]( int lane ){
         return yPos + ostep * ( lane + 0.5 );
-        };
+    };
 
     const uint32_t inactiveColor = 0xFF555555;
 

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -57,18 +57,18 @@ void View::DrawThread( const TimelineContext& ctx, const ThreadData& thread, con
 
     const auto yPos = wpos.y + offset;
     const float cropperWidth = ImGui::CalcTextSize(ICON_FA_CARET_DOWN).x;
-    const float radius = (cropperWidth - 2.0f * GetScale() ) / 2.0f ;
-    const float margin = wpos.x + cropperWidth;
+    const float cropperCircleRadius = (cropperWidth - 2.0f * GetScale() ) / 2.0f ;
+    const float cropperAdditionalMargin = cropperWidth + wpos.x; // We add the left window margin for symmetry
     
     if( depth > 0 )
     {
-        depth = DrawThreadCropper( depth, thread.id, wpos.x, yPos, ostep, radius, cropperWidth, hasCtxSwitch );
+        depth = DrawThreadCropper( depth, thread.id, wpos.x, yPos, ostep, cropperCircleRadius, cropperWidth, hasCtxSwitch );
     }
     const auto* drawList = ImGui::GetWindowDrawList();
-    ImGui::PushClipRect( drawList->GetClipRectMin() + ImVec2( margin, 0 ), drawList->GetClipRectMax(), true );
+    ImGui::PushClipRect( drawList->GetClipRectMin() + ImVec2( cropperAdditionalMargin, 0 ), drawList->GetClipRectMax(), true );
     if( !draw.empty() && yPos <= yMax && yPos + ostep * depth >= yMin )
     {
-        DrawZoneList( ctx, draw, offset, thread.id, depth, margin );
+        DrawZoneList( ctx, draw, offset, thread.id, depth, cropperAdditionalMargin + GetScale() /* Ensure text has a bit of space for text */ );
     }
     offset += ostep * depth;
 
@@ -218,7 +218,7 @@ void View::DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineD
 {
     auto draw = ImGui::GetWindowDrawList();
     const auto w = ctx.w;
-    const auto& wpos = ctx.wpos;
+    const auto wpos = ctx.wpos + ImVec2( margin, 0.f );
     const auto dpos = wpos + ImVec2( 0.5f, 0.5f );
     const auto ty = ctx.ty;
     const auto ostep = ty + 1;

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -54,13 +54,12 @@ void View::DrawThread( const TimelineContext& ctx, const ThreadData& thread, con
     }
 
     const auto yPos = wpos.y + offset;
-    const float marginLeft = 5.5f;
-    const float radius = 4.5f *  GetScale();
-    const float margin = 2 * radius + marginLeft + 3.0f * GetScale();
+    const float radius = 4.0f * GetScale();
+    const float margin = wpos.x + 2.0f * radius + 3.0f * GetScale();
     
     if( depth > 0 )
     {
-        depth = DrawThreadCropper( depth, thread.id, yPos, ostep, radius, marginLeft, hasCtxSwitch );
+        depth = DrawThreadCropper( depth, thread.id, yPos, ostep, radius, wpos.x, hasCtxSwitch );
     }
     const auto* drawList = ImGui::GetWindowDrawList();
     ImGui::PushClipRect( drawList->GetClipRectMin() + ImVec2( margin, 0 ), drawList->GetClipRectMax(), true );
@@ -633,6 +632,8 @@ int View::DrawThreadCropper( const int depth, const uint64_t tid, const float yP
     ImVec2 mouse = ImGui::GetMousePos();
     const bool clicked = ImGui::IsMouseClicked( 0 );
     auto draw = ImGui::GetWindowDrawList();
+    draw->Flags &= ~ImDrawListFlags_AntiAliasedLines;
+    draw->Flags &= ~ImDrawListFlags_AntiAliasedFill;
     auto foreground = ImGui::GetForegroundDrawList();
     auto window = ImGui::GetWindowSize();
     bool isCropped = ( m_threadMaxDisplayDepth.find( tid ) != m_threadMaxDisplayDepth.end() );


### PR DESCRIPTION
This PR introduces a new feature that allows users to crop the timeline on a per-thread basis, improving focus and readability when analyzing a thread with many sub-zones.

- Interactive crop toggles: Small round handles are displayed per thread on the left side of the timeline.
- Hovering over a handle displays a red guideline indicating where the crop will begin.
- Clicking a handle highlights it in white and crops the visible timeline to that thread's active zone.
- Clicking again removes the crop, restoring the full view.

This helps reduce visual clutter and makes it easier to focus on deeply nested or dense thread activity.

https://github.com/user-attachments/assets/620f3d77-3da6-461e-9246-8b0a38b76ec8