### PR TITLE
Refine .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,18 +1,35 @@
 # Empirical format config, based on observed style guide
 # Use this only as an help to fit the surrounding code style - don't reformat whole files at once
 ---
-BasedOnStyle: LLVM
-AllowShortIfStatementsOnASingleLine: WithoutElse
+BasedOnStyle: Microsoft
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
 AllowShortLoopsOnASingleLine: true
-AlwaysBreakTemplateDeclarations: Yes
-BreakBeforeBraces: Allman
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+# AllowShortEnumsOnASingleLine: true # Broken for some reason, even in last versions of clang-format... So don't use it or it may change formating in the future.
+AllowShortLambdasOnASingleLine: All
 BreakConstructorInitializers: BeforeComma
 BreakStringLiterals: false
-ColumnLimit: 120
+SpaceAfterTemplateKeyword: false
+AlwaysBreakTemplateDeclarations: Yes
+# Allman seems to break lambda formatting for some reason with `ColumnLimit: 0`. See https://github.com/llvm/llvm-project/issues/50275
+# Even though it is supposed to have been fixed, issue still remains in 20.1.8. (and is very much present in 18.x which is the one shipped by VS2022 and VSCord clangd as of 2025-07-27)
+# Things work fine with `BasedOnStyle: Microsoft` so use that instead
+#BreakBeforeBraces: Allman 
+ColumnLimit: 0
+# We'd like to use LeftWithLastLine but it's only available in >=19.x
+#AlignEscapedNewlines: LeftWithLastLine
+AlignEscapedNewlines: Left
 FixNamespaceComments: false
 IndentPPDirectives: AfterHash
+IndentAccessModifiers: false
+AccessModifierOffset: -4
+LambdaBodyIndentation: OuterScope
+PPIndentWidth: 2
 IndentWidth: 4
 PointerAlignment: Left
 SpaceBeforeParens: Never
 SpacesInParentheses: true
 TabWidth: 4
+AlignTrailingComments:
+  Kind: Leave


### PR DESCRIPTION
I tried to refine a bit the `.clang-format` file that was introduced in https://github.com/wolfpld/tracy/pull/835 .

There were and still are a few issues:

> Known caveats:
    - could not manage to keep small enum on a single line

This is still broken, the tool has bugs

    - you put 2 spaces in ifdefs (instead of the 4 elsewhere), haven't managed to replicate it

Fixed

    - it's not possible to remove the spaces around binary operators 

Still not possible.

---

I also fixed a few other things such as lambdas, spaces with templates, ...

---

I uploaded a branch with the files fully formatted with this new file here: https://github.com/wolfpld/tracy/commit/6ef555881dc2d1760448766b03f7d092cd7aff08

Things that I noticed and still aren't really good:

- short enum are still not working (even if not commented in config)
  - https://github.com/wolfpld/tracy/commit/6ef555881dc2d1760448766b03f7d092cd7aff08#diff-1405072143d8fb79c9a359bd0374a286b3c7a7660f493348da6c60acbd616065L25
- Spaces around operators (and assignment ones in `for` loops) 
  - https://github.com/wolfpld/tracy/commit/6ef555881dc2d1760448766b03f7d092cd7aff08#diff-ab3c1a0fb45194251b86d26ec68f78a4ec7a76a733858ef89927461a6fe7cb63R1345
- Arrays do not break before braces 
  - https://github.com/wolfpld/tracy/commit/6ef555881dc2d1760448766b03f7d092cd7aff08#diff-ab3c1a0fb45194251b86d26ec68f78a4ec7a76a733858ef89927461a6fe7cb63R708-R709
- Spaces in parens where we do not really expect them (function signatures, operator priority disambiguation, ...) 
  - https://github.com/wolfpld/tracy/commit/6ef555881dc2d1760448766b03f7d092cd7aff08#diff-1405072143d8fb79c9a359bd0374a286b3c7a7660f493348da6c60acbd616065L25
  - https://github.com/wolfpld/tracy/commit/6ef555881dc2d1760448766b03f7d092cd7aff08#diff-1405072143d8fb79c9a359bd0374a286b3c7a7660f493348da6c60acbd616065L25
- Preprocessor indentation may look weird (though correct) when whole files are hidden behind a big `#if`
  - https://github.com/wolfpld/tracy/commit/6ef555881dc2d1760448766b03f7d092cd7aff08#diff-1405072143d8fb79c9a359bd0374a286b3c7a7660f493348da6c60acbd616065L25
  - This can in some cases be limited a bit for example by removing unneeded `#if` https://github.com/wolfpld/tracy/commit/6ef555881dc2d1760448766b03f7d092cd7aff08#diff-0050b814bc7135be0784c57ca198df3787ff137d2bbcdc929048032fdd426464L1
  - This may not be desirable, especially in the public headers https://github.com/wolfpld/tracy/blob/6ef555881dc2d1760448766b03f7d092cd7aff08/public/tracy/TracyOpenGL.hpp#L52-L77
- Reorders includes, which may be problematic

Overall, while the output diff is big, there seem to be a lot of valid formatting fixes.
Would it be possible to consider applying (progressively) clang-format on whole files from the `profiler` and `public/common` folders?
Note that it is possible to disable formatting locally using `// clang-format off`/`// clang-format on`

The reason I ask this is that (imho), even though the formatting doesn't always look great, it would be very helpful to be able to format the whole document as some editors do not support partial formatting (as mentioned in https://github.com/wolfpld/tracy/issues/958). Worse VS20XX does pick and apply `.clang-format` by default on the whole file. (It can be disabled but then you lose the ability to format using the `clang-format`).

This would make the onboarding easier (and perhaps a bit less formatting errors in PRs, of which I'm very much guilty, sorry.) 

Thoughts ? (We can shift this discussion to an issue if you prefer, as it is a bit orthogonal to the changes applied to the config file here)
