### PR TITLE
Suppress variable shadowing warnings

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -1397,7 +1397,7 @@ void Function()
 }
 \end{lstlisting}
 
-This doesn't stop some compilers from dispensing \emph{fashion advice} about variable shadowing (as both \texttt{ZoneScoped} calls create a variable with the same name, with the inner scope one shadowing the one in the outer scope). If you want to avoid these warnings, you will also need to use the \texttt{ZoneNamed} macros.
+This doesn't stop some compilers from dispensing \emph{fashion advice} about variable shadowing (as both \texttt{ZoneScoped} calls create a variable with the same name, with the inner scope one shadowing the one in the outer scope). By default the produced warnings are suppressed when using clang, gcc or MSVC. This behavior can be opted out of by defining \texttt{TRACY\_ALLOW\_SHADOW\_WARNING}. An alternative approach avoids variable name shadowing by manually defining zone names with \texttt{ZoneNamed}. Using this approach requires using the V variants of zone macros like \texttt{ZoneTextV}.
 
 \subsubsection{Exiting program from within a zone}
 

--- a/public/tracy/Tracy.hpp
+++ b/public/tracy/Tracy.hpp
@@ -149,24 +149,26 @@
 #define ZoneTransientN( varname, name, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), TRACY_CALLSTACK, active )
 #define ZoneTransientNC( varname, name, color, active ) tracy::ScopedZone varname( TracyLine, TracyFile, strlen( TracyFile ), TracyFunction, strlen( TracyFunction ), name, strlen( name ), color, TRACY_CALLSTACK, active )
 
-#if defined(__clang__)
+#if defined(TRACY_ALLOW_SHADOW_WARNING)
+    #define SuppressVarShadowWarning(Expr) Expr
+#elif defined(__clang__)
     #define SuppressVarShadowWarning(Expr) \
-        _Pragma("clang diagnostic push"); \
-        _Pragma("clang diagnostic ignored \"-Wshadow\""); \
-        Expr; \
-        _Pragma("clang diagnostic pop");
+        _Pragma("clang diagnostic push") \
+        _Pragma("clang diagnostic ignored \"-Wshadow\"") \
+        Expr \
+        _Pragma("clang diagnostic pop")
 #elif defined(__GNU__)
     #define SuppressVarShadowWarning(Expr) \
-        _Pragma("GCC diagnostic push"); \
-        _Pragma("GCC diagnostic ignored \"-Wshadow\""); \
-        Expr; \
-        _Pragma("GCC diagnostic pop");
+        _Pragma("GCC diagnostic push") \
+        _Pragma("GCC diagnostic ignored \"-Wshadow\"") \
+        Expr \
+        _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER) 
     #define SuppressVarShadowWarning(Expr) \
-        _Pragma("warning(push)"); \
-        _Pragma("warning(disable : 4456)"); \
-        Expr; \
-        _Pragma("warning(pop)");
+        _Pragma("warning(push)") \
+        _Pragma("warning(disable : 4456)") \
+        Expr \
+        _Pragma("warning(pop)")
 #else
     #define SuppressVarShadowWarning(Expr) Expr
 #endif


### PR DESCRIPTION
This disables the warnings for MSVC, GCC and Clang in the ZoneScopedXX macros.

The warnings produced are both a false positive since they didn't find a bug *and* they don't happen in user written code, so the user couldn't even do much about it. The previous workaround of using ZoneNamedXXX is a poor solution since the Zone(Text|Name|etc.) macros all rely on the `___tracy_scoped_zone` name.

I hope this is a relatively uncontroversial change. I'm not sure if maybe some of the TracyC.h macros should also be changed. The documentation - which is refreshingly great btw - could probably stay as is since some non-standard compiler may still produce these warnings.