### PR TITLE
Add macro cheat sheet PDF to documentation

### DIFF
--- a/doc/Tracy_Macro_CheatSheet.pdf
+++ b/doc/Tracy_Macro_CheatSheet.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20251124150155+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20251124150155+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 632
+>>
+stream
+Gatn$9lHLd&;KZL'r.:hb&LRuN/t(U99nilOuZOV/2.q+A_1+O[-=d_/r<dTCK8^gM8L=)H03X2&9.8/g36^$I#d1GL&c3:c@P`u+6"k7`&DPh"kPJO[o4SkJA?`tMCbK8'gZ*@/=&,@JK7I]J9?EB_7i06G7]7Vpqq%2oiAMI\!c,fp/Q(eVrEZ'Khkm4[rC5GQC?igIlR2l,Xl#p":>GKkm;)l*CBcYkCbb(a2@9;O]H^R\/XfQG/M#Q$/\BUkYg-a8lWTKX3p4kd[KLu0O"o3j:q4$Rde;H:naWSKQ=`,f0O>NSp.(uisjgN[Y=gnTg9k@Sl,:b\X%&)pBdrVK6'+CacGJQ*Fa$F.k6fjO"F(f:"bRMlD=E4B4X[M6>aL\EZI"nCo6=K5t6b;Te5U9T)Fjr5ci\\Zi;9;%<'Z.'C,-/cJb1s#,c^0r_dO1QK:hpZ:nW)+J)G^.OS?qX)MI[_n)^8eD`4^:fEPNUL)AqP;%^%&:-Jp9U[2*Y<@EeAVR=s?LS9li@sg]q<c.M%Li/1'iV"!6d$1&9'tH(@_B-2bkr.'VtD`*.liBrr&J=_I*rDY?r,L\')JD#K;Y^`I'fsKmSCHWLooqF8T,JQQ-@UT#rfU!13=&.~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000536 00000 n 
+0000000604 00000 n 
+0000000900 00000 n 
+0000000959 00000 n 
+trailer
+<<
+/ID 
+[<aeb6703249564ffa77d6b8debf13b0f6><aeb6703249564ffa77d6b8debf13b0f6>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1681
+%%EOF


### PR DESCRIPTION
This PR adds a new macro cheat sheet PDF to the Tracy documentation, addressing #1173.

 Changes:
- Added `Tracy_Macro_CheatSheet.pdf` under the `doc/` folder
- Added a link to the cheat sheet in the README for easier discovery

The goal is to make macro usage reference more accessible for new contributors and users.
