### PR TITLE
Fix selPos warning on trace worker

### DIFF
--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -1353,7 +1353,7 @@ void SysTraceWorker( void* ptr )
                 {
                     // Find the earliest event from the active buffers
                     int sel = -1;
-                    int selPos;
+                    int selPos = -1;
                     int64_t t0 = std::numeric_limits<int64_t>::max();
                     for( int i=0; i<activeNum; i++ )
                     {


### PR DESCRIPTION
Fixes a warning on selPos about it being possibly used uninitialized, so i decided to initialize it to -1 just like sel above it, hopefully its good enough of an init value