### PR TITLE
Fix shadow error suppression on GCC

### DIFF
--- a/public/tracy/Tracy.hpp
+++ b/public/tracy/Tracy.hpp
@@ -157,7 +157,7 @@
         _Pragma("clang diagnostic ignored \"-Wshadow\"") \
         Expr \
         _Pragma("clang diagnostic pop")
-#elif defined(__GNU__)
+#elif defined(__GNUC__)
     #define SuppressVarShadowWarning(Expr) \
         _Pragma("GCC diagnostic push") \
         _Pragma("GCC diagnostic ignored \"-Wshadow\"") \


### PR DESCRIPTION
It looks like the actual macro defined by GCC is `__GNUC__`.

From my testing, `__GNU__` does not seem to be defined neither on my musl machine nor a Fedora Linux VM. I have no idea if it's a typo or set by specific libraries, but testing for `__GNUC__` actually suppresses shadowing errors on my end.