### PR TITLE
Merge ZoneEvent and GpuEvent (redo)

### DIFF
--- a/csvexport/src/csvexport.cpp
+++ b/csvexport/src/csvexport.cpp
@@ -299,9 +299,9 @@ int main(int argc, char** argv)
             const auto& zone_data = it->second;
             for (const auto& zone_thread_data : zone_data.zones)
             {
-                tracy::GpuEvent* gpu_event = zone_thread_data.Zone();
-                const auto start = gpu_event->GpuStart();
-                const auto end = gpu_event->GpuEnd();
+                auto& gpu_event = worker.GetGpuExtra( *zone_thread_data.Zone() );
+                const auto start = gpu_event.GpuStart();
+                const auto end = gpu_event.GpuEnd();
 
                 values[2] = std::to_string( start );
 

--- a/profiler/src/profiler/TracyTimelineItemGpu.cpp
+++ b/profiler/src/profiler/TracyTimelineItemGpu.cpp
@@ -70,12 +70,12 @@ void TimelineItemGpu::HeaderTooltip( const char* label ) const
                 {
                     if( it->second.timeline.is_magic() )
                     {
-                        auto& tl = *(Vector<GpuEvent>*)&it->second.timeline;
-                        tid = m_worker.DecompressThread( tl.begin()->Thread() );
+                        auto& tl = *(Vector<ZoneEvent>*)&it->second.timeline;
+                        tid = m_worker.DecompressThread( m_worker.GetGpuExtra( *tl.begin() ).Thread() );
                     }
                     else
                     {
-                        tid = m_worker.DecompressThread( (*it->second.timeline.begin())->Thread() );
+                        tid = m_worker.DecompressThread( m_worker.GetGpuExtra( **it->second.timeline.begin() ).Thread() );
                     }
                 }
             }
@@ -147,11 +147,11 @@ int64_t TimelineItemGpu::RangeBegin() const
         int64_t t0;
         if( td.second.timeline.is_magic() )
         {
-            t0 = ((Vector<GpuEvent>*)&td.second.timeline)->front().GpuStart();
+            t0 = ((Vector<ZoneEvent>*)&td.second.timeline)->front().Start();
         }
         else
         {
-            t0 = td.second.timeline.front()->GpuStart();
+            t0 = td.second.timeline.front()->Start();
         }
         if( t0 >= 0 )
         {
@@ -169,21 +169,21 @@ int64_t TimelineItemGpu::RangeEnd() const
         int64_t t0;
         if( td.second.timeline.is_magic() )
         {
-            t0 = ((Vector<GpuEvent>*)&td.second.timeline)->front().GpuStart();
+            t0 = ((Vector<ZoneEvent>*)&td.second.timeline)->front().Start();
         }
         else
         {
-            t0 = td.second.timeline.front()->GpuStart();
+            t0 = td.second.timeline.front()->Start();
         }
         if( t0 >= 0 )
         {
             if( td.second.timeline.is_magic() )
             {
-                t = std::max( t, std::min( m_worker.GetLastTime(), m_worker.GetZoneEnd( ((Vector<GpuEvent>*)&td.second.timeline)->back() ) ) );
+                t = std::max( t, std::min( m_worker.GetLastTime(), m_worker.GetZoneEndGPU( ((Vector<ZoneEvent>*)&td.second.timeline)->back() ) ) );
             }
             else
             {
-                t = std::max( t, std::min( m_worker.GetLastTime(), m_worker.GetZoneEnd( *td.second.timeline.back() ) ) );
+                t = std::max( t, std::min( m_worker.GetLastTime(), m_worker.GetZoneEndGPU( *td.second.timeline.back() ) ) );
             }
         }
     }

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -344,8 +344,7 @@ private:
     void ShowZoneInfo( const ZoneEvent& ev );
     void ShowZoneInfo( const ZoneEventC ev, uint64_t thread );
 
-    void ZoneTooltip( const ZoneEvent& ev );
-    void ZoneTooltipGPU( const ZoneEventC ev );
+    void ZoneTooltip( const ZoneEventC ev );
     void CallstackTooltip( uint32_t idx );
     void CallstackTooltipContents( uint32_t idx );
     void CrashTooltip();
@@ -359,6 +358,7 @@ private:
     const ThreadData* GetZoneThreadData( const ZoneEvent& zone ) const;
     uint64_t GetZoneThread( const ZoneEvent& zone ) const;
     uint64_t GetZoneThreadGPU( const EventAdapter<true>& zone ) const;
+    uint64_t GetZoneThread( const ZoneEventC evC ) const;
     bool FindMatchingZone( int prev0, int prev1, int flags );
     const ZoneEvent* FindZoneAtTime( uint64_t thread, int64_t time ) const;
     uint64_t GetFrameNumber( const FrameData& fd, int i ) const;

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -255,7 +255,7 @@ private:
     void DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineDraw>& drawList, int offset, uint64_t tid, int maxDepth, double margin );
     void DrawThreadCropper( const int depth, const uint64_t tid, const float xPos, const float yPos, const float ostep, const float cropperWidth, const bool hasCtxSwitches );
     void DrawContextSwitchList( const TimelineContext& ctx, const std::vector<ContextSwitchDraw>& drawList, const Vector<ContextSwitchData>& ctxSwitch, int offset, int endOffset, bool isFiber );
-    int DispatchGpuZoneLevel( const Vector<short_ptr<GpuEvent>>& vec, bool hover, double pxns, int64_t nspx, const ImVec2& wpos, int offset, int depth, uint64_t thread, float yMin, float yMax, int64_t begin, int drift );
+    int DispatchGpuZoneLevel( const Vector<short_ptr<ZoneEvent>>& vec, bool hover, double pxns, int64_t nspx, const ImVec2& wpos, int offset, int depth, uint64_t thread, float yMin, float yMax, int64_t begin, int drift );
     template<typename Adapter, typename V>
     int DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx, const ImVec2& wpos, int offset, int depth, uint64_t thread, float yMin, float yMax, int64_t begin, int drift );
     template<typename Adapter, typename V>
@@ -333,21 +333,21 @@ private:
     uint32_t GetSrcLocColor( const SourceLocation& srcloc, int depth );
     uint32_t GetRawSrcLocColor( const SourceLocation& srcloc, int depth );
     uint32_t GetZoneColor( const ZoneEvent& ev, uint64_t thread, int depth );
-    uint32_t GetZoneColor( const GpuEvent& ev );
+    uint32_t GetZoneColor( const ZoneEvent& ev );
     ZoneColorData GetZoneColorData( const ZoneEvent& ev, uint64_t thread, int depth, uint32_t inheritedColor );
-    ZoneColorData GetZoneColorData( const GpuEvent& ev );
+    ZoneColorData GetZoneColorData( const ZoneEvent& ev );
 
     void ZoomToZone( const ZoneEvent& ev );
-    void ZoomToZone( const GpuEvent& ev );
+    void ZoomToZoneGPU( const ZoneEvent& ev );
     void ZoomToPrevFrame();
     void ZoomToNextFrame();
     void CenterAtTime( int64_t t );
 
     void ShowZoneInfo( const ZoneEvent& ev );
-    void ShowZoneInfo( const GpuEvent& ev, uint64_t thread );
+    void ShowZoneInfo( const ZoneEvent& ev, uint64_t thread );
 
     void ZoneTooltip( const ZoneEvent& ev );
-    void ZoneTooltip( const GpuEvent& ev );
+    void ZoneTooltipGPU( const ZoneEvent& ev );
     void CallstackTooltip( uint32_t idx );
     void CallstackTooltipContents( uint32_t idx );
     void CrashTooltip();
@@ -357,11 +357,11 @@ private:
     const ZoneEvent* GetZoneChild( const ZoneEvent& zone, int64_t time ) const;
     bool IsZoneReentry( const ZoneEvent& zone ) const;
     bool IsZoneReentry( const ZoneEvent& zone, uint64_t tid ) const;
