### PR TITLE
If we have samples in view and they are displayed, timeline should be displayed even without zones

### DIFF
--- a/profiler/src/profiler/TracyTimelineItemThread.cpp
+++ b/profiler/src/profiler/TracyTimelineItemThread.cpp
@@ -262,7 +262,7 @@ void TimelineItemThread::HeaderExtraContents( const TimelineContext& ctx, int of
 bool TimelineItemThread::DrawContents( const TimelineContext& ctx, int& offset )
 {
     m_view.DrawThread( ctx, *m_thread, m_draw, m_ctxDraw, m_samplesDraw, m_lockDraw, offset, m_depth, m_hasCtxSwitch, m_hasSamples );
-    if( m_depth == 0 && !m_hasMessages )
+    if( m_depth == 0 && !m_hasMessages && ( !m_view.GetViewData().drawSamples || !m_hasSamples ) )
     {
         auto& crash = m_worker.GetCrashEvent();
         return crash.thread == m_thread->id;


### PR DESCRIPTION
This is kind of misleading as you may think a thread is inactive but is not. It also made it hard to inspect samples that are at the beginning of a thread where a zone might not have been called yet.

## Current behavior:

https://github.com/user-attachments/assets/a5317f1e-d2e8-4eec-8131-4a2748d7e2c6

## With this PR changes:

https://github.com/user-attachments/assets/6026ce70-a260-4036-823c-797c3f23ef20

