### PR TITLE
Document a classic mistake with Tracy's C GPU Zones API and `TRACY_ON_DEMAND`

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -2240,6 +2240,15 @@ CPU and GPU timestamps may be periodically resynchronized via the \texttt{\_\_\_
 
 To see how you should use this API, you should look at the reference implementation contained in API-specific C++ headers provided by Tracy. For example, to see how to write your instrumentation of OpenGL, you should closely follow the contents of the \texttt{TracyOpenGL.hpp} implementation.
 
+
+\begin{bclogo}[
+	noborder=true,
+	couleur=black!5,
+	logo=\bcbombe
+	]{Important}
+A common mistake is to skip the zone "\texttt{isActive}" check. When using \texttt{TRACY\_ON\_DEMAND}, you need to read the value of \texttt{TracyCIsConnected} once, and check the same value for both \newline \texttt{\_\_\_tracy\_emit\_gpu\_zone\_begin\_alloc} and \texttt{\_\_\_tracy\_emit\_gpu\_zone\_end}. Tracy may otherwise receive a zone end without a zone begin.
+\end{bclogo}
+
 \subsubsection{Fibers}
 
 Fibers are available in the C API through the \texttt{TracyCFiberEnter} and \texttt{TracyCFiberLeave} macros. To use them, you should observe the requirements listed in section~\ref{fibers}.


### PR DESCRIPTION
Some users were having issues with Tracy reporting a Zone End without a Zone Begin.
Issue is related to using GPU zones with tracy on demand, which requires checking the connection properly.

This adds a note in the manual, since fixing it in tracy is not possible without changing/breaking the API (we would need a shared context between gpu zone begin/end, as is done for normal zones with `TracyCZoneCtx`.

This may also be the origin of some of the reports in #864

Preview of the changes: 
<img width="1071" height="207" alt="image" src="https://github.com/user-attachments/assets/e662770a-c40d-4088-b0a0-b92f5b718916" />