-    const GpuEvent* GetZoneParent( const GpuEvent& zone ) const;
+    const ZoneEvent* GetZoneParentGPU( const ZoneEvent& zone ) const;
     const ThreadData* GetZoneThreadData( const ZoneEvent& zone ) const;
     uint64_t GetZoneThread( const ZoneEvent& zone ) const;
-    uint64_t GetZoneThread( const GpuEvent& zone ) const;
-    const GpuCtxData* GetZoneCtx( const GpuEvent& zone ) const;
+    uint64_t GetZoneThreadGPU( const EventAdapter<true>& zone ) const;
+    const GpuCtxData* GetZoneCtx( const ZoneEvent& zone ) const;
     bool FindMatchingZone( int prev0, int prev1, int flags );
     const ZoneEvent* FindZoneAtTime( uint64_t thread, int64_t time ) const;
     uint64_t GetFrameNumber( const FrameData& fd, int i ) const;
@@ -379,12 +379,10 @@ private:
     void SmallCallstackButton( const char* name, uint32_t callstack, int& idx, bool tooltip = true );
     void DrawCallstackCalls( uint32_t callstack, uint16_t limit ) const;
     void SetViewToLastFrames();
-    int64_t GetZoneChildTime( const ZoneEvent& zone );
-    int64_t GetZoneChildTime( const GpuEvent& zone );
+    int64_t GetZoneChildTime( const ZoneEvent& zone, bool gpu );
     int64_t GetZoneChildTimeFast( const ZoneEvent& zone );
     int64_t GetZoneChildTimeFastClamped( const ZoneEvent& zone, int64_t t0, int64_t t1 );
-    int64_t GetZoneSelfTime( const ZoneEvent& zone );
-    int64_t GetZoneSelfTime( const GpuEvent& zone );
+    int64_t GetZoneSelfTime( const ZoneEvent& zone, bool gpu = false );
     bool GetZoneRunningTime( const ContextSwitch* ctx, const ZoneEvent& ev, int64_t& time, uint64_t& cnt );
     bool GetZoneRunningTime( const ContextSwitch* ctx, const ZoneEvent& ev, const RangeSlim& range, int64_t& time, uint64_t& cnt );
     const char* GetThreadContextData( uint64_t thread, bool& local, bool& untracked, const char*& program );
@@ -479,8 +477,8 @@ private:
     DecayValue<const MessageData*> m_msgHighlight = nullptr;
     DecayValue<uint32_t> m_lockHoverHighlight = InvalidId;
     DecayValue<const MessageData*> m_msgToFocus = nullptr;
-    const GpuEvent* m_gpuInfoWindow = nullptr;
-    const GpuEvent* m_gpuHighlight;
+    const ZoneEvent* m_gpuInfoWindow = nullptr;
+    const ZoneEvent* m_gpuHighlight;
     uint64_t m_gpuInfoWindowThread;
     uint32_t m_callstackInfoWindow = 0;
     int64_t m_memoryAllocInfoWindow = -1;
@@ -575,7 +573,7 @@ private:
     BuzzAnim<uint32_t> m_statBuzzAnim;
 
     Vector<const ZoneEvent*> m_zoneInfoStack;
-    Vector<const GpuEvent*> m_gpuInfoStack;
+    Vector<const ZoneEvent*> m_gpuInfoStack;
 
     SourceContents m_srcHintCache;
     std::unique_ptr<SourceView> m_sourceView;
@@ -877,8 +875,6 @@ private:
     struct {
         std::pair<const ZoneEvent*, int64_t> zoneSelfTime = { nullptr, 0 };
         std::pair<const ZoneEvent*, int64_t> zoneSelfTime2 = { nullptr, 0 };
-        std::pair<const GpuEvent*, int64_t> gpuSelfTime = { nullptr, 0 };
-        std::pair<const GpuEvent*, int64_t> gpuSelfTime2 = { nullptr, 0 };
     } m_cache;
 
     struct {

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -332,10 +332,8 @@ private:
     uint32_t GetThreadColor( uint64_t thread, int depth );
     uint32_t GetSrcLocColor( const SourceLocation& srcloc, int depth );
     uint32_t GetRawSrcLocColor( const SourceLocation& srcloc, int depth );
-    uint32_t GetZoneColor( const ZoneEvent& ev, uint64_t thread, int depth );
-    uint32_t GetZoneColor( const ZoneEvent& ev );
-    ZoneColorData GetZoneColorData( const ZoneEvent& ev, uint64_t thread, int depth, uint32_t inheritedColor );
-    ZoneColorData GetZoneColorData( const ZoneEvent& ev );
+    uint32_t GetZoneColor( const ZoneEventC ev, uint64_t thread, int depth );
+    ZoneColorData GetZoneColorData( const ZoneEventC ev, uint64_t thread, int depth, uint32_t inheritedColor );
 
     void ZoomToZone( const ZoneEvent& ev );
     void ZoomToZoneGPU( const ZoneEventC ev );

--- a/profiler/src/profiler/TracyView_FindZone.cpp
+++ b/profiler/src/profiler/TracyView_FindZone.cpp
@@ -230,7 +230,7 @@ void View::DrawZoneList( int id, const Vector<short_ptr<ZoneEvent>>& zones )
                 {
                     ZoomToZone( *ev );
                 }
-                ZoneTooltip( *ev );
+                ZoneTooltip( { ev, nullptr } );
                 m_zoneHover2 = ev;
             }
 

