### PR TITLE
Refactor libbacktrace usage with TRACY_USE_LIBBACKTRACE

### DIFF
--- a/public/TracyClient.cpp
+++ b/public/TracyClient.cpp
@@ -35,28 +35,8 @@
 #ifdef TRACY_ROCPROF
 #  include "client/TracyRocprof.cpp"
 #endif
-
-#if defined(TRACY_HAS_CALLSTACK)
-#  if TRACY_HAS_CALLSTACK == 2 || TRACY_HAS_CALLSTACK == 3 || TRACY_HAS_CALLSTACK == 4 || TRACY_HAS_CALLSTACK == 6
-#    include "libbacktrace/alloc.cpp"
-#    include "libbacktrace/dwarf.cpp"
-#    include "libbacktrace/fileline.cpp"
-#    include "libbacktrace/mmapio.cpp"
-#    include "libbacktrace/posix.cpp"
-#    include "libbacktrace/sort.cpp"
-#    include "libbacktrace/state.cpp"
-#    if TRACY_HAS_CALLSTACK == 4
-#      include "libbacktrace/macho.cpp"
-#    else
-#      include "libbacktrace/elf.cpp"
-#    endif
-#    include "common/TracyStackFrames.cpp"
-#  endif
-#endif
-
 #ifdef _MSC_VER
 #  pragma comment(lib, "ws2_32.lib")
-#  pragma comment(lib, "dbghelp.lib")
 #  pragma comment(lib, "advapi32.lib")
 #  pragma comment(lib, "user32.lib")
 #  pragma warning(pop)

--- a/public/client/TracyCallstack.h
+++ b/public/client/TracyCallstack.h
@@ -30,6 +30,10 @@
 #    define TRACY_HAS_CALLSTACK 6
 #  endif
 
+#if TRACY_HAS_CALLSTACK == 2 || TRACY_HAS_CALLSTACK == 3 || TRACY_HAS_CALLSTACK == 4 || TRACY_HAS_CALLSTACK == 6
+#define TRACY_USE_LIBBACKTRACE
+#endif
+
 #endif
 
 #endif


### PR DESCRIPTION
This is part of the changes we had in #1009

- Move libbacktrace `.cpp` includes to `TracyCallstack.cpp` (This makes it easier to share with the profiler for #1009 where the file will be moved to the `common` folder )
- Same thing done with the `pragma comment( lib, "dbghelp.lib" )`: since only `TracyCallstack.cpp` depends on it, it was move to this file.
- Use the define `TRACY_USE_LIBBACKTRACE` to reflect usage of libbacktrace as we may want to change the backend (#1026) or enable it on other platforms in the future (for linux binaries resolution on windows, after #1009)
