### PR TITLE
Fix usage of stat64 on non-glibc Linux

### DIFF
--- a/server/TracyFileRead.hpp
+++ b/server/TracyFileRead.hpp
@@ -18,7 +18,7 @@
 #ifdef _MSC_VER
 #  define stat64 _stat64
 #endif
-#if defined __APPLE__ || defined __FreeBSD__
+#if defined __APPLE__ || defined __FreeBSD__ || (defined __linux__ && !defined __GLIBC__)
 #  define stat64 stat
 #endif
 


### PR DESCRIPTION
Add an extra conditional alongside the other platforms that have a 64-bit `stat` for any Linux platforms that don't use glibc. Fixes #1145.

Between the widely used libc implementations for Linux, glibc is the only one that might still [use a 32-bit definition of `stat`](https://github.com/bminor/glibc/blob/d2097651cc57834dbfcaa102ddfacae0d86cfb66/bits/stat.h#L31), while [musl](https://git.musl-libc.org/cgit/musl/tree/include/sys/stat.h?h=v1.2.5#n157) and [bionic](https://android.googlesource.com/platform/bionic/+/refs/tags/android-platform-15.0.0_r11/libc/include/sys/stat.h#102) (for example), will always have a 64-bit `stat`.

Since musl doesn't even define `stat64` by default anymore, making that type aliasing ourselves becomes a necessity to avoid build errors, just as we already do for MacOS and FreeBSD.