### PR TITLE
Configuration of defaults.

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3795,6 +3795,9 @@ Function names in the remaining places across the UI will be normalized unless t
 
 Disabling the display of some events is especially recommended when the profiler performance drops below acceptable levels for interactive usage.
 
+It is possible to store defaults for certain settings to the global Tracy configuration file.
+This can be done using the \emph{Save defaults} button at the bottom of the window, or by manually editing this configuration file indicated in the tooltip.
+
 \subsection{Messages window}
 \label{messages}
 

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3798,6 +3798,7 @@ Disabling the display of some events is especially recommended when the profiler
 It is possible to store defaults for the settings marked with a red \emph{\textcolor{red}{*}} to the global Tracy configuration file.
 This can be done using the \emph{Save current options as defaults} button at the bottom of the window, or by manually editing this configuration file (for which the path is indicated in the tooltip).
 Next time you use Tracy, these stored default options will be used instead.
+For now, restoring the defaults can be done by deleting the configuration file.
 
 \subsection{Messages window}
 \label{messages}

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3795,8 +3795,9 @@ Function names in the remaining places across the UI will be normalized unless t
 
 Disabling the display of some events is especially recommended when the profiler performance drops below acceptable levels for interactive usage.
 
-It is possible to store defaults for settings marked with a red \emph{\textcolor{red}{*}} to the global Tracy configuration file.
-This can be done using the \emph{Save defaults} button at the bottom of the window, or by manually editing this configuration file indicated in the tooltip.
+It is possible to store defaults for the settings marked with a red \emph{\textcolor{red}{*}} to the global Tracy configuration file.
+This can be done using the \emph{Save current options as defaults} button at the bottom of the window, or by manually editing this configuration file (for which the path is indicated in the tooltip).
+Next time you use Tracy, these stored default options will be used instead.
 
 \subsection{Messages window}
 \label{messages}

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3795,7 +3795,7 @@ Function names in the remaining places across the UI will be normalized unless t
 
 Disabling the display of some events is especially recommended when the profiler performance drops below acceptable levels for interactive usage.
 
-It is possible to store defaults for certain settings to the global Tracy configuration file.
+It is possible to store defaults for settings marked with a red \emph{\textcolor{red}{*}} to the global Tracy configuration file.
 This can be done using the \emph{Save defaults} button at the bottom of the window, or by manually editing this configuration file indicated in the tooltip.
 
 \subsection{Messages window}

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3795,7 +3795,7 @@ Function names in the remaining places across the UI will be normalized unless t
 
 Disabling the display of some events is especially recommended when the profiler performance drops below acceptable levels for interactive usage.
 
-It is possible to store defaults for the settings marked with a red \emph{\textcolor{red}{*}} to the global Tracy configuration file.
+It is possible to store defaults for the settings marked with a \emph{*} to the global Tracy configuration file.
 This can be done using the \emph{Save current options as defaults} button at the bottom of the window, or by manually editing this configuration file (for which the path is indicated in the tooltip).
 Next time you use Tracy, these stored default options will be used instead.
 For now, restoring the defaults can be done by deleting the configuration file.

--- a/profiler/src/profiler/TracyConfig.cpp
+++ b/profiler/src/profiler/TracyConfig.cpp
@@ -23,6 +23,7 @@ void LoadConfig()
     if( ini_sget( ini, "core", "threadedRendering", "%d", &v ) ) s_config.threadedRendering = v;
     if( ini_sget( ini, "core", "focusLostLimit", "%d", &v ) ) s_config.focusLostLimit = v;
     if( ini_sget( ini, "timeline", "targetFps", "%d", &v ) && v >= 1 && v < 10000 ) s_config.targetFps = v;
+    if( ini_sget( ini, "timeline", "drawFrameTargets", "%d", &v ) ) s_config.drawFrameTargets = v;
     if( ini_sget( ini, "timeline", "dynamicColors", "%d", &v ) ) s_config.dynamicColors = v;
     if( ini_sget( ini, "timeline", "forceColors", "%d", &v ) ) s_config.forceColors = v;
     if( ini_sget( ini, "timeline", "ghostZones", "%d", &v ) ) s_config.ghostZones = v;
