### PR TITLE
Generate pkgconf file for tracy downstream users

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -220,7 +220,8 @@ endif
 pkg = import('pkgconfig')
 pkg.generate(tracy,
   extra_cflags : tracy_dep_compile_args,
-  requires     : tracy_public_deps)
+  requires     : tracy_public_deps,
+  libraries: [tracy])
 
 tracy_dep = declare_dependency(
     compile_args        : tracy_dep_compile_args,


### PR DESCRIPTION
This change makes Mason generate the `/lib/pkgconfig/tracy.pc` file for pkg-config. 
This allows authors of bindings in other languages to link to `tracy` without manually specifying library paths such as `/usr/local/`.

I'm not a C/C++ developer, so there might be trade-offs I'm not fully aware of. 
The change has been tested with Nix+Haskell, and the generated pkg-config file works as expected: see https://github.com/haskell-game/tracy-profiler/pull/10/files.
