### PR TITLE
Fix clipboard button and add code preview in Zone Info

### DIFF
--- a/profiler/src/profiler/TracyImGui.hpp
+++ b/profiler/src/profiler/TracyImGui.hpp
@@ -240,6 +240,15 @@ static constexpr const uint32_t AsmSyntaxColors[] = {
     return res;
 }
 
+[[maybe_unused]] static inline void TextFocusedClipboard( const char* label, const char* value, const char* clipboard, const int clipboardButtonId )
+{
+    TextDisabledUnformatted( label );
+    ImGui::SameLine();
+    if( ClipboardButton( clipboardButtonId ) ) ImGui::SetClipboardText( value );
+    ImGui::SameLine();
+    ImGui::TextUnformatted( clipboard );
+}
+
 [[maybe_unused]] static tracy_force_inline void DrawLine( ImDrawList* draw, const ImVec2& v1, const ImVec2& v2, uint32_t col, float thickness = 1.0f )
 {
     const ImVec2 data[2] = { v1, v2 };

--- a/profiler/src/profiler/TracyView_ZoneInfo.cpp
+++ b/profiler/src/profiler/TracyView_ZoneInfo.cpp
@@ -410,31 +410,26 @@ void View::DrawZoneInfoWindow()
         else if( srcloc.name.active )
         {
             ImGui::PushFont( g_fonts.normal, FontBig );
-            TextFocused( "Zone name:", m_worker.GetString( srcloc.name ) );
+            TextFocusedClipboard( "Zone name:", m_worker.GetString( srcloc.name ), m_worker.GetString( srcloc.name ), 1 );
             ImGui::PopFont();
-            ImGui::SameLine();
-            if( ClipboardButton( 1 ) ) ImGui::SetClipboardText( m_worker.GetString( srcloc.name ) );
-            TextFocused( "Function:", m_worker.GetString( srcloc.function ) );
-            ImGui::SameLine();
-            if( ClipboardButton( 2 ) ) ImGui::SetClipboardText( m_worker.GetString( srcloc.function ) );
+            TextFocusedClipboard( "Function:", m_worker.GetString( srcloc.function ), m_worker.GetString( srcloc.function ), 2 );
         }
         else
         {
             ImGui::PushFont( g_fonts.normal, FontBig );
-            TextFocused( "Function:", m_worker.GetString( srcloc.function ) );
+            TextFocusedClipboard( "Function:", m_worker.GetString( srcloc.function ), m_worker.GetString( srcloc.function ), 1 );
             ImGui::PopFont();
-            ImGui::SameLine();
-            if( ClipboardButton( 1 ) ) ImGui::SetClipboardText( m_worker.GetString( srcloc.function ) );
         }
         SmallColorBox( GetSrcLocColor( m_worker.GetSourceLocation( ev.SrcLoc() ), 0 ) );
         ImGui::SameLine();
-        TextDisabledUnformatted( "Location:" );
-        ImGui::SameLine();
-        ImGui::TextUnformatted( LocationToString( m_worker.GetString( srcloc.file ), srcloc.line ) );
-        ImGui::SameLine();
-        if( ClipboardButton( 3 ) )
+        TextFocusedClipboard( "Location:", LocationToString( fileName, srcloc.line ), LocationToString( m_worker.GetString( srcloc.file ), srcloc.line ), 3 );
+        if( ImGui::IsItemHovered() )
         {
-            ImGui::SetClipboardText( LocationToString( m_worker.GetString( srcloc.file ), srcloc.line ) );
+            DrawSourceTooltip( fileName, srcloc.line );
+            if( ImGui::IsItemClicked( ImGuiMouseButton_Right ) && SourceFileValid( fileName, m_worker.GetCaptureTime(), *this, m_worker ) )
+            {
+                ViewSourceCheckKeyMod( fileName, srcloc.line, m_worker.GetString( srcloc.function ) );
+            }
         }
         SmallColorBox( GetThreadColor( tid, 0 ) );
         ImGui::SameLine();
@@ -1514,23 +1509,11 @@ void View::DrawGpuInfoWindow()
 
         const auto tid = GetZoneThread( ev );
         ImGui::PushFont( g_fonts.normal, FontBig );
-        TextFocused( "Zone name:", m_worker.GetString( srcloc.name ) );
+        TextFocusedClipboard( "Zone name:", m_worker.GetString( srcloc.name ), m_worker.GetString( srcloc.name ), 1 );
+        ImGui::SameLine();
         ImGui::PopFont();
-        ImGui::SameLine();
-        if( ClipboardButton( 1 ) ) ImGui::SetClipboardText( m_worker.GetString( srcloc.name ) );
-        TextFocused( "Function:", m_worker.GetString( srcloc.function ) );
-        ImGui::SameLine();
-        if( ClipboardButton( 2 ) ) ImGui::SetClipboardText( m_worker.GetString( srcloc.function ) );
-        SmallColorBox( GetZoneColor( ev ) );
-        ImGui::SameLine();
-        TextDisabledUnformatted( "Location:" );
-        ImGui::SameLine();
-        ImGui::TextUnformatted( LocationToString( m_worker.GetString( srcloc.file ), srcloc.line ) );
-        ImGui::SameLine();
-        if( ClipboardButton( 3 ) )
-        {
-            ImGui::SetClipboardText( LocationToString( m_worker.GetString( srcloc.file ), srcloc.line ) );
-        }
+        TextFocusedClipboard( "Function:", m_worker.GetString( srcloc.function ), m_worker.GetString( srcloc.function ), 2 );
+        TextFocusedClipboard( "Location:", LocationToString( m_worker.GetString( srcloc.file ), srcloc.line ), LocationToString( m_worker.GetString( srcloc.file ), srcloc.line ), 3 );
         SmallColorBox( GetThreadColor( tid, 0 ) );
         ImGui::SameLine();
         TextFocused( "Thread:", m_worker.GetThreadName( tid ) );


### PR DESCRIPTION
(Opening this PR on behalf of @MrAntoine77)

---

This PR improves the usability of the ZoneInfo component:

- Moved the clipboard copy button to the left of the text 
  - It would be problematic with long file paths as it would be out of the ZoneInfo window (or if the window is narrow)
  - no more need to move the mouse all the way to the right to copy the content.
- Added code preview on right-click of the zone path, similar to the behavior in FindZone.

These changes aim to make interaction faster and more consistent with other parts of the UI.

Before:
<img width="1087" height="154" alt="468511050-b0438915-7fc3-4447-8db0-d50259e7c55f" src="https://github.com/user-attachments/assets/01f0c010-6b6c-41d6-9c55-f406b5accd35" />


After:
<img width="826" height="159" alt="468510301-49d52cdd-eabc-4ccf-a69f-141e775c7a2c" src="https://github.com/user-attachments/assets/c47130f7-d01e-4a97-858b-65298a5d7c8e" />

<img width="1109" height="294" alt="468510328-c2d1d1ba-0c0d-4394-ba61-ab328385fc55" src="https://github.com/user-attachments/assets/799a232e-101e-41bd-8189-343b27fde7fe" />