@@ -61,6 +62,7 @@ bool SaveConfig()
 
     fprintf( f, "\n[timeline]\n" );
     fprintf( f, "targetFps = %i\n", s_config.targetFps );
+    fprintf( f, "drawFrameTargets = %i\n", s_config.drawFrameTargets );
     fprintf( f, "dynamicColors = %i\n", s_config.dynamicColors );
     fprintf( f, "forceColors = %i\n", (int)s_config.forceColors );
     fprintf( f, "ghostZones = %i\n", (int)s_config.ghostZones );

--- a/profiler/src/profiler/TracyConfig.cpp
+++ b/profiler/src/profiler/TracyConfig.cpp
@@ -25,6 +25,7 @@ void LoadConfig()
     if( ini_sget( ini, "timeline", "targetFps", "%d", &v ) && v >= 1 && v < 10000 ) s_config.targetFps = v;
     if( ini_sget( ini, "timeline", "dynamicColors", "%d", &v ) ) s_config.dynamicColors = v;
     if( ini_sget( ini, "timeline", "forceColors", "%d", &v ) ) s_config.forceColors = v;
+    if( ini_sget( ini, "timeline", "ghostZones", "%d", &v ) ) s_config.ghostZones = v;
     if( ini_sget( ini, "timeline", "shortenName", "%d", &v ) ) s_config.shortenName = v;
     if( ini_sget( ini, "timeline", "horizontalScrollMultiplier", "%lf", &v1 ) && v1 > 0.0 ) s_config.horizontalScrollMultiplier = v1;
     if( ini_sget( ini, "timeline", "verticalScrollMultiplier", "%lf", &v1 ) && v1 > 0.0 ) s_config.verticalScrollMultiplier = v1;
@@ -59,6 +60,7 @@ bool SaveConfig()
     fprintf( f, "targetFps = %i\n", s_config.targetFps );
     fprintf( f, "dynamicColors = %i\n", s_config.dynamicColors );
     fprintf( f, "forceColors = %i\n", (int)s_config.forceColors );
+    fprintf( f, "ghostZones = %i\n", (int)s_config.ghostZones );
     fprintf( f, "shortenName = %i\n", s_config.shortenName );
     fprintf( f, "horizontalScrollMultiplier = %lf\n", s_config.horizontalScrollMultiplier );
     fprintf( f, "verticalScrollMultiplier = %lf\n", s_config.verticalScrollMultiplier );

--- a/profiler/src/profiler/TracyConfig.cpp
+++ b/profiler/src/profiler/TracyConfig.cpp
@@ -27,6 +27,9 @@ void LoadConfig()
     if( ini_sget( ini, "timeline", "forceColors", "%d", &v ) ) s_config.forceColors = v;
     if( ini_sget( ini, "timeline", "ghostZones", "%d", &v ) ) s_config.ghostZones = v;
     if( ini_sget( ini, "timeline", "shortenName", "%d", &v ) ) s_config.shortenName = v;
+    if( ini_sget( ini, "timeline", "drawSamples", "%d", &v ) ) s_config.drawSamples = v;
+    if( ini_sget( ini, "timeline", "drawContextSwitches", "%d", &v ) ) s_config.drawContextSwitches = v;
+    if( ini_sget( ini, "timeline", "plotHeight", "%d", &v ) ) s_config.plotHeight = v;
     if( ini_sget( ini, "timeline", "horizontalScrollMultiplier", "%lf", &v1 ) && v1 > 0.0 ) s_config.horizontalScrollMultiplier = v1;
     if( ini_sget( ini, "timeline", "verticalScrollMultiplier", "%lf", &v1 ) && v1 > 0.0 ) s_config.verticalScrollMultiplier = v1;
     if( ini_sget( ini, "memory", "limit", "%d", &v ) ) s_config.memoryLimit = v;