--- a/profiler/src/profiler/TracyView_GpuTimeline.cpp
+++ b/profiler/src/profiler/TracyView_GpuTimeline.cpp
@@ -162,7 +162,7 @@ int View::DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
         const auto zoneThread = ctx->thread != 0 ? ctx->thread : m_worker.DecompressThread( ev.Thread() );
         if( zsz < MinVisSize )
         {
-            const auto color = GetZoneColor( ev );
+            const auto color = GetZoneColor( { &ev.event, ctx }, zoneThread, depth );
             const auto MinVisNs = MinVisSize * nspx;
             int num = 0;
             const auto px0 = ( start - m_vd.zvStart ) * pxns;
@@ -242,7 +242,7 @@ int View::DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
             const auto pr1 = ( end - m_vd.zvStart ) * pxns;
             const auto px0 = std::max( pr0, -10.0 );
             const auto px1 = std::max( { std::min( pr1, double( w + 10 ) ), px0 + pxns * 0.5, px0 + MinVisSize } );
-            const auto zoneColor = GetZoneColorData( ev );
+            const auto zoneColor = GetZoneColorData( { &ev.event, ctx }, zoneThread, depth, 0 );
             draw->AddRectFilled( wpos + ImVec2( px0, offset ), wpos + ImVec2( px1, offset + tsz.y ), zoneColor.color );
             if( zoneColor.highlight )
             {

--- a/profiler/src/profiler/TracyView_GpuTimeline.cpp
+++ b/profiler/src/profiler/TracyView_GpuTimeline.cpp
@@ -203,7 +203,7 @@ int View::DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
                 }
                 else
                 {
-                    ZoneTooltipGPU( { &ev.event, ctx } );
+                    ZoneTooltip( { &ev.event, ctx } );
 
                     if( IsMouseClicked( 2 ) && rend - start > 0 )
                     {
@@ -288,7 +288,7 @@ int View::DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
 
             if( hover && ImGui::IsMouseHoveringRect( wpos + ImVec2( px0, offset ), wpos + ImVec2( px1, offset + tsz.y + 1 ) ) )
             {
-                ZoneTooltipGPU( { &ev.event, ctx } );
+                ZoneTooltip( { &ev.event, ctx } );
 
                 if( !m_zoomAnim.active && IsMouseClicked( 2 ) )
                 {

--- a/profiler/src/profiler/TracyView_GpuTimeline.cpp
+++ b/profiler/src/profiler/TracyView_GpuTimeline.cpp
@@ -40,10 +40,10 @@ bool View::DrawGpu( const TimelineContext& ctx, const GpuCtxData& gpu, int& offs
         assert( !tl.empty() );
         if( tl.is_magic() )
         {
-            auto& tlm = *(Vector<GpuEvent>*)&tl;
-            if( tlm.front().GpuStart() >= 0 )
+            auto& tlm = *(Vector<ZoneEvent>*)&tl;
+            if( tlm.front().Start() >= 0 )
             {
-                const auto begin = tlm.front().GpuStart();
+                const auto begin = tlm.front().Start();
                 const auto drift = GpuDrift( &gpu );
                 if( !singleThread ) offset += sstep;
                 const auto partDepth = DispatchGpuZoneLevel( tl, hover, pxns, int64_t( nspx ), wpos, offset, 0, gpu.thread, yMin, yMax, begin, drift );
@@ -68,9 +68,9 @@ bool View::DrawGpu( const TimelineContext& ctx, const GpuCtxData& gpu, int& offs
         }
         else
         {
-            if( tl.front()->GpuStart() >= 0 )
+            if( tl.front()->Start() >= 0 )
             {
-                const auto begin = tl.front()->GpuStart();
+                const auto begin = tl.front()->Start();
                 const auto drift = GpuDrift( &gpu );
                 if( !singleThread ) offset += sstep;
                 const auto partDepth = DispatchGpuZoneLevel( tl, hover, pxns, int64_t( nspx ), wpos, offset, 0, gpu.thread, yMin, yMax, begin, drift );
@@ -97,7 +97,7 @@ bool View::DrawGpu( const TimelineContext& ctx, const GpuCtxData& gpu, int& offs
     return depth != 0;
 }
 
-int View::DispatchGpuZoneLevel( const Vector<short_ptr<GpuEvent>>& vec, bool hover, double pxns, int64_t nspx, const ImVec2& wpos, int _offset, int depth, uint64_t thread, float yMin, float yMax, int64_t begin, int drift )
+int View::DispatchGpuZoneLevel( const Vector<short_ptr<ZoneEvent>>& vec, bool hover, double pxns, int64_t nspx, const ImVec2& wpos, int _offset, int depth, uint64_t thread, float yMin, float yMax, int64_t begin, int drift )
 {
     const auto ty = ImGui::GetTextLineHeight();
     const auto ostep = ty + 1;
@@ -108,22 +108,22 @@ int View::DispatchGpuZoneLevel( const Vector<short_ptr<GpuEvent>>& vec, bool hov
     {
         if( vec.is_magic() )
         {
-            return DrawGpuZoneLevel<VectorAdapterDirect<GpuEvent>>( *(Vector<GpuEvent>*)&vec, hover, pxns, nspx, wpos, _offset, depth, thread, yMin, yMax, begin, drift );
+            return DrawGpuZoneLevel<VectorAdapterDirect<ZoneEvent>>( *(Vector<ZoneEvent>*)&vec, hover, pxns, nspx, wpos, _offset, depth, thread, yMin, yMax, begin, drift );
         }
         else
         {
-            return DrawGpuZoneLevel<VectorAdapterPointer<GpuEvent>>( vec, hover, pxns, nspx, wpos, _offset, depth, thread, yMin, yMax, begin, drift );
+            return DrawGpuZoneLevel<VectorAdapterPointer<ZoneEvent>>( vec, hover, pxns, nspx, wpos, _offset, depth, thread, yMin, yMax, begin, drift );
         }
     }
     else
     {
         if( vec.is_magic() )
         {
-            return SkipGpuZoneLevel<VectorAdapterDirect<GpuEvent>>( *(Vector<GpuEvent>*)&vec, hover, pxns, nspx, wpos, _offset, depth, thread, yMin, yMax, begin, drift );
+            return SkipGpuZoneLevel<VectorAdapterDirect<ZoneEvent>>( *(Vector<ZoneEvent>*)&vec, hover, pxns, nspx, wpos, _offset, depth, thread, yMin, yMax, begin, drift );
         }
         else
         {
-            return SkipGpuZoneLevel<VectorAdapterPointer<GpuEvent>>( vec, hover, pxns, nspx, wpos, _offset, depth, thread, yMin, yMax, begin, drift );
+            return SkipGpuZoneLevel<VectorAdapterPointer<ZoneEvent>>( vec, hover, pxns, nspx, wpos, _offset, depth, thread, yMin, yMax, begin, drift );
         }
     }
 }
@@ -132,14 +132,14 @@ template<typename Adapter, typename V>
 int View::DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx, const ImVec2& wpos, int _offset, int depth, uint64_t thread, float yMin, float yMax, int64_t begin, int drift )
 {
     // cast to uint64_t, so that unended zones (end = -1) are still drawn
-    auto it = std::lower_bound( vec.begin(), vec.end(), std::max<int64_t>( 0, m_vd.zvStart ), [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).GpuEnd(), begin, drift ) < (uint64_t)r; } );
+    auto it = std::lower_bound( vec.begin(), vec.end(), std::max<int64_t>( 0, m_vd.zvStart ), [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).End(), begin, drift ) < (uint64_t)r; } );
     if( it == vec.end() ) return depth;
 
     Adapter a;
 
-    const auto zitend = std::lower_bound( it, vec.end(), std::max<int64_t>( 0, m_vd.zvEnd ), [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).GpuStart(), begin, drift ) < (uint64_t)r; } );
+    const auto zitend = std::lower_bound( it, vec.end(), std::max<int64_t>( 0, m_vd.zvEnd ), [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).Start(), begin, drift ) < (uint64_t)r; } );
     if( it == zitend ) return depth;
-    if( AdjustGpuTime( a(*(zitend-1)).GpuEnd(), begin, drift ) < m_vd.zvStart ) return depth;
+    if( AdjustGpuTime( a(*(zitend-1)).End(), begin, drift ) < m_vd.zvStart ) return depth;
 
     const auto w = ImGui::GetContentRegionAvail().x - 1;
     const auto ty = ImGui::GetTextLineHeight();
@@ -153,8 +153,8 @@ int View::DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
 
     while( it < zitend )
     {
-        auto& ev = a(*it);
-        auto end = m_worker.GetZoneEnd( ev );
+        auto& ev = m_worker.GetGpuExtra(a(*it));
+        auto end = m_worker.GetZoneEndGPU( ev );
         if( end == std::numeric_limits<int64_t>::max() ) break;
         const auto start = AdjustGpuTime( ev.GpuStart(), begin, drift );
         end = AdjustGpuTime( end, begin, drift );
@@ -171,11 +171,11 @@ int View::DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
             for(;;)
             {
                 const auto prevIt = it;
-                it = std::lower_bound( it, zitend, std::max<int64_t>( 0, nextTime ), [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).GpuEnd(), begin, drift ) < (uint64_t)r; } );
+                it = std::lower_bound( it, zitend, std::max<int64_t>( 0, nextTime ), [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).End(), begin, drift ) < (uint64_t)r; } );
                 if( it == prevIt ) ++it;
                 num += std::distance( prevIt, it );
                 if( it == zitend ) break;
-                const auto nend = AdjustGpuTime( m_worker.GetZoneEnd( a(*it) ), begin, drift );
+                const auto nend = AdjustGpuTime( m_worker.GetZoneEndGPU( a(*it) ), begin, drift );
                 const auto nsnext = nend - m_vd.zvStart;
                 if( nsnext < 0 || nsnext - px1ns >= MinVisNs * 2 ) break;
                 px1ns = nsnext;
@@ -203,11 +203,11 @@ int View::DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
                 else
                 {
                     const auto zoneThread = thread != 0 ? thread : m_worker.DecompressThread( ev.Thread() );
-                    ZoneTooltip( ev );
+                    ZoneTooltipGPU( ev );
 
                     if( IsMouseClicked( 2 ) && rend - start > 0 )
                     {
-                        ZoomToZone( ev );
+                        ZoomToZoneGPU( ev );
                     }
                     if( IsMouseClicked( 0 ) )
                     {
@@ -288,12 +288,12 @@ int View::DrawGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
 
             if( hover && ImGui::IsMouseHoveringRect( wpos + ImVec2( px0, offset ), wpos + ImVec2( px1, offset + tsz.y + 1 ) ) )
             {
-                const auto zoneThread = thread != 0 ? thread : m_worker.DecompressThread( ev.Thread() );
-                ZoneTooltip( ev );
+                const auto zoneThread = thread != 0 ? thread : m_worker.DecompressThread( ev.thread );
+                ZoneTooltipGPU( ev );
 
                 if( !m_zoomAnim.active && IsMouseClicked( 2 ) )
                 {
-                    ZoomToZone( ev );
+                    ZoomToZoneGPU( ev );
                 }
                 if( IsMouseClicked( 0 ) )
                 {
@@ -315,14 +315,14 @@ template<typename Adapter, typename V>
 int View::SkipGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx, const ImVec2& wpos, int _offset, int depth, uint64_t thread, float yMin, float yMax, int64_t begin, int drift )
 {
     // cast to uint64_t, so that unended zones (end = -1) are still drawn
-    auto it = std::lower_bound( vec.begin(), vec.end(), std::max<int64_t>( 0, m_vd.zvStart ), [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).GpuEnd(), begin, drift ) < (uint64_t)r; } );
+    auto it = std::lower_bound( vec.begin(), vec.end(), std::max<int64_t>( 0, m_vd.zvStart ), [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).End(), begin, drift ) < (uint64_t)r; } );
     if( it == vec.end() ) return depth;
 
     Adapter a;
 
-    const auto zitend = std::lower_bound( it, vec.end(), std::max<int64_t>( 0, m_vd.zvEnd ), [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).GpuStart(), begin, drift ) < (uint64_t)r; } );
+    const auto zitend = std::lower_bound( it, vec.end(), std::max<int64_t>( 0, m_vd.zvEnd ), [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).Start(), begin, drift ) < (uint64_t)r; } );
     if( it == zitend ) return depth;
