### PR TITLE
fix: GetDebugInfoDescriptor signature

### DIFF
--- a/public/libbacktrace/elf.cpp
+++ b/public/libbacktrace/elf.cpp
@@ -75,7 +75,7 @@ namespace tracy
 {
 
 #ifdef TRACY_DEBUGINFOD
-int GetDebugInfoDescriptor( const char* buildid_data, size_t buildid_size );
+int GetDebugInfoDescriptor( const char* buildid_data, size_t buildid_size, const char* filename );
 #endif
 
 #if !defined(HAVE_DECL_STRNLEN) || !HAVE_DECL_STRNLEN


### PR DESCRIPTION
Both the (only) call and definition of this function use the `filename` argument. It fixes a build failure I'm having.