### PR TITLE
Add connection check when TRACY_ON_DEMAND for EnterFiber and LeaveFiber

### DIFF
--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -726,6 +726,9 @@ public:
 #ifdef TRACY_FIBERS
     static tracy_force_inline void EnterFiber( const char* fiber, int32_t groupHint )
     {
+#ifdef TRACY_ON_DEMAND
+        if( !GetProfiler().IsConnected() ) return;
+#endif
         TracyQueuePrepare( QueueType::FiberEnter );
         MemWrite( &item->fiberEnter.time, GetTime() );
         MemWrite( &item->fiberEnter.fiber, (uint64_t)fiber );
@@ -735,6 +738,9 @@ public:
 
     static tracy_force_inline void LeaveFiber()
     {
+#ifdef TRACY_ON_DEMAND
+        if( !GetProfiler().IsConnected() ) return;
+#endif
         TracyQueuePrepare( QueueType::FiberLeave );
         MemWrite( &item->fiberLeave.time, GetTime() );
         TracyQueueCommit( fiberLeave );


### PR DESCRIPTION
I found connection check was missing for `EnterFiber` and `LeaveFiber` function. This leads to a crash when `tracy_malloc` returns NULL because m_serialQueue grows infinitely when not connected to tracy server. 

In my program, I've got thousands of fibers per second so it grows quickly.

```C++
    tracy_no_inline void AllocMore()
    {
        const auto cap = size_t( m_end - m_ptr ) * 2;
        const auto size = size_t( m_write - m_ptr );
        T* ptr = (T*)tracy_malloc( sizeof( T ) * cap );
        memcpy( ptr, m_ptr, size * sizeof( T ) );     // crashed here because ptr was NULL
        tracy_free_fast( m_ptr );
        m_ptr = ptr;
        m_write = m_ptr + size;
        m_end = m_ptr + cap;
    }
```