### PR TITLE
Add p99 and p99.9 stats

### DIFF
--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -682,7 +682,7 @@ private:
         size_t sortedNum = 0, selSortNum, selSortActive;
         float average, selAverage;
         float median, selMedian;
-        float p75, p90;
+        float p75, p90, p99, p99_9;
         int64_t total, selTotal;
         int64_t selTime;
         bool drawAvgMed = true;
@@ -728,6 +728,8 @@ private:
             median = 0;
             p75 = 0;
             p90 = 0;
+            p99 = 0;
+            p99_9 = 0;
             total = 0;
             tmin = std::numeric_limits<int64_t>::max();
             tmax = std::numeric_limits<int64_t>::min();

--- a/profiler/src/profiler/TracyView_FindZone.cpp
+++ b/profiler/src/profiler/TracyView_FindZone.cpp
@@ -557,6 +557,8 @@ void View::DrawFindZone()
                     m_findZone.median = vec[vsz/2];
                     m_findZone.p75 = vec[3 * (vsz / 4)];
                     m_findZone.p90 = vec[vsz / 10 * 9];
+                    m_findZone.p99 = vec[size_t(float(vsz * 0.99))];
+                    m_findZone.p99_9 = vec[size_t(float(vsz * 0.999))];
                     m_findZone.total = total;
                     m_findZone.sortedNum = i;
                     m_findZone.tmin = tmin;
@@ -982,6 +984,14 @@ void View::DrawFindZone()
                         ImGui::Spacing();
                         ImGui::SameLine();
                         TextFocused( "P90:", TimeToString( m_findZone.p90 ) );
+                        ImGui::SameLine();
+                        ImGui::Spacing();
+                        ImGui::SameLine();
+                        TextFocused( "P99:", TimeToString( m_findZone.p99 ) );
+                        ImGui::SameLine();
+                        ImGui::Spacing();
+                        ImGui::SameLine();
+                        TextFocused( "P99.9:", TimeToString( m_findZone.p99_9 ) );
                         ImGui::SameLine();
                         ImGui::Spacing();
                         ImGui::SameLine();


### PR DESCRIPTION
Adds 99th and 99.9th percentiles to the statistics view. These metrics can be quite useful to detect stutters in e.g. a rendering engine. 