### PR TITLE
fix window icon/dock integration with objc on macos

### DIFF
--- a/profiler/src/BackendGlfw.cpp
+++ b/profiler/src/BackendGlfw.cpp
@@ -246,9 +246,6 @@ void Backend::EndFrame()
 void Backend::SetIcon( uint8_t* data, int w, int h )
 {
 #ifdef __APPLE__
-    (void)data;
-    (void)w;
-    (void)h;
     EnsureMacAppRegistration();
     SetMacAppIcon();
 #else


### PR DESCRIPTION
glfw doesn't properly support cocoa, so we see this:
```
Error 65548: Cocoa: Regular windows do not have icons on macOS
```

so this fix adds proper support to set up dock icon on macos