### PR TITLE
Support for new DWARF sections used in macOS Sequoia

### DIFF
--- a/public/libbacktrace/macho.cpp
+++ b/public/libbacktrace/macho.cpp
@@ -309,9 +309,9 @@ static const char * const dwarf_section_names[DEBUG_MAX] =
   "__debug_abbrev",
   "__debug_ranges",
   "__debug_str",
-  "", /* DEBUG_ADDR */
+  "__debug_addr",
   "__debug_str_offs",
-  "", /* DEBUG_LINE_STR */
+  "__debug_line_str",
   "__debug_rnglists"
 };
 


### PR DESCRIPTION
Adds support for additional DWARF sections found in recent versions of Mach-O binaries

This change matches upstream modifications in the libbacktrace repository:
https://github.com/ianlancetaylor/libbacktrace/commit/d48f84034ce3e53e501d10593710d025cb1121db