### PR TITLE
Fix error suppression macro

### DIFF
--- a/public/tracy/Tracy.hpp
+++ b/public/tracy/Tracy.hpp
@@ -155,19 +155,19 @@
     #define SuppressVarShadowWarning(Expr) \
         _Pragma("clang diagnostic push") \
         _Pragma("clang diagnostic ignored \"-Wshadow\"") \
-        Expr \
+        Expr; \
         _Pragma("clang diagnostic pop")
 #elif defined(__GNUC__)
     #define SuppressVarShadowWarning(Expr) \
         _Pragma("GCC diagnostic push") \
         _Pragma("GCC diagnostic ignored \"-Wshadow\"") \
-        Expr \
+        Expr; \
         _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER) 
     #define SuppressVarShadowWarning(Expr) \
         _Pragma("warning(push)") \
         _Pragma("warning(disable : 4456)") \
-        Expr \
+        Expr; \
         _Pragma("warning(pop)")
 #else
     #define SuppressVarShadowWarning(Expr) Expr


### PR DESCRIPTION
My previous fix triggered another issue: apparently at least GCC expects the `_Pragma` operator to be placed in its own statement (after a semicolon). The current macro simply dumped the expression and the _Pragma together, triggering an error. Putting a semicolon after `Expr` fixes the issue (actually double-checked after a `git clean -fdx`), although slightly changing the API (the semicolon after the wrapped macros is now optional).

---

I'm really sorry for missing this issue before filing the past PR. I had a local workaround still applied and some working object cached, for some reason.

If the semicolon after the macro is desired to be mandatory (I think it was), my only idea would be to add a `do { /* ... */ } while(0)` at the end of the patch or similar. I don't know if there are better solutions, unfortunately my macro game is not that strong.