### PR TITLE
Merge GpuEvent and ZoneEvent

### DIFF
--- a/cmake/server.cmake
+++ b/cmake/server.cmake
@@ -22,6 +22,7 @@ set(TRACY_SERVER_SOURCES
     TracyTextureCompression.cpp
     TracyThreadCompress.cpp
     TracyWorker.cpp
+    TracyContext.cpp
 )
 
 list(TRANSFORM TRACY_SERVER_SOURCES PREPEND "${TRACY_SERVER_DIR}/")

--- a/profiler/src/profiler/TracyTimelineItemGpu.hpp
+++ b/profiler/src/profiler/TracyTimelineItemGpu.hpp
@@ -2,6 +2,7 @@
 #define __TRACYTIMELINEITEMGPU_HPP__
 
 #include "TracyEvent.hpp"
+#include "TracyContext.hpp"
 #include "TracyTimelineItem.hpp"
 
 namespace tracy

--- a/profiler/src/profiler/TracyTimelineItemThread.hpp
+++ b/profiler/src/profiler/TracyTimelineItemThread.hpp
@@ -2,6 +2,7 @@
 #define __TRACYTIMELINEITEMTHREAD_HPP__
 
 #include "TracyEvent.hpp"
+#include "TracyContext.hpp"
 #include "TracyTimelineDraw.hpp"
 #include "TracyTimelineItem.hpp"
 

--- a/profiler/src/profiler/TracyUtility.hpp
+++ b/profiler/src/profiler/TracyUtility.hpp
@@ -7,6 +7,7 @@
 
 #include "imgui.h"
 #include "../server/TracyEvent.hpp"