-    if( AdjustGpuTime( a(*(zitend-1)).GpuEnd(), begin, drift ) < m_vd.zvStart ) return depth;
+    if( AdjustGpuTime( a(*(zitend-1)).End(), begin, drift ) < m_vd.zvStart ) return depth;
 
     depth++;
     int maxdepth = depth;
@@ -330,9 +330,9 @@ int View::SkipGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
     while( it < zitend )
     {
         auto& ev = a(*it);
-        auto end = m_worker.GetZoneEnd( ev );
+        auto end = m_worker.GetZoneEndGPU( ev );
         if( end == std::numeric_limits<int64_t>::max() ) break;
-        const auto start = AdjustGpuTime( ev.GpuStart(), begin, drift );
+        const auto start = AdjustGpuTime( ev.Start(), begin, drift );
         end = AdjustGpuTime( end, begin, drift );
         const auto zsz = std::max( ( end - start ) * pxns, pxns * 0.5 );
         if( zsz < MinVisSize )
@@ -343,10 +343,10 @@ int View::SkipGpuZoneLevel( const V& vec, bool hover, double pxns, int64_t nspx,
             for(;;)
             {
                 const auto prevIt = it;
-                it = std::lower_bound( it, zitend, nextTime, [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).GpuEnd(), begin, drift ) < (uint64_t)r; } );
+                it = std::lower_bound( it, zitend, nextTime, [begin, drift] ( const auto& l, const auto& r ) { Adapter a; return (uint64_t)AdjustGpuTime( a(l).End(), begin, drift ) < (uint64_t)r; } );
                 if( it == prevIt ) ++it;
                 if( it == zitend ) break;
-                const auto nend = AdjustGpuTime( m_worker.GetZoneEnd( a(*it) ), begin, drift );
+                const auto nend = AdjustGpuTime( m_worker.GetZoneEndGPU( a(*it) ), begin, drift );
                 const auto nsnext = nend - m_vd.zvStart;
                 if( nsnext - px1ns >= MinVisNs * 2 ) break;
                 px1ns = nsnext;

--- a/profiler/src/profiler/TracyView_Memory.cpp
+++ b/profiler/src/profiler/TracyView_Memory.cpp
@@ -618,7 +618,7 @@ void View::DrawMemoryAllocWindow()
                 {
                     ZoomToZone( *zoneAlloc );
                 }
-                ZoneTooltip( *zoneAlloc );
+                ZoneTooltip( { zoneAlloc, nullptr } );
             }
         }
 
@@ -643,7 +643,7 @@ void View::DrawMemoryAllocWindow()
                     {
                         ZoomToZone( *zoneFree );
                     }
-                    ZoneTooltip( *zoneFree );
+                    ZoneTooltip( { zoneFree, nullptr } );
                 }
                 if( zoneAlloc == zoneFree )
                 {
@@ -833,7 +833,7 @@ void View::ListMemData( std::vector<const MemEvent*>& vec, const std::function<v
                         {
                             ZoomToZone( *zone );
                         }
-                        ZoneTooltip( *zone );
+                        ZoneTooltip( { zone, nullptr } );
                     }
                 }
                 ImGui::TableNextColumn();
@@ -877,7 +877,7 @@ void View::ListMemData( std::vector<const MemEvent*>& vec, const std::function<v
                             {
                                 ZoomToZone( *zoneFree );
                             }
-                            ZoneTooltip( *zoneFree );
+                            ZoneTooltip( { zoneFree, nullptr } );
                         }
                     }
                 }

--- a/profiler/src/profiler/TracyView_Navigation.cpp
+++ b/profiler/src/profiler/TracyView_Navigation.cpp
@@ -10,11 +10,12 @@ void View::ZoomToZone( const ZoneEvent& ev )
     ZoomToRange( ev.Start(), end );
 }
 
-void View::ZoomToZoneGPU( const ZoneEvent& ev )
+void View::ZoomToZoneGPU( const ZoneEventC evC )
 {
+    auto& ev = *evC.event;
+    auto ctx = evC.ctx;
     const auto end = m_worker.GetZoneEndGPU( ev );
     if( end - ev.Start() <= 0 ) return;
-    auto ctx = GetZoneCtx( ev );
     if( !ctx )
     {
         ZoomToRange( ev.Start(), end );

--- a/profiler/src/profiler/TracyView_Navigation.cpp
+++ b/profiler/src/profiler/TracyView_Navigation.cpp
@@ -10,30 +10,31 @@ void View::ZoomToZone( const ZoneEvent& ev )
     ZoomToRange( ev.Start(), end );
 }
 
-void View::ZoomToZone( const GpuEvent& ev )
+void View::ZoomToZoneGPU( const ZoneEvent& ev )
 {
-    const auto end = m_worker.GetZoneEnd( ev );
-    if( end - ev.GpuStart() <= 0 ) return;
+    const auto end = m_worker.GetZoneEndGPU( ev );
+    if( end - ev.Start() <= 0 ) return;
     auto ctx = GetZoneCtx( ev );
     if( !ctx )
     {
-        ZoomToRange( ev.GpuStart(), end );
+        ZoomToRange( ev.Start(), end );
     }
     else
     {
-        const auto td = ctx->threadData.size() == 1 ? ctx->threadData.begin() : ctx->threadData.find( m_worker.DecompressThread( ev.Thread() ) );
+        auto thread = m_worker.DecompressThread( m_worker.GetGpuExtra(ev).thread );
+        const auto td = ctx->threadData.size() == 1 ? ctx->threadData.begin() : ctx->threadData.find( thread );
         assert( td != ctx->threadData.end() );
         int64_t begin;
         if( td->second.timeline.is_magic() )
         {
-            begin = ((Vector<GpuEvent>*)&td->second.timeline)->front().GpuStart();
+            begin = ((Vector<ZoneEvent>*)&td->second.timeline)->front().Start();
         }
         else
         {
-            begin = td->second.timeline.front()->GpuStart();
+            begin = td->second.timeline.front()->Start();
         }
         const auto drift = GpuDrift( ctx );
-        ZoomToRange( AdjustGpuTime( ev.GpuStart(), begin, drift ), AdjustGpuTime( end, begin, drift ) );
+        ZoomToRange( AdjustGpuTime( ev.Start(), begin, drift ), AdjustGpuTime( end, begin, drift ) );
     }
 }
 

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -161,10 +161,10 @@ void View::DrawOptions()
                             size_t lastidx = 0;
                             if( timeline.is_magic() )
                             {
-                                auto& tl = *((Vector<GpuEvent>*)&timeline);
+                                auto& tl = *( (Vector<ZoneEvent>*)&timeline );
                                 for( size_t j=tl.size()-1; j > 0; j-- )
                                 {
-                                    if( tl[j].GpuEnd() >= 0 )
+                                    if( tl[j].End() >= 0 )
                                     {
                                         lastidx = j;
                                         break;
@@ -175,7 +175,7 @@ void View::DrawOptions()
                             {
                                 for( size_t j=timeline.size()-1; j > 0; j-- )
                                 {
-                                    if( timeline[j]->GpuEnd() >= 0 )
+                                    if( timeline[j]->End() >= 0 )
                                     {
                                         lastidx = j;
                                         break;
@@ -191,14 +191,14 @@ void View::DrawOptions()
                             size_t idx = 0;
                             if( timeline.is_magic() )
                             {
-                                auto& tl = *((Vector<GpuEvent>*)&timeline);
+                                auto& tl = *( (Vector<ZoneEvent>*)&timeline );
                                 do
                                 {
                                     const auto p0 = dist( gen );
                                     const auto p1 = dist( gen );
                                     if( p0 != p1 )
                                     {
-                                        slopes[idx++] = float( 1.0 - double( tl[p1].GpuStart() - tl[p0].GpuStart() ) / double( tl[p1].CpuStart() - tl[p0].CpuStart() ) );
+                                        slopes[idx++] = float( 1.0 - double( tl[p1].Start() - tl[p0].Start() ) / double( m_worker.GetGpuExtra( tl[p1] ).CpuStart() - m_worker.GetGpuExtra( tl[p0] ).CpuStart() ) );
                                     }
                                 }
                                 while( idx < NumSlopes );
@@ -211,7 +211,7 @@ void View::DrawOptions()
                                     const auto p1 = dist( gen );
                                     if( p0 != p1 )
                                     {
-                                        slopes[idx++] = float( 1.0 - double( timeline[p1]->GpuStart() - timeline[p0]->GpuStart() ) / double( timeline[p1]->CpuStart() - timeline[p0]->CpuStart() ) );
+                                        slopes[idx++] = float( 1.0 - double( timeline[p1]->Start() - timeline[p0]->Start() ) / double( m_worker.GetGpuExtra( *timeline[p1] ).CpuStart() - m_worker.GetGpuExtra( *timeline[p0] ).CpuStart() ) );
                                     }
                                 }
                                 while( idx < NumSlopes );

--- a/profiler/src/profiler/TracyView_Statistics.cpp
+++ b/profiler/src/profiler/TracyView_Statistics.cpp
@@ -364,8 +364,8 @@ void View::DrawStatistics()
                             for( auto& v : it->second.zones )
                             {
                                 auto& z = *v.Zone();
-                                const auto start = z.GpuStart();
-                                const auto end = z.GpuEnd();
+                                const auto start = z.Start();
+                                const auto end = z.End();
                                 if( start >= min && end <= max )
                                 {
                                     const auto zt = end - start;
@@ -403,8 +403,8 @@ void View::DrawStatistics()
                                 for( auto& v : it->second.zones )
                                 {
                                     auto& z = *v.Zone();
-                                    const auto start = z.GpuStart();
-                                    const auto end = z.GpuEnd();
+                                    const auto start = z.Start();
+                                    const auto end = z.End();
                                     if( start >= min && end <= max )
                                     {
                                         const auto zt = end - start;

--- a/profiler/src/profiler/TracyView_Timeline.cpp
+++ b/profiler/src/profiler/TracyView_Timeline.cpp
@@ -473,8 +473,9 @@ void View::DrawTimeline()
     }
     if( m_gpuInfoWindow )
     {
-        const auto px0 = ( m_gpuInfoWindow->CpuStart() - m_vd.zvStart ) * pxns;
-        const auto px1 = std::max( px0 + std::max( 1.0, pxns * 0.5 ), ( m_gpuInfoWindow->CpuEnd() - m_vd.zvStart ) * pxns );
+        const auto ex = m_worker.GetGpuExtra( *m_gpuInfoWindow );
+        const auto px0 = ( ex.CpuStart() - m_vd.zvStart ) * pxns;
+        const auto px1 = std::max( px0 + std::max( 1.0, pxns * 0.5 ), ( ex.CpuEnd() - m_vd.zvStart ) * pxns );
         draw->AddRectFilled( ImVec2( wpos.x + px0, linepos.y ), ImVec2( wpos.x + px1, linepos.y + lineh ), 0x2288DD88 );
         draw->AddRect( ImVec2( wpos.x + px0, linepos.y ), ImVec2( wpos.x + px1, linepos.y + lineh ), 0x4488DD88 );
     }

--- a/profiler/src/profiler/TracyView_Timeline.cpp
+++ b/profiler/src/profiler/TracyView_Timeline.cpp
@@ -473,7 +473,7 @@ void View::DrawTimeline()
     }
     if( m_gpuInfoWindow )
     {
-        const auto ex = m_worker.GetGpuExtra( *m_gpuInfoWindow );
+        const auto ex = m_worker.GetGpuExtra( *m_gpuInfoWindow.event );
         const auto px0 = ( ex.CpuStart() - m_vd.zvStart ) * pxns;
         const auto px1 = std::max( px0 + std::max( 1.0, pxns * 0.5 ), ( ex.CpuEnd() - m_vd.zvStart ) * pxns );
         draw->AddRectFilled( ImVec2( wpos.x + px0, linepos.y ), ImVec2( wpos.x + px1, linepos.y + lineh ), 0x2288DD88 );

--- a/profiler/src/profiler/TracyView_Utility.cpp
+++ b/profiler/src/profiler/TracyView_Utility.cpp
@@ -49,13 +49,13 @@ uint32_t View::GetSrcLocColor( const SourceLocation& srcloc, int depth )
     return GetRawSrcLocColor( srcloc, depth );
 }
 
-uint32_t View::GetZoneColor( const ZoneEvent& ev, uint64_t thread, int depth )
+uint32_t View::GetZoneColor( const ZoneEventC ev, uint64_t thread, int depth )
 {
     const auto sl = ev.SrcLoc();
     const auto& srcloc = m_worker.GetSourceLocation( sl );
     if( !m_vd.forceColors )
     {
-        if( m_worker.HasZoneExtra( ev ) )
+        if( m_worker.HasZoneExtra( *ev.event ) )
         {
             const auto custom_color = m_worker.GetZoneExtra( ev ).color.Val();
             if( custom_color != 0 ) return custom_color | 0xFF000000;
@@ -77,25 +77,18 @@ uint32_t View::GetZoneColor( const ZoneEvent& ev, uint64_t thread, int depth )
     }
 }
 
-uint32_t View::GetZoneColor( const ZoneEvent& ev )
-{
-    const auto& srcloc = m_worker.GetSourceLocation( ev.SrcLoc() );
-    const auto color = srcloc.color;
-    return color != 0 ? ( color | 0xFF000000 ) : 0xFF222288;
-}
-
-View::ZoneColorData View::GetZoneColorData( const ZoneEvent& ev, uint64_t thread, int depth, uint32_t inheritedColor )
+View::ZoneColorData View::GetZoneColorData( const ZoneEventC ev, uint64_t thread, int depth, uint32_t inheritedColor )
 {
     ZoneColorData ret;
     const auto& srcloc = ev.SrcLoc();
-    if( m_zoneInfoWindow == &ev )
+    if( m_zoneInfoWindow == ev.event )
     {
         ret.color = inheritedColor ? inheritedColor : GetZoneColor( ev, thread, depth );
         ret.accentColor = 0xFF44DD44;
         ret.thickness = 3.f;
         ret.highlight = true;
     }
-    else if( m_zoneHighlight == &ev )
+    else if( m_zoneHighlight == ev.event )
     {
         ret.color = inheritedColor ? inheritedColor : GetZoneColor( ev, thread, depth );
         ret.accentColor = 0xFF4444FF;
@@ -135,33 +128,6 @@ View::ZoneColorData View::GetZoneColorData( const ZoneEvent& ev, uint64_t thread
     }
     return ret;
 }
-
-View::ZoneColorData View::GetZoneColorData( const ZoneEvent& ev )
-{
-    ZoneColorData ret;
-    const auto color = GetZoneColor( ev );
-    ret.color = color;
-    if( m_gpuInfoWindow == &ev )
-    {
-        ret.accentColor = 0xFF44DD44;
-        ret.thickness = 3.f;
-        ret.highlight = true;
-    }
-    else if( m_gpuHighlight == &ev )
-    {
-        ret.accentColor = 0xFF4444FF;
-        ret.thickness = 3.f;
-        ret.highlight = true;
-    }
-    else
-    {
-        ret.accentColor = HighlightColor( color );
-        ret.thickness = 1.f;
-        ret.highlight = false;
-    }
-    return ret;
-}
-
 
 const ZoneEvent* View::FindZoneAtTime( uint64_t thread, int64_t time ) const
 {

--- a/profiler/src/profiler/TracyView_Utility.cpp
+++ b/profiler/src/profiler/TracyView_Utility.cpp
@@ -491,6 +491,11 @@ uint64_t View::GetZoneThreadGPU( const EventAdapter<true>& zone ) const
     }
 }
 
+uint64_t View::GetZoneThread( const ZoneEventC evC ) const
+{
+    return evC.IsGpu() ? GetZoneThreadGPU( m_worker.GetGpuExtra( *evC.event ) ) : GetZoneThread( *evC.event );
+}
+
 int64_t View::GetZoneChildTime( const ZoneEvent& zone, bool gpu )
 {
     int64_t time = 0;

--- a/profiler/src/profiler/TracyView_Utility.cpp
+++ b/profiler/src/profiler/TracyView_Utility.cpp
@@ -77,7 +77,7 @@ uint32_t View::GetZoneColor( const ZoneEvent& ev, uint64_t thread, int depth )
     }
 }
 
-uint32_t View::GetZoneColor( const GpuEvent& ev )
+uint32_t View::GetZoneColor( const ZoneEvent& ev )
 {
     const auto& srcloc = m_worker.GetSourceLocation( ev.SrcLoc() );
     const auto color = srcloc.color;
@@ -136,7 +136,7 @@ View::ZoneColorData View::GetZoneColorData( const ZoneEvent& ev, uint64_t thread
     return ret;
 }
 
-View::ZoneColorData View::GetZoneColorData( const GpuEvent& ev )
+View::ZoneColorData View::GetZoneColorData( const ZoneEvent& ev )
 {
     ZoneColorData ret;
     const auto color = GetZoneColor( ev );
@@ -395,23 +395,23 @@ bool View::IsZoneReentry( const ZoneEvent& zone, uint64_t tid ) const
     return false;
 }
 
-const GpuEvent* View::GetZoneParent( const GpuEvent& zone ) const
+const ZoneEvent* View::GetZoneParentGPU( const ZoneEvent& zone ) const
 {
     for( const auto& ctx : m_worker.GetGpuData() )
     {
         for( const auto& td : ctx->threadData )
         {
-            const GpuEvent* parent = nullptr;
-            const Vector<short_ptr<GpuEvent>>* timeline = &td.second.timeline;
+            const ZoneEvent* parent = nullptr;
+            const Vector<short_ptr<ZoneEvent>>* timeline = &td.second.timeline;
             if( timeline->empty() ) continue;
             for(;;)
             {
                 if( timeline->is_magic() )
                 {
-                    auto vec = (Vector<GpuEvent>*)timeline;
-                    auto it = std::upper_bound( vec->begin(), vec->end(), zone.GpuStart(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r.GpuStart(); } );
+                    auto vec = (Vector<ZoneEvent>*)timeline;
+                    auto it = std::upper_bound( vec->begin(), vec->end(), zone.Start(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r.Start(); } );
                     if( it != vec->begin() ) --it;
-                    if( zone.GpuEnd() >= 0 && it->GpuStart() > zone.GpuEnd() ) break;
+                    if( zone.End() >= 0 && it->Start() > zone.End() ) break;
                     if( it == &zone ) return parent;
                     if( it->Child() < 0 ) break;
                     parent = it;
@@ -419,9 +419,9 @@ const GpuEvent* View::GetZoneParent( const GpuEvent& zone ) const
                 }
                 else
                 {
-                    auto it = std::upper_bound( timeline->begin(), timeline->end(), zone.GpuStart(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r->GpuStart(); } );
+                    auto it = std::upper_bound( timeline->begin(), timeline->end(), zone.Start(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r->Start(); } );
                     if( it != timeline->begin() ) --it;
-                    if( zone.GpuEnd() >= 0 && (*it)->GpuStart() > zone.GpuEnd() ) break;
+                    if( zone.End() >= 0 && (*it)->Start() > zone.End() ) break;
                     if( *it == &zone ) return parent;
                     if( (*it)->Child() < 0 ) break;
                     parent = *it;
@@ -486,33 +486,33 @@ uint64_t View::GetZoneThread( const ZoneEvent& zone ) const
     return threadData ? threadData->id : 0;
 }
 
-uint64_t View::GetZoneThread( const GpuEvent& zone ) const
+uint64_t View::GetZoneThreadGPU( const EventAdapter<true>& zone ) const
 {
     if( zone.Thread() == 0 )
     {
         for( const auto& ctx : m_worker.GetGpuData() )
         {
             if ( ctx->threadData.size() != 1 ) continue;
-            const Vector<short_ptr<GpuEvent>>* timeline = &ctx->threadData.begin()->second.timeline;
+            const Vector<short_ptr<ZoneEvent>>* timeline = &ctx->threadData.begin()->second.timeline;
             if( timeline->empty() ) continue;
             for(;;)
             {
                 if( timeline->is_magic() )
                 {
-                    auto vec = (Vector<GpuEvent>*)timeline;
-                    auto it = std::upper_bound( vec->begin(), vec->end(), zone.GpuStart(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r.GpuStart(); } );
+                    auto vec = (Vector<ZoneEvent>*)timeline;
+                    auto it = std::upper_bound( vec->begin(), vec->end(), zone.GpuStart(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r.Start(); } );
                     if( it != vec->begin() ) --it;
-                    if( zone.GpuEnd() >= 0 && it->GpuStart() > zone.GpuEnd() ) break;
-                    if( it == &zone ) return ctx->thread;
+                    if( zone.GpuEnd() >= 0 && it->Start() > zone.GpuEnd() ) break;
+                    if( it == &zone.event ) return ctx->thread;
                     if( it->Child() < 0 ) break;
                     timeline = &m_worker.GetGpuChildren( it->Child() );
                 }
                 else
                 {
-                    auto it = std::upper_bound( timeline->begin(), timeline->end(), zone.GpuStart(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r->GpuStart(); } );
+                    auto it = std::upper_bound( timeline->begin(), timeline->end(), zone.GpuStart(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r->Start(); } );
                     if( it != timeline->begin() ) --it;
-                    if( zone.GpuEnd() >= 0 && (*it)->GpuStart() > zone.GpuEnd() ) break;
-                    if( *it == &zone ) return ctx->thread;
+                    if( zone.GpuEnd() >= 0 && (*it)->Start() > zone.GpuEnd() ) break;
+                    if( *it == &zone.event ) return ctx->thread;
                     if( (*it)->Child() < 0 ) break;
                     timeline = &m_worker.GetGpuChildren( (*it)->Child() );
                 }
@@ -526,31 +526,31 @@ uint64_t View::GetZoneThread( const GpuEvent& zone ) const
     }
 }
 
-const GpuCtxData* View::GetZoneCtx( const GpuEvent& zone ) const
+const GpuCtxData* View::GetZoneCtx( const ZoneEvent& zone ) const
 {
     for( const auto& ctx : m_worker.GetGpuData() )
     {
         for( const auto& td : ctx->threadData )
         {
-            const Vector<short_ptr<GpuEvent>>* timeline = &td.second.timeline;
+            const Vector<short_ptr<ZoneEvent>>* timeline = &td.second.timeline;
             if( timeline->empty() ) continue;
             for(;;)
             {
                 if( timeline->is_magic() )
                 {
-                    auto vec = (Vector<GpuEvent>*)timeline;
-                    auto it = std::upper_bound( vec->begin(), vec->end(), zone.GpuStart(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r.GpuStart(); } );
+                    auto vec = (Vector<ZoneEvent>*)timeline;
+                    auto it = std::upper_bound( vec->begin(), vec->end(), zone.Start(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r.Start(); } );
                     if( it != vec->begin() ) --it;
-                    if( zone.GpuEnd() >= 0 && it->GpuStart() > zone.GpuEnd() ) break;
+                    if( zone.End() >= 0 && it->Start() > zone.End() ) break;
                     if( it == &zone ) return ctx;
                     if( it->Child() < 0 ) break;
                     timeline = &m_worker.GetGpuChildren( it->Child() );
                 }
                 else
                 {
-                    auto it = std::upper_bound( timeline->begin(), timeline->end(), zone.GpuStart(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r->GpuStart(); } );
+                    auto it = std::upper_bound( timeline->begin(), timeline->end(), zone.Start(), [] ( const auto& l, const auto& r ) { return (uint64_t)l < (uint64_t)r->Start(); } );
                     if( it != timeline->begin() ) --it;
-                    if( zone.GpuEnd() >= 0 && (*it)->GpuStart() > zone.GpuEnd() ) break;
+                    if( zone.End() >= 0 && (*it)->Start() > zone.End() ) break;
                     if( *it == &zone ) return ctx;
                     if( (*it)->Child() < 0 ) break;
                     timeline = &m_worker.GetGpuChildren( (*it)->Child() );
@@ -561,12 +561,12 @@ const GpuCtxData* View::GetZoneCtx( const GpuEvent& zone ) const
     return nullptr;
 }
 
-int64_t View::GetZoneChildTime( const ZoneEvent& zone )
+int64_t View::GetZoneChildTime( const ZoneEvent& zone, bool gpu )
 {
     int64_t time = 0;
     if( zone.HasChildren() )
     {
-        auto& children = m_worker.GetZoneChildren( zone.Child() );
+        auto& children = gpu ?  m_worker.GetGpuChildren( zone.Child() ) : m_worker.GetZoneChildren( zone.Child() );
         if( children.is_magic() )
         {
             auto& vec = *(Vector<ZoneEvent>*)&children;
@@ -581,33 +581,6 @@ int64_t View::GetZoneChildTime( const ZoneEvent& zone )
             for( auto& v : children )
             {
                 const auto childSpan = std::max( int64_t( 0 ), v->End() - v->Start() );
-                time += childSpan;
-            }
-        }
-    }
-    return time;
-}
-
-int64_t View::GetZoneChildTime( const GpuEvent& zone )
-{
-    int64_t time = 0;
-    if( zone.Child() >= 0 )
-    {
-        auto& children = m_worker.GetGpuChildren( zone.Child() );
-        if( children.is_magic() )
-        {
-            auto& vec = *(Vector<GpuEvent>*)&children;
-            for( auto& v : vec )
-            {
-                const auto childSpan = std::max( int64_t( 0 ), v.GpuEnd() - v.GpuStart() );
-                time += childSpan;
-            }
-        }
-        else
-        {
-            for( auto& v : children )
-            {
-                const auto childSpan = std::max( int64_t( 0 ), v->GpuEnd() - v->GpuStart() );
                 time += childSpan;
             }
         }
@@ -681,30 +654,16 @@ int64_t View::GetZoneChildTimeFastClamped( const ZoneEvent& zone, int64_t t0, in
     return time;
 }
 
-int64_t View::GetZoneSelfTime( const ZoneEvent& zone )
+int64_t View::GetZoneSelfTime( const ZoneEvent& zone, bool gpu )
 {
     if( m_cache.zoneSelfTime.first == &zone ) return m_cache.zoneSelfTime.second;
     if( m_cache.zoneSelfTime2.first == &zone ) return m_cache.zoneSelfTime2.second;
-    const auto ztime = m_worker.GetZoneEnd( zone ) - zone.Start();
-    const auto selftime = ztime - GetZoneChildTime( zone );
+    const auto ztime = (gpu ? m_worker.GetZoneEndGPU( zone ) : m_worker.GetZoneEnd( zone ) ) - zone.Start();
+    const auto selftime = ztime - GetZoneChildTime( zone, gpu );
     if( zone.IsEndValid() )
     {
         m_cache.zoneSelfTime2 = m_cache.zoneSelfTime;
         m_cache.zoneSelfTime = std::make_pair( &zone, selftime );
-    }
-    return selftime;
-}
-
-int64_t View::GetZoneSelfTime( const GpuEvent& zone )
-{
-    if( m_cache.gpuSelfTime.first == &zone ) return m_cache.gpuSelfTime.second;
-    if( m_cache.gpuSelfTime2.first == &zone ) return m_cache.gpuSelfTime2.second;
-    const auto ztime = m_worker.GetZoneEnd( zone ) - zone.GpuStart();
-    const auto selftime = ztime - GetZoneChildTime( zone );
-    if( zone.GpuEnd() >= 0 )
-    {
-        m_cache.gpuSelfTime2 = m_cache.gpuSelfTime;
-        m_cache.gpuSelfTime = std::make_pair( &zone, selftime );
     }
     return selftime;
 }

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -310,7 +310,7 @@ void View::DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineD
                 }
                 else
                 {
-                    ZoneTooltip( ev );
+                    ZoneTooltip( { &ev, nullptr} );
 
                     if( IsMouseClicked( 2 ) && rend - ev.Start() > 0 )
                     {
@@ -384,7 +384,7 @@ void View::DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineD
 
             if( hover && ImGui::IsMouseHoveringRect( wpos + ImVec2( px0, offset ), wpos + ImVec2( px1, offset + tsz.y + 1 ) ) )
             {
-                ZoneTooltip( ev );
+                ZoneTooltip( { &ev, nullptr} );
                 if( IsMouseClickReleased( 1 ) ) m_setRangePopup = RangeSlim { ev.Start(), m_worker.GetZoneEnd( ev ), true };
 
                 if( !m_zoomAnim.active && IsMouseClicked( 2 ) )

--- a/profiler/src/profiler/TracyView_ZoneTimeline.cpp
+++ b/profiler/src/profiler/TracyView_ZoneTimeline.cpp
@@ -351,7 +351,7 @@ void View::DrawZoneList( const TimelineContext& ctx, const std::vector<TimelineD
             const auto pr1 = ( end - vStart ) * pxns;
             const auto zsz = std::max( pr1 - pr0, pxns * 0.5 );
 
-            const auto zoneColor = GetZoneColorData( ev, tid, v.depth, v.inheritedColor );
+            const auto zoneColor = GetZoneColorData( { &ev, nullptr }, tid, v.depth, v.inheritedColor );
             const char* zoneName = m_worker.GetZoneName( ev );
 
             auto tsz = ImGui::CalcTextSize( zoneName );

--- a/server/TracyEvent.hpp
+++ b/server/TracyEvent.hpp
@@ -801,6 +801,14 @@ struct ZoneEventC
 {
     tracy_force_inline ZoneEventC(const ZoneEvent* event, const GpuCtxData* ctx): event(event), ctx(ctx) {}
 
+    tracy_force_inline int64_t Start() const { return event->Start(); }
+    tracy_force_inline int64_t End() const { return event->End(); }
+    tracy_force_inline bool IsEndValid() const { return event->IsEndValid(); }
+    tracy_force_inline int16_t SrcLoc() const { return event->SrcLoc(); }
+    tracy_force_inline int32_t Child() const { return event->Child(); }
+    tracy_force_inline bool HasChildren() const { return event->HasChildren(); }
+    tracy_force_inline bool IsGpu() const { return ctx != nullptr; }
+
     tracy_force_inline operator bool() const { return event != nullptr; }
     tracy_force_inline bool operator==( const ZoneEventC& other ) const { return other.event == event; }
     tracy_force_inline bool operator==( const ZoneEvent* other ) const { return other == event; }

--- a/server/TracyEvent.hpp
+++ b/server/TracyEvent.hpp
@@ -797,6 +797,17 @@ struct GpuCtxData
 
 enum { GpuCtxDataSize = sizeof( GpuCtxData ) };
 
+struct ZoneEventC
+{
+    tracy_force_inline ZoneEventC(const ZoneEvent* event, const GpuCtxData* ctx): event(event), ctx(ctx) {}
+
+    tracy_force_inline operator bool() const { return event != nullptr; }
+    tracy_force_inline bool operator==( const ZoneEventC& other ) const { return other.event == event; }
+    tracy_force_inline bool operator==( const ZoneEvent* other ) const { return other == event; }
+
+    const ZoneEvent* event;
+    const GpuCtxData* ctx;
+};
 
 enum class PlotType : uint8_t
 {

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -2641,6 +2641,14 @@ const Worker::SourceLocationZones& Worker::GetZonesForSourceLocation( int16_t sr
     return it != m_data.sourceLocationZones.end() ? it->second : empty;
 }
 
+const Worker::SourceLocationZones& Worker::GetGpuZonesForSourceLocation( int16_t srcloc ) const
+{
+    assert( AreGpuSourceLocationZonesReady() );
+    static const SourceLocationZones empty;
+    auto it = m_data.gpuSourceLocationZones.find( srcloc );
+    return it != m_data.gpuSourceLocationZones.end() ? it->second : empty;
+}
+
 const SymbolStats* Worker::GetSymbolStats( uint64_t symAddr ) const
 {
     assert( AreCallstackSamplesReady() );

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -2359,7 +2359,7 @@ const uint64_t* Worker::GetInlineSymbolList( uint64_t sym, uint32_t len )
     return it;
 }
 
-int64_t Worker::GetZoneEndImpl( const ZoneEvent& ev, const Vector<Vector<short_ptr<ZoneEvent>>>& childArray )
+int64_t Worker::GetZoneEndImpl( const ZoneEvent& ev, const Vector<Vector<short_ptr<ZoneEvent>>>& childArray ) const
 {
     assert( !ev.IsEndValid() );
     auto ptr = &ev;

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -616,6 +616,7 @@ public:
 #ifndef TRACY_NO_STATISTICS
     SourceLocationZones& GetZonesForSourceLocation( int16_t srcloc );
     const SourceLocationZones& GetZonesForSourceLocation( int16_t srcloc ) const;
+    const SourceLocationZones& GetGpuZonesForSourceLocation( int16_t srcloc ) const;
     const unordered_flat_map<int16_t, SourceLocationZones>& GetSourceLocationZones() const { return m_data.sourceLocationZones; }
     const unordered_flat_map<int16_t, SourceLocationZones>& GetGpuSourceLocationZones() const { return m_data.gpuSourceLocationZones; }
     bool AreSourceLocationZonesReady() const { return m_data.sourceLocationZonesReady; }

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -579,6 +579,7 @@ public:
     //     before its children have ended).
     // GetZoneEndDirect() will only return zone's direct timing data, without looking at children.
     tracy_force_inline int64_t GetZoneEnd( const ZoneEvent& ev ) { return ev.IsEndValid() ? ev.End() : GetZoneEndImpl( ev, m_data.zoneChildren ); }
+    tracy_force_inline int64_t GetZoneEnd( const ZoneEventC ev ) const { return ev.IsEndValid() ? ev.End() : GetZoneEndImpl( *ev.event, ev.IsGpu() ? m_data.gpuChildren : m_data.zoneChildren ); }
     tracy_force_inline int64_t GetZoneEndGPU( const ZoneEvent& ev ) { return ev.IsEndValid() ? ev.End() : GetZoneEndImpl( ev, m_data.gpuChildren ); }
     static tracy_force_inline int64_t GetZoneEndDirect( const ZoneEvent& ev ) { return ev.IsEndValid() ? ev.End() : ev.Start(); }
 
@@ -606,6 +607,7 @@ public:
     tracy_force_inline const bool HasZoneExtra( const ZoneEvent& ev ) const { return ev.extra != 0; }
     tracy_force_inline const ZoneExtra& GetZoneExtra( const ZoneEvent& ev ) const { return m_data.zoneExtra[ev.extra]; }
     tracy_force_inline const EventAdapter<true> GetGpuExtra( const ZoneEvent& ev ) const { return { ev, m_data.gpuExtra[ev.extra] }; }
+    tracy_force_inline const ZoneExtra& GetZoneExtra( const ZoneEventC ev ) const { return ev.IsGpu() ? m_data.gpuExtra[ev.event->extra] : m_data.zoneExtra[ev.event->extra]; }
 
     std::vector<int16_t> GetMatchingSourceLocation( const char* query, bool ignoreCase ) const;
 
@@ -959,7 +961,7 @@ private:
     tracy_force_inline ZoneExtra& AllocZoneExtra( ZoneEvent& ev );
     tracy_force_inline ZoneExtra& RequestZoneExtra( ZoneEvent& ev );
 
-    int64_t GetZoneEndImpl( const ZoneEvent& ev, const Vector<Vector<short_ptr<ZoneEvent>>>& childArray );
+    int64_t GetZoneEndImpl( const ZoneEvent& ev, const Vector<Vector<short_ptr<ZoneEvent>>>& childArray ) const;
 
     void UpdateMbps( int64_t td );
 

--- a/server/TracyWorker.hpp
+++ b/server/TracyWorker.hpp
@@ -951,8 +951,7 @@ private:
     tracy_force_inline void ReadTimelineHaveSize( FileRead& f, ZoneEvent* zone, int64_t& refTime, int64_t& refGpuTime, int32_t& childIdx, uint64_t sz, bool hasQueryId );
 
 #ifndef TRACY_NO_STATISTICS
-    tracy_force_inline void ReconstructZoneStatistics( uint8_t* countMap, ZoneEvent& zone, uint16_t thread );
-    tracy_force_inline void ReconstructZoneStatistics( ZoneEvent& zone, uint16_t thread );
+    tracy_force_inline void ReconstructZoneStatistics( uint8_t* countMap, ZoneEvent& zone, uint16_t thread, bool is_gpu );
 #else
     tracy_force_inline void CountZoneStatistics( ZoneEvent* zone );
 #endif


### PR DESCRIPTION
This PR accomplishes part of what #1155 does with fewer changes.

The work is split across three changes:
* Replace GpuEvent with ZoneEvent: This is a smaller revision that accomplishes the removal of GpuEvent, while changing as little else as possible. It is hard to demonstrate the virtue of doing this without further changes; this patch does unify a few small functions.
* Eliminate the function GetZoneCtx: This function turns out to be unnecessary, this patch introduces a helper struct to carry around the context which is also used in the next patch.
* Merge the GetZoneColor functions: The GPU and CPU code is made to use the same code to determine zone color. The helper struct from the previous patch is used by the unified functions to distinguish CPU and GPU events. This allows GPU events to have a custom color (although the protocol doesn't allow it to be set yet).

Overall notes:
* The file format is not changed.
* The protocol is not changed.
* The UI is changed because GPU zones now appear as a different color.
* The original task of ensuring feature parity between GPU and CPU remains unfinished.
* Compared to the previous PR, the ZoneExtra data is expanded only for GPU, saving some memory. Also, the previous PR eliminated the thread field but this doesn't. That uses more memory but avoids having to go search for the thread.