### PR TITLE
fix CPUID parsing in TraceInfo

### DIFF
--- a/profiler/src/profiler/TracyView_TraceInfo.cpp
+++ b/profiler/src/profiler/TracyView_TraceInfo.cpp
@@ -899,8 +899,9 @@ void View::DrawInfo()
         const auto stepping = cpuId & 0xF;
         const auto baseModel = ( cpuId >> 4 ) & 0xF;
         const auto baseFamily = ( cpuId >> 8 ) & 0xF;
-        const auto extModel = ( cpuId >> 12 ) & 0xF;
-        const auto extFamily = ( cpuId >> 16 );
+        // 12-15 unused
+        const auto extModel = ( cpuId >> 16 ) & 0xF;
+        const auto extFamily = ( cpuId >> 20 ) & 0xFF;
 
         const uint32_t model = ( baseFamily == 6 || baseFamily == 15 ) ? ( ( extModel << 4 ) | baseModel ) : baseModel;
         const uint32_t family = baseFamily == 15 ? baseFamily + extFamily : baseFamily;


### PR DESCRIPTION
the extended model was reading from bits 12-15 instead of 16-19
the extended family was reading from bit 16 onwards without proper masking (so if there was data in the reserved space, it would've bled in) instead of bits 20-27

this caused incorrect CPU family/model display for modern AMD processors - for example, my AMD Ryzen 9 7900X would show "Family 181" instead of "Family 25"

<details>
<summary>misc. notes</summary>

technically, bits 12-13 are used by intel for their processor type field - but this is not really used

the reason why there's a hardcoded check for family 6 (as well as the obvious 15) is because Intel has been on family 6 for 30 years (though soon no longer! this will break then! 😹 it will be safe to add `|| 7` though )

</details>

before:
<img width="333" height="23" alt="image" src="https://github.com/user-attachments/assets/12c3b60f-0d21-4e7f-803e-a8a0c4049e4f" />

after:
<img width="362" height="31" alt="image" src="https://github.com/user-attachments/assets/819ef789-97f8-4fe9-946a-a4647a3d6d2a" />


fixes #1193