+#include "../server/TracyContext.hpp"
 
 namespace tracy
 {

--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -1140,7 +1140,6 @@ bool View::DrawImpl()
     ImGui::End();
 
     m_zoneHighlight = nullptr;
-    m_gpuHighlight = nullptr;
 
     DrawInfoWindow();
 

--- a/profiler/src/profiler/TracyView_ContextSwitch.cpp
+++ b/profiler/src/profiler/TracyView_ContextSwitch.cpp
@@ -69,7 +69,7 @@ const char* View::DecodeContextSwitchReason( uint8_t reason )
     {
     case ContextSwitchData::Win32_Executive: return "(Thread is waiting for the scheduler)";
     case ContextSwitchData::Win32_FreePage: return "(Thread is waiting for a free virtual memory page)";
-    case ContextSwitchData::Win32_PageIn: return "(Thread is waiting for a virtual memory page to arrive in memory)";    
+    case ContextSwitchData::Win32_PageIn: return "(Thread is waiting for a virtual memory page to arrive in memory)";
     case ContextSwitchData::Win32_PoolAllocation: return "(Thread is waiting for a system allocation)";
     case ContextSwitchData::Win32_DelayExecution: return "(Thread execution is delayed)";
     case ContextSwitchData::Win32_Suspended: return "(Thread execution is suspended)";
@@ -399,6 +399,7 @@ void View::DrawWaitStacks()
     {
         if( WaitStackThread( t->id ) )
         {
+            const CPUThreadData* t = static_cast<const CPUThreadData*>(t);
             auto it = t->ctxSwitchSamples.begin();
             auto end = t->ctxSwitchSamples.end();
             if( m_waitStackRange.active )
@@ -507,8 +508,9 @@ void View::DrawWaitStacks()
         }
 
         int idx = 0;
-        for( const auto& t : m_threadOrder )
+        for( const auto& td : m_threadOrder )
         {
+            const CPUThreadData* t = static_cast<const CPUThreadData*>(td);
             if( t->ctxSwitchSamples.empty() ) continue;
             ImGui::PushID( idx++ );
             const auto threadColor = GetThreadColor( t->id, 0 );

--- a/profiler/src/profiler/TracyView_CpuData.cpp
+++ b/profiler/src/profiler/TracyView_CpuData.cpp
@@ -389,7 +389,7 @@ bool View::DrawCpuData( const TimelineContext& ctx, const std::vector<CpuUsageDr
 
                         if( local && IsMouseClicked( 0 ) )
                         {
-                            auto& item = m_tc.GetItem( m_worker.GetThreadData( thread ) );
+                            auto& item = m_tc.GetItem( m_worker.GetDefaultCtx().GetThreadData( thread ) );
                             item.SetVisible( true );
                             item.SetShowFull( true );
                         }

--- a/profiler/src/profiler/TracyView_FrameOverview.cpp
+++ b/profiler/src/profiler/TracyView_FrameOverview.cpp
@@ -259,9 +259,9 @@ void View::DrawFrames()
 
     int i = 0, idx = 0;
 #ifndef TRACY_NO_STATISTICS
-    if( m_worker.AreSourceLocationZonesReady() && m_findZone.show && m_findZone.showZoneInFrames && !m_findZone.match.empty() )
+    if( m_worker.GetDefaultCtx().AreSourceLocationZonesReady() && m_findZone.show && m_findZone.showZoneInFrames && !m_findZone.match.empty() )
     {
-        auto& zoneData = m_worker.GetZonesForSourceLocation( m_findZone.match[m_findZone.selMatch] );
+        auto& zoneData = m_worker.GetDefaultCtx().GetZonesForSourceLocation( m_findZone.match[m_findZone.selMatch] );
         zoneData.zones.ensure_sorted();
         auto begin = zoneData.zones.begin();
         while( i < onScreen && m_vd.frameStart + idx < total )

--- a/profiler/src/profiler/TracyView_Memory.cpp
+++ b/profiler/src/profiler/TracyView_Memory.cpp
@@ -597,11 +597,11 @@ void View::DrawMemoryAllocWindow()
 
         bool sep = false;
         auto zoneAlloc = FindZoneAtTime( tidAlloc, ev.TimeAlloc() );
-        if( zoneAlloc )
+        if( zoneAlloc.first )
         {
             ImGui::Separator();
             sep = true;
-            const auto& srcloc = m_worker.GetSourceLocation( zoneAlloc->SrcLoc() );
+            const auto& srcloc = m_worker.GetSourceLocation( zoneAlloc.first->SrcLoc() );
             const auto txt = srcloc.name.active ? m_worker.GetString( srcloc.name ) : m_worker.GetString( srcloc.function );
             ImGui::PushID( idx++ );
             TextFocused( "Zone alloc:", txt );
@@ -609,41 +609,41 @@ void View::DrawMemoryAllocWindow()
             ImGui::PopID();
             if( ImGui::IsItemClicked() )
             {
-                ShowZoneInfo( *zoneAlloc );
+                ShowZoneInfo( *zoneAlloc.first );
             }
             if( hover )
             {
-                m_zoneHighlight = zoneAlloc;
+                m_zoneHighlight = zoneAlloc.first;
                 if( IsMouseClicked( 2 ) )
                 {
-                    ZoomToZone( *zoneAlloc );
+                    ZoomToZone( *zoneAlloc.first );
                 }
-                ZoneTooltip( *zoneAlloc );
+                ZoneTooltip( *zoneAlloc.first, *zoneAlloc.second );
             }
         }
 
         if( ev.TimeFree() >= 0 )
         {
             auto zoneFree = FindZoneAtTime( tidFree, ev.TimeFree() );
-            if( zoneFree )
+            if( zoneFree.first )
             {
                 if( !sep ) ImGui::Separator();
-                const auto& srcloc = m_worker.GetSourceLocation( zoneFree->SrcLoc() );
+                const auto& srcloc = m_worker.GetSourceLocation( zoneFree.first->SrcLoc() );
                 const auto txt = srcloc.name.active ? m_worker.GetString( srcloc.name ) : m_worker.GetString( srcloc.function );
                 TextFocused( "Zone free:", txt );
                 auto hover = ImGui::IsItemHovered();
                 if( ImGui::IsItemClicked() )
                 {
-                    ShowZoneInfo( *zoneFree );
+                    ShowZoneInfo( *zoneFree.first );
                 }
                 if( hover )
                 {
-                    m_zoneHighlight = zoneFree;
+                    m_zoneHighlight = zoneFree.first;
                     if( IsMouseClicked( 2 ) )
                     {
-                        ZoomToZone( *zoneFree );
+                        ZoomToZone( *zoneFree.first );
                     }
-                    ZoneTooltip( *zoneFree );
+                    ZoneTooltip( *zoneFree.first, *zoneAlloc.second );
                 }
                 if( zoneAlloc == zoneFree )
                 {
@@ -810,30 +810,30 @@ void View::ListMemData( std::vector<const MemEvent*>& vec, const std::function<v
                 }
                 ImGui::TableNextColumn();
                 auto zone = FindZoneAtTime( m_worker.DecompressThread( v->ThreadAlloc() ), v->TimeAlloc() );
-                if( !zone )
+                if( !zone.first )
                 {
                     ImGui::TextUnformatted( "-" );
                 }
                 else
                 {
-                    const auto& srcloc = m_worker.GetSourceLocation( zone->SrcLoc() );
+                    const auto& srcloc = m_worker.GetSourceLocation( zone.first->SrcLoc() );
                     const auto txt = srcloc.name.active ? m_worker.GetString( srcloc.name ) : m_worker.GetString( srcloc.function );
                     ImGui::PushID( idx++ );
-                    auto sel = ImGui::Selectable( txt, m_zoneInfoWindow == zone );
+                    auto sel = ImGui::Selectable( txt, m_zoneInfoWindow == zone.first );
                     auto hover = ImGui::IsItemHovered();
                     ImGui::PopID();
                     if( sel )
                     {
-                        ShowZoneInfo( *zone );
+                        ShowZoneInfo( *zone.first );
                     }
                     if( hover )
                     {
-                        m_zoneHighlight = zone;
+                        m_zoneHighlight = zone.first;
                         if( IsMouseClicked( 2 ) )
                         {
-                            ZoomToZone( *zone );
+                            ZoomToZone( *zone.first );
                         }
-                        ZoneTooltip( *zone );
+                        ZoneTooltip( *zone.first, *zone.second );
                     }
                 }
                 ImGui::TableNextColumn();
@@ -844,40 +844,40 @@ void View::ListMemData( std::vector<const MemEvent*>& vec, const std::function<v
                 else
                 {
                     auto zoneFree = FindZoneAtTime( m_worker.DecompressThread( v->ThreadFree() ), v->TimeFree() );
-                    if( !zoneFree )
+                    if( !zoneFree.first )
                     {
                         ImGui::TextUnformatted( "-" );
                     }
                     else
                     {
-                        const auto& srcloc = m_worker.GetSourceLocation( zoneFree->SrcLoc() );
+                        const auto& srcloc = m_worker.GetSourceLocation( zoneFree.first->SrcLoc() );
                         const auto txt = srcloc.name.active ? m_worker.GetString( srcloc.name ) : m_worker.GetString( srcloc.function );
                         ImGui::PushID( idx++ );
                         bool sel;
                         if( zoneFree == zone )
                         {
                             ImGui::PushStyleColor( ImGuiCol_Text, ImVec4( 1.f, 1.f, 0.6f, 1.f ) );
-                            sel = ImGui::Selectable( txt, m_zoneInfoWindow == zoneFree );
+                            sel = ImGui::Selectable( txt, m_zoneInfoWindow == zoneFree.first );
                             ImGui::PopStyleColor( 1 );
                         }
                         else
                         {
-                            sel = ImGui::Selectable( txt, m_zoneInfoWindow == zoneFree );
+                            sel = ImGui::Selectable( txt, m_zoneInfoWindow == zoneFree.first );
                         }
                         auto hover = ImGui::IsItemHovered();
                         ImGui::PopID();
                         if( sel )
                         {
-                            ShowZoneInfo( *zoneFree );
+                            ShowZoneInfo( *zoneFree.first );
                         }
                         if( hover )
                         {
-                            m_zoneHighlight = zoneFree;
+                            m_zoneHighlight = zoneFree.first;
                             if( IsMouseClicked( 2 ) )
                             {
-                                ZoomToZone( *zoneFree );
+                                ZoomToZone( *zoneFree.first );
                             }
-                            ZoneTooltip( *zoneFree );
+                            ZoneTooltip( *zoneFree.first, *zoneFree.second );
                         }
                     }
                 }

--- a/profiler/src/profiler/TracyView_Statistics.cpp
+++ b/profiler/src/profiler/TracyView_Statistics.cpp
@@ -45,7 +45,12 @@ void View::DrawStatistics()
     ImGui::TextWrapped( "Collection of statistical data is disabled in this build." );
     ImGui::TextWrapped( "Rebuild without the TRACY_NO_STATISTICS macro to enable statistics view." );
 #else
-    if( !m_worker.AreSourceLocationZonesReady() && ( !m_worker.AreCallstackSamplesReady() || m_worker.GetCallstackSampleCount() == 0 ) )
+    ContextCombo( m_statCtxName, &m_statCtx );
+    auto ctx = m_worker.GetCtxData()[m_statCtx];
+
+    ImGui::SameLine();
+
+    if( !ctx->AreSourceLocationZonesReady() && ( !m_worker.AreCallstackSamplesReady() || m_worker.GetCallstackSampleCount() == 0 ) )
     {
         const auto ty = ImGui::GetTextLineHeight();
         ImGui::PushFont( g_fonts.normal, FontBig );
@@ -78,13 +83,6 @@ void View::DrawStatistics()
             ImGui::RadioButton( ICON_FA_PUZZLE_PIECE " Symbols", &m_statMode, 1 );
         }
     }
-    if( m_worker.GetGpuZoneCount() > 0 )
-    {
-        ImGui::SameLine();
-        ImGui::Spacing();
-        ImGui::SameLine();
-        ImGui::RadioButton( ICON_FA_EYE " GPU", &m_statMode, 2 );
-    }
     ImGui::SameLine();
     ImGui::Spacing();
     ImGui::SameLine();
@@ -99,7 +97,7 @@ void View::DrawStatistics()
     bool copySrclocsToClipboard = false;
     if( m_statMode == 0 )
     {
-        if( !m_worker.AreSourceLocationZonesReady() )
+        if( !ctx->AreSourceLocationZonesReady() )
         {
             ImGui::Spacing();
             ImGui::Separator();
@@ -111,7 +109,7 @@ void View::DrawStatistics()
         }
 
         const auto filterActive = m_statisticsFilter.IsActive();
-        auto& slz = m_worker.GetSourceLocationZones();
+        auto& slz = ctx->GetSourceLocationZones();
         srcloc.reserve( slz.size() );
         uint32_t slzcnt = 0;
         if( m_statRange.active )
@@ -321,6 +319,8 @@ void View::DrawStatistics()
     }
     else
     {
+      assert(0);
+      /*
         assert( m_statMode == 2 );
         if( !m_worker.AreGpuSourceLocationZonesReady() )
         {
@@ -456,6 +456,7 @@ void View::DrawStatistics()
         TextFocused( "Visible zones:", RealToString( srcloc.size() ) );
         ImGui::SameLine();
         copySrclocsToClipboard = ClipboardButton();
+      */
     }
 
     ImGui::Separator();

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1243,7 +1243,7 @@ struct ProfilerData
     moodycamel::ConcurrentQueue<QueueItem> queue;
     Profiler profiler;
     std::atomic<uint32_t> lockCounter { 0 };
-    std::atomic<uint8_t> gpuCtxCounter { 0 };
+    std::atomic<uint8_t> gpuCtxCounter { 1 }; // 0 reserved for default context
     std::atomic<ThreadNameData*> threadNameData { nullptr };
 };
 
@@ -1425,7 +1425,7 @@ thread_local bool RpThreadInitDone = false;
 thread_local bool RpThreadShutdown = false;
 moodycamel::ConcurrentQueue<QueueItem> init_order(103) s_queue( QueuePrealloc );
 std::atomic<uint32_t> init_order(104) s_lockCounter( 0 );
-std::atomic<uint8_t> init_order(104) s_gpuCtxCounter( 0 );
+std::atomic<uint8_t> init_order(104) s_gpuCtxCounter( 1 ); // 0 reserved for default context
 
 thread_local GpuCtxWrapper init_order(104) s_gpuCtx { nullptr };
 

--- a/public/client/TracyRocprof.cpp
+++ b/public/client/TracyRocprof.cpp
@@ -104,7 +104,7 @@ uint8_t gpu_context_allocate( ToolData* data )
         tracy::MemWrite( &item->gpuNewContext.period, timestamp_period );
         tracy::MemWrite( &item->gpuNewContext.context, context_id );
         tracy::MemWrite( &item->gpuNewContext.flags, context_flags );
-        tracy::MemWrite( &item->gpuNewContext.type, tracy::GpuContextType::Rocprof );
+        tracy::MemWrite( &item->gpuNewContext.type, tracy::ZoneContextType::Rocprof );
         tracy::Profiler::QueueSerialFinish();
     }
 
@@ -451,6 +451,7 @@ void calibration_thread( void* ptr )
 {
     while( !TracyIsStarted )
         ;
+    SetThreadName( "rocprofiler calibration" );
     ToolData* data = static_cast<ToolData*>( ptr );
     data->context_id = gpu_context_allocate( data );
     const char* user_counters = GetEnvVar( "TRACY_ROCPROF_COUNTERS" );

--- a/public/common/TracyQueue.hpp
+++ b/public/common/TracyQueue.hpp
@@ -398,7 +398,7 @@ struct QueueMessageColorFatThread : public QueueMessageColorFat
 };
 
 // Don't change order, only add new entries at the end, this is also used on trace dumps!
-enum class GpuContextType : uint8_t
+enum class ZoneContextType : uint8_t
 {
     Invalid,
     OpenGl,
@@ -409,7 +409,8 @@ enum class GpuContextType : uint8_t
     Metal,
     Custom,
     CUDA,
-    Rocprof
+    Rocprof,
+    CPU
 };
 
 enum GpuContextFlags : uint8_t
@@ -425,7 +426,7 @@ struct QueueGpuNewContext
     float period;
     uint8_t context;
     GpuContextFlags flags;
-    GpuContextType type;
+    ZoneContextType type;
 };
 
 struct QueueGpuZoneBeginLean

--- a/public/common/TracyVersion.hpp
+++ b/public/common/TracyVersion.hpp
@@ -6,8 +6,8 @@ namespace tracy
 namespace Version
 {
 enum { Major = 0 };
-enum { Minor = 12 };
-enum { Patch = 4 };
+enum { Minor = 13 };
+enum { Patch = 0 };
 }
 }
 

--- a/server/TracyContext.cpp
+++ b/server/TracyContext.cpp
@@ -1,0 +1,65 @@
+#include "TracyContext.hpp"
+
+namespace tracy
+{
+
+const ThreadData* ZoneContext::GetThreadData( uint64_t tid ) const
+{
+    auto it = threadData.find( tid );
+    if( it == threadData.end() ) return nullptr;
+    return it->second;
+}
+
+#ifndef TRACY_NO_STATISTICS
+ZoneContext::SourceLocationZones& ZoneContext::GetZonesForSourceLocation( int16_t srcloc )
+{
+    assert( AreSourceLocationZonesReady() );
+    static SourceLocationZones empty;
+    auto it = sourceLocationZones.find( srcloc );
+    return it != sourceLocationZones.end() ? it->second : empty;
+}
+
+const ZoneContext::SourceLocationZones& ZoneContext::GetZonesForSourceLocation( int16_t srcloc ) const
+{
+    assert( AreSourceLocationZonesReady() );
+    static const SourceLocationZones empty;
+    auto it = sourceLocationZones.find( srcloc );
+    return it != sourceLocationZones.end() ? it->second : empty;
+}
+
+ZoneContext::SourceLocationZones* ZoneContext::GetSourceLocationZonesReal( uint16_t srcloc )
+{
+    auto it = sourceLocationZones.find( srcloc );
+    assert( it != sourceLocationZones.end() );
+    srclocZonesLast.first = srcloc;
+    srclocZonesLast.second = &it->second;
+    return &it->second;
+}
+
+void ZoneContext::InitSourceLocationZones( uint16_t srcloc )
+{
+    auto res = sourceLocationZones.emplace( srcloc, SourceLocationZones() );
+    srclocZonesLast.first = srcloc;
+    srclocZonesLast.second = &res.first->second;
+}
+
+#else
+uint64_t* ZoneContext::GetSourceLocationZonesCntReal( uint16_t srcloc )
+{
+    auto it = sourceLocationZonesCnt.find( srcloc );
+    assert( it != sourceLocationZonesCnt.end() );
+    srclocCntLast.first = srcloc;
+    srclocCntLast.second = &it->second;
+    return &it->second;
+}
+
+void InitSourceLocationZonesCnt( uint16_t srcloc )
+{
+    auto res = sourceLocationZonesCnt.emplace( srcloc, 0 );
+    srclocCntLast.first = srcloc;
+    srclocCntLast.second = &res.first->second;
+}
+
+#endif
+
+} // namespace tracy

--- a/server/TracyContext.hpp
+++ b/server/TracyContext.hpp
@@ -1,0 +1,192 @@
+#ifndef __TRACYCONTEXT_HPP__
+#define __TRACYCONTEXT_HPP__
+
+#include "TracyEvent.hpp"
+#include "TracyShortPtr.hpp"
+#include "tracy_robin_hood.h"
+
+namespace tracy
+{
+
+constexpr const char* ZoneContextNames[] = {
+    "Invalid",
+    "OpenGL",
+    "Vulkan",
+    "OpenCL",
+    "Direct3D 12",
+    "Direct3D 11",
+    "Metal",
+    "Custom",
+    "CUDA",
+    "Rocprof",
+    "CPU"
+};
+
+struct ZoneContext;
+class Worker;
+
+struct ThreadData
+{
+    uint64_t id;
+    uint64_t count;
+    Vector<short_ptr<ZoneEvent>> timeline;
+    Vector<short_ptr<ZoneEvent>> stack;
+    Vector<short_ptr<MessageData>> messages;
+    uint32_t nextZoneId;
+    Vector<uint32_t> zoneIdStack;
+    uint8_t isFiber;
+    ThreadData* fiber;
+    uint8_t* stackCount;
+    int32_t groupHint;
+    ZoneContext* ctx;
+#ifndef TRACY_NO_STATISTICS
+  Vector<int64_t> childTimeStack;
+#endif
+
+    tracy_force_inline void IncStackCount( int16_t srcloc ) { stackCount[uint16_t( srcloc )]++; }
+    tracy_force_inline bool DecStackCount( int16_t srcloc ) { return --stackCount[uint16_t( srcloc )] != 0; }
+};
+
+struct ZoneContext
+{
+    struct ZoneThreadData
+    {
+        tracy_force_inline ZoneEvent* Zone() const { return (ZoneEvent*)( _zone_thread >> 16 ); }
+        tracy_force_inline void SetZone( ZoneEvent* zone )
+        {
+            auto z64 = (uint64_t)zone;
+            assert( ( z64 & 0xFFFF000000000000 ) == 0 );
+            memcpy( ( (char*)&_zone_thread ) + 2, &z64, 4 );
+            memcpy( ( (char*)&_zone_thread ) + 6, ( (char*)&z64 ) + 4, 2 );
+        }
+        tracy_force_inline uint16_t Thread() const { return uint16_t( _zone_thread & 0xFFFF ); }
+        tracy_force_inline void SetThread( uint16_t thread ) { memcpy( &_zone_thread, &thread, 2 ); }
+
+        uint64_t _zone_thread;
+    };
+    enum
+    {
+        ZoneThreadDataSize = sizeof( ZoneThreadData )
+    };
+
+private:
+    struct SourceLocationZones
+    {
+        struct ZtdSort
+        {
+            bool operator()( const ZoneThreadData& lhs, const ZoneThreadData& rhs ) const { return lhs.Zone()->Start() < rhs.Zone()->Start(); }
+        };
+
+        SortedVector<ZoneThreadData, ZtdSort> zones;
+        int64_t min = std::numeric_limits<int64_t>::max();
+        int64_t max = std::numeric_limits<int64_t>::min();
+        int64_t total = 0;
+        double sumSq = 0;
+        int64_t selfMin = std::numeric_limits<int64_t>::max();
+        int64_t selfMax = std::numeric_limits<int64_t>::min();
+        int64_t selfTotal = 0;
+        size_t nonReentrantCount = 0;
+        int64_t nonReentrantMin = std::numeric_limits<int64_t>::max();
+        int64_t nonReentrantMax = std::numeric_limits<int64_t>::min();
+        int64_t nonReentrantTotal = 0;
+        unordered_flat_map<uint16_t, uint64_t> threadCnt;
+    };
+
+#ifndef TRACY_NO_STATISTICS
+    unordered_flat_map<int16_t, SourceLocationZones> sourceLocationZones;
+    bool sourceLocationZonesReady = false;
+#else
+    unordered_flat_map<int16_t, uint64_t> sourceLocationZonesCnt;
+#endif
+
+#ifndef TRACY_NO_STATISTICS
+    std::pair<uint16_t, SourceLocationZones*> srclocZonesLast = std::make_pair( 0, nullptr );
+#else
+    std::pair<uint16_t, uint64_t*> srclocCntLast = std::make_pair( 0, nullptr );
+#endif
+
+public:
+    StringIdx name;
+    std::string longName;
+    ZoneContextType type;
+    unordered_flat_map<uint64_t, ThreadData*> threadData;
+    Vector<ThreadData*> threads;
+    uint64_t count;
+    unordered_flat_map<int64_t, StringIdx> noteNames;
+    unordered_flat_map<uint16_t, unordered_flat_map<int64_t, double>> notes;
+
+    uint64_t threadCtx = 0;
+    ThreadData* threadCtxData = nullptr;
+    int64_t refTimeThread = 0;
+
+    const ThreadData* GetThreadData( uint64_t tid ) const;
+
+    SourceLocationZones& GetZonesForSourceLocation( int16_t srcloc );
+    const SourceLocationZones& GetZonesForSourceLocation( int16_t srcloc ) const;
+    const unordered_flat_map<int16_t, SourceLocationZones>& GetSourceLocationZones() const { return sourceLocationZones; }
+    bool AreSourceLocationZonesReady() const { return sourceLocationZonesReady; }
+    void SetSourceLocationZonesReady() { sourceLocationZonesReady = true; }
+
+#ifndef TRACY_NO_STATISTICS
+    SourceLocationZones* GetSourceLocationZones( uint16_t srcloc )
+    {
+        if( srclocZonesLast.first == srcloc ) return srclocZonesLast.second;
+        return GetSourceLocationZonesReal( srcloc );
+    }
+    SourceLocationZones* GetSourceLocationZonesReal( uint16_t srcloc );
+    void InitSourceLocationZones( uint16_t srcloc );
+#else
+    uint64_t* GetSourceLocationZonesCnt( uint16_t srcloc )
+    {
+        if( srclocCntLast.first == srcloc ) return srclocCntLast.second;
+        return GetSourceLocationZonesCntReal( srcloc );
+    }
+    uint64_t* GetSourceLocationZonesCntReal( uint16_t srcloc );
+    void InitSourceLocationZonesCnt( uint16_t srcloc );
+#endif
+
+    friend class Worker;
+};
+
+struct CPUZoneContext : public ZoneContext
+{
+    CPUZoneContext() { type = ZoneContextType::CPU; }
+};
+
+struct CPUThreadData : public ThreadData
+{
+#ifndef TRACY_NO_STATISTICS
+    Vector<GhostZone> ghostZones;
+    uint64_t ghostIdx;
+    SortedVector<SampleData, SampleDataSort> postponedSamples;
+#endif
+    Vector<SampleData> samples;
+    SampleData pendingSample;
+    Vector<SampleData> ctxSwitchSamples;
+    uint64_t kernelSampleCnt;
+};
+
+struct GpuCtxData : public ZoneContext
+{
+    int64_t timeDiff;
+    uint64_t thread;
+    float period;
+    bool hasPeriod;
+    bool hasCalibration;
+    int64_t calibratedGpuTime;
+    int64_t calibratedCpuTime;
+    double calibrationMod;
+    int64_t lastGpuTime;
+    uint64_t overflow;
+    uint32_t overflowMul;
+    short_ptr<ZoneEvent> query[64 * 1024];
+};
+
+enum
+{
+    GpuCtxDataSize = sizeof( GpuCtxData )
+};
+
+} // namespace tracy
+
+#endif /* TRACYCONTEXT_H */


### PR DESCRIPTION
This patch changes GPU to use ZoneEvents, to reduce code duplication and allow consistent feature support between GPU and CPU. The CPU is given a context similar to how GPUs have a context.

The following features now work with GPU events:
Trace Comparison
Zone Search
Zone Histogram
Flame Graph

Fixes #1109

I'm posting this for some feedback on the concept. There are still some major to do items for this:
* Testing with different platforms and build configurations.
* It should be possible to have the extra bytes in ZoneExtra only for GPU contexts. But this will need a whole lot of additional refactoring.
* File format reverse compatibility is broken, but can probably be fixed.

Also, this rework could allow more than one CPU context, which could be used to support cluster tracing.