@@ -62,6 +65,9 @@ bool SaveConfig()
     fprintf( f, "forceColors = %i\n", (int)s_config.forceColors );
     fprintf( f, "ghostZones = %i\n", (int)s_config.ghostZones );
     fprintf( f, "shortenName = %i\n", s_config.shortenName );
+    fprintf( f, "drawSamples = %i\n", s_config.drawSamples );
+    fprintf( f, "drawContextSwitches = %i\n", s_config.drawContextSwitches );
+    fprintf( f, "plotHeight = %i\n", s_config.plotHeight );
     fprintf( f, "horizontalScrollMultiplier = %lf\n", s_config.horizontalScrollMultiplier );
     fprintf( f, "verticalScrollMultiplier = %lf\n", s_config.verticalScrollMultiplier );
 

--- a/profiler/src/profiler/TracyConfig.hpp
+++ b/profiler/src/profiler/TracyConfig.hpp
@@ -13,6 +13,7 @@ struct Config
     bool threadedRendering = true;
     bool focusLostLimit = true;
     int targetFps = 60;
+    bool drawFrameTargets = false;
     double horizontalScrollMultiplier = 1.0;
     double verticalScrollMultiplier = 1.0;
     bool memoryLimit = false;

--- a/profiler/src/profiler/TracyConfig.hpp
+++ b/profiler/src/profiler/TracyConfig.hpp
@@ -23,8 +23,12 @@ struct Config
     bool forceColors = false;
     bool ghostZones = true;
     int shortenName = (int)ShortenName::NoSpaceAndNormalize;
+    bool drawSamples = true;
+    bool drawContextSwitches = true;
     bool saveUserScale = false;
     float userScale = 1.0f;
+
+    // LLM assistant settings
 #ifdef __EMSCRIPTEN__
     bool llm = false;
 #else

--- a/profiler/src/profiler/TracyConfig.hpp
+++ b/profiler/src/profiler/TracyConfig.hpp
@@ -25,6 +25,7 @@ struct Config
     int shortenName = (int)ShortenName::NoSpaceAndNormalize;
     bool drawSamples = true;
     bool drawContextSwitches = true;
+    int plotHeight = 100;
     bool saveUserScale = false;
     float userScale = 1.0f;
 

--- a/profiler/src/profiler/TracyConfig.hpp
+++ b/profiler/src/profiler/TracyConfig.hpp
@@ -21,6 +21,7 @@ struct Config
     bool achievementsAsked = false;
     int dynamicColors = 1;
     bool forceColors = false;
+    bool ghostZones = true;
     int shortenName = (int)ShortenName::NoSpaceAndNormalize;
     bool saveUserScale = false;
     float userScale = 1.0f;

--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -137,6 +137,7 @@ void View::SetupConfig()
 {
     // Keep in sync with TracyView_Options.cpp View::DrawOptions(), bottom of the file.
     m_vd.frameTarget = s_config.targetFps;
+    m_vd.drawFrameTargets = s_config.drawFrameTargets;
     m_vd.dynamicColors = s_config.dynamicColors;
     m_vd.forceColors = s_config.forceColors;
     m_vd.ghostZones = s_config.ghostZones;

--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -138,6 +138,7 @@ void View::SetupConfig()
     m_vd.frameTarget = s_config.targetFps;
     m_vd.dynamicColors = s_config.dynamicColors;
     m_vd.forceColors = s_config.forceColors;
+    m_vd.ghostZones = s_config.ghostZones;
     m_vd.shortenName = (ShortenName)s_config.shortenName;
 }
 

--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -143,6 +143,7 @@ void View::SetupConfig()
     m_vd.shortenName = (ShortenName)s_config.shortenName;
     m_vd.drawSamples = s_config.drawSamples;
     m_vd.drawContextSwitches = s_config.drawContextSwitches;
+    m_vd.plotHeight = s_config.plotHeight;
 }
 
 void View::Achieve( const char* id )

--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -135,11 +135,14 @@ void View::InitTextEditor()
 
 void View::SetupConfig()
 {
+    // Keep in sync with TracyView_Options.cpp View::DrawOptions(), bottom of the file.
     m_vd.frameTarget = s_config.targetFps;
     m_vd.dynamicColors = s_config.dynamicColors;
     m_vd.forceColors = s_config.forceColors;
     m_vd.ghostZones = s_config.ghostZones;
     m_vd.shortenName = (ShortenName)s_config.shortenName;
+    m_vd.drawSamples = s_config.drawSamples;
+    m_vd.drawContextSwitches = s_config.drawContextSwitches;
 }
 
 void View::Achieve( const char* id )

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -873,6 +873,8 @@ void View::DrawOptions()
             "Pressing this button stores their current values as the default values.\n\n"
             "Alternatively, you can manually adjust those default values by editing the config file at:" );
         TextDisabledUnformatted( fn );
+        ImGui::Spacing();
+        ImGui::TextUnformatted( "For now, to restore the default values, you may delete this configuration file." );
         ImGui::EndTooltip();
     }
 

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -15,8 +15,15 @@
 namespace tracy
 {
 
+static void DefaultMarker() {
+    // Add a red * to indicate that the default value for this setting can be configured.
+    ImGui::SameLine(0.0f, 2.0f);
+    TextColoredUnformatted( ImVec4(0.9f, 0.05f, 0.1f, 0.8f), "*" );
+}
+
 void View::DrawOptions()
 {
+
     ImGui::Begin( "Options", &m_showOptions, ImGuiWindowFlags_AlwaysAutoResize );
     if( ImGui::GetCurrentWindowRead()->SkipItems ) { ImGui::End(); return; }
 
@@ -27,6 +34,7 @@ void View::DrawOptions()
     val = m_vd.drawFrameTargets;
     ImGui::Checkbox( ICON_FA_FLAG_CHECKERED " Draw frame targets", &val );
     m_vd.drawFrameTargets = val;
+    DefaultMarker();
     ImGui::Indent();
     int tmp = m_vd.frameTarget;
     ImGui::PushStyleVar( ImGuiStyleVar_FramePadding, ImVec2( 0, 0 ) );
@@ -36,6 +44,7 @@ void View::DrawOptions()
         if( tmp < 1 ) tmp = 1;
         m_vd.frameTarget = tmp;
     }
+    DefaultMarker();
     ImGui::SameLine();
     TextDisabledUnformatted( TimeToString( 1000*1000*1000 / tmp ) );
     ImGui::PopStyleVar();
@@ -61,6 +70,7 @@ void View::DrawOptions()
         val = m_vd.drawContextSwitches;
         ImGui::Checkbox( ICON_FA_PERSON_HIKING " Draw context switches", &val );
         m_vd.drawContextSwitches = val;
+        DefaultMarker();
         ImGui::Indent();
         val = m_vd.darkenContextSwitches;
         SmallCheckbox( ICON_FA_MOON " Darken inactive threads", &val );
@@ -81,6 +91,7 @@ void View::DrawOptions()
         val = m_vd.drawSamples;
         ImGui::Checkbox( ICON_FA_EYE_DROPPER " Draw stack samples", &val );
         m_vd.drawSamples = val;
+        DefaultMarker();
     }
 
     const auto& gpuData = m_worker.GetGpuData();
@@ -220,6 +231,7 @@ void View::DrawOptions()
         val = m_vd.ghostZones;
         SmallCheckbox( ICON_FA_GHOST " Draw ghost zones", &val );
         m_vd.ghostZones = val;
+        DefaultMarker();
     }
 #endif
 
@@ -228,6 +240,7 @@ void View::DrawOptions()
     ImGui::SameLine();
     bool forceColors = m_vd.forceColors;
     if( SmallCheckbox( "Ignore custom", &forceColors ) ) m_vd.forceColors = forceColors;
+    DefaultMarker();
     ImGui::SameLine();
     bool inheritColors = m_vd.inheritParentColors;
     if( SmallCheckbox( "Inherit parent colors", &inheritColors ) ) m_vd.inheritParentColors = inheritColors;
@@ -241,6 +254,7 @@ void View::DrawOptions()
     m_vd.dynamicColors = ival;
     ival = (int)m_vd.shortenName;
     ImGui::TextUnformatted( ICON_FA_RULER_HORIZONTAL " Zone name shortening" );
+    DefaultMarker();
     ImGui::Indent();
     ImGui::PushStyleVar( ImGuiStyleVar_FramePadding, ImVec2( 0, 0 ) );
     ImGui::RadioButton( "Disabled", &ival, (uint8_t)ShortenName::Never );
@@ -597,6 +611,7 @@ void View::DrawOptions()
         int pH = m_vd.plotHeight;
         ImGui::SliderInt("Plot heights", &pH, 30, 200);
         m_vd.plotHeight = pH;
+        DefaultMarker();
 
         const auto expand = ImGui::TreeNode( "Plots" );
         ImGui::SameLine();
@@ -826,7 +841,13 @@ void View::DrawOptions()
         }
     }
 
-    ImGui::Spacing();
+    ImGui::Separator();
+
+    ImGui::TextUnformatted("");
+    DefaultMarker();
+    ImGui::SameLine(0.0f, 1.0f);
+    ImGui::TextUnformatted( ": The default value for this option is configurable." );
+
     if( ImGui::Button( "Save defaults" ) )
     {
         // Keep in sync with TracyView.cpp View::SetupConfig()
@@ -843,8 +864,12 @@ void View::DrawOptions()
     {
         ImGui::BeginTooltip();
         const auto fn = tracy::GetSavePath( "tracy.ini" );
+
+        ImGui::TextUnformatted( "The options above marked with " );
+        DefaultMarker();
+        ImGui::SameLine();
+        ImGui::TextUnformatted( "have configurable default values." );
         ImGui::TextUnformatted(
-            "A handful of the options above have configurable default values.\n"
             "There is no UI yet to set those items, except this button which saves the default for all of them.\n\n"
             "For now, you can also manually adjust those defaults by editing the config file at:"
         );

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -17,8 +17,8 @@ namespace tracy
 
 static void DefaultMarker() {
     // Add a red * to indicate that the default value for this setting can be configured.
-    ImGui::SameLine(0.0f, 2.0f);
-    TextColoredUnformatted( ImVec4(0.9f, 0.05f, 0.1f, 0.8f), "*" );
+    ImGui::SameLine( 0.0f, 2.0f );
+    TextColoredUnformatted( ImVec4( 0.9f, 0.05f, 0.1f, 0.8f ), "*" );
 }
 
 void View::DrawOptions()
@@ -843,12 +843,12 @@ void View::DrawOptions()
 
     ImGui::Separator();
 
-    ImGui::TextUnformatted("");
+    ImGui::TextUnformatted( "" );
     DefaultMarker();
-    ImGui::SameLine(0.0f, 1.0f);
+    ImGui::SameLine( 0.0f, 1.0f );
     ImGui::TextUnformatted( ": The default value for this option is configurable." );
 
-    if( ImGui::Button( "Save defaults" ) )
+    if( ImGui::Button( "Save current options as defaults" ) )
     {
         // Keep in sync with TracyView.cpp View::SetupConfig()
         s_config.targetFps = m_vd.frameTarget;
@@ -870,12 +870,10 @@ void View::DrawOptions()
         ImGui::SameLine();
         ImGui::TextUnformatted( "have configurable default values." );
         ImGui::TextUnformatted(
-            "There is no UI yet to set those items, except this button which saves the default for all of them.\n\n"
-            "For now, you can also manually adjust those defaults by editing the config file at:"
-        );
+            "Pressing this button stores their current values as the default values.\n\n"
+            "Alternatively, you can manually adjust those default values by editing the config file at:" );
         TextDisabledUnformatted( fn );
         ImGui::EndTooltip();
-
     }
 
     ImGui::End();

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -848,7 +848,7 @@ void View::DrawOptions()
             "There is no UI yet to set those items, except this button which saves the default for all of them.\n\n"
             "For now, you can also manually adjust those defaults by editing the config file at:"
         );
-        TextDisabledUnformatted(fn);
+        TextDisabledUnformatted( fn );
         ImGui::EndTooltip();
 
     }

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -855,9 +855,10 @@ void View::DrawOptions()
     DefaultMarker( default_markers_active, false );
     ImGui::SameLine( 0.0f, 1.0f );
     ImGui::TextUnformatted( ": The default value for this option is configurable." );
+    bool highlight = false;
     if( ImGui::IsItemHovered() )
     {
-        default_markers_active = true;
+        highlight = true;
     }
 
     if( ImGui::Button( "Save current options as defaults" ) )
@@ -872,9 +873,10 @@ void View::DrawOptions()
         s_config.drawContextSwitches = m_vd.drawContextSwitches;
         SaveConfig();
     }
+
     if( ImGui::IsItemHovered() )
     {
-        default_markers_active = true;
+        highlight = true;
         ImGui::BeginTooltip();
         const auto fn = tracy::GetSavePath( "tracy.ini" );
 
@@ -890,10 +892,8 @@ void View::DrawOptions()
         ImGui::TextUnformatted( "For now, to restore the default values, you may delete this configuration file." );
         ImGui::EndTooltip();
     }
-    else
-    {
-        default_markers_active = false;
-    }
+
+    default_markers_active = highlight;
 
     ImGui::End();
 }

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -8,6 +8,7 @@
 #include "TracyTimelineItemGpu.hpp"
 #include "TracyUtility.hpp"
 #include "TracyView.hpp"
+#include "TracyStorage.hpp"
 #include "tracy_pdqsort.h"
 #include "../Fonts.hpp"
 
@@ -824,6 +825,34 @@ void View::DrawOptions()
             ImGui::TreePop();
         }
     }
+
+    ImGui::Spacing();
+    if( ImGui::Button( "Save defaults" ) )
+    {
+        // Keep in sync with TracyView.cpp View::SetupConfig()
+        s_config.targetFps = m_vd.frameTarget;
+        s_config.dynamicColors = m_vd.dynamicColors;
+        s_config.forceColors = m_vd.forceColors;
+        s_config.ghostZones = m_vd.ghostZones;
+        s_config.shortenName = (int)m_vd.shortenName;
+        s_config.drawSamples = m_vd.drawSamples;
+        s_config.drawContextSwitches = m_vd.drawContextSwitches;
+        SaveConfig();
+    }
+    if( ImGui::IsItemHovered() )
+    {
+        ImGui::BeginTooltip();
+        const auto fn = tracy::GetSavePath( "tracy.ini" );
+        ImGui::TextUnformatted(
+            "A handful of the options above have configurable default values.\n"
+            "There is no UI yet to set those items, except this button which saves the default for all of them.\n\n"
+            "For now, you can also manually adjust those defaults by editing the config file at:"
+        );
+        TextDisabledUnformatted(fn);
+        ImGui::EndTooltip();
+
+    }
+
     ImGui::End();
 }
 


### PR DESCRIPTION
 - Button to save current options to the global Tracy Config.
 - red stars indicating which options get saved.
 - Added a bunch of settings I expect people to like having defaults configurable for.
 - Tooltip explaining you can edit the global config file manually as well.

<img width="676" height="720" alt="tracy_options" src="https://github.com/user-attachments/assets/8391b869-f370-4ae2-90c5-a90e898d15b9" />

 (fixed that awkward space after the red star in the tooltip after taking this screenshot)

Fixes #1139 