### PR TITLE
feat: Add build option to ignore memory free faults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ set_option(TRACY_LIBUNWIND_BACKTRACE "Use libunwind backtracing where supported"
 set_option(TRACY_SYMBOL_OFFLINE_RESOLVE "Instead of full runtime symbol resolution, only resolve the image path and offset to enable offline symbol resolution" OFF)
 set_option(TRACY_LIBBACKTRACE_ELF_DYNLOAD_SUPPORT "Enable libbacktrace to support dynamically loaded elfs in symbol resolution resolution after the first symbol resolve operation" OFF)
 set_option(TRACY_DEBUGINFOD "Enable debuginfod support" OFF)
+set_option(TRACY_IGNORE_MEMORY_FAULTS "Ignore instrumentation errors from memory free events that do not have a matching allocation" OFF)
 
 # advanced
 set_option(TRACY_VERBOSE "[advanced] Verbose output from the profiler" OFF)

--- a/meson.build
+++ b/meson.build
@@ -119,6 +119,10 @@ if get_option('debuginfod')
   tracy_public_deps += dependency('libdebuginfod')
 endif
 
+if get_option('ignore_memory_faults')
+  tracy_common_args += ['-DTRACY_IGNORE_MEMORY_FAULTS']
+endif
+
 tracy_shared_libs = get_option('default_library') == 'shared'
 
 if tracy_shared_libs

--- a/meson.options
+++ b/meson.options
@@ -25,3 +25,4 @@ option('fibers', type : 'boolean', value : false, description : 'Enable fibers s
 option('no_crash_handler', type : 'boolean', value : false, description : 'Disable crash handling')
 option('verbose', type : 'boolean', value : false, description : 'Enable verbose logging')
 option('debuginfod', type : 'boolean', value : false, description : 'Enable debuginfod support')
+option('ignore_memory_faults', type : 'boolean', value : false, description : 'Ignore instrumentation errors from memory free events that do not have a matching allocation')

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1765,8 +1765,8 @@ void Profiler::Worker()
 #ifdef TRACY_ON_DEMAND
     flags |= WelcomeFlag::OnDemand;
 #endif
-#ifdef __APPLE__
-    flags |= WelcomeFlag::IsApple;
+#if defined TRACY_IGNORE_MEMORY_FAULTS || defined __APPLE__
+    flags |= WelcomeFlag::IgnoreMemFaults;
 #endif
 #ifndef TRACY_NO_CODE_TRANSFER
     flags |= WelcomeFlag::CodeTransfer;

--- a/public/common/TracyProtocol.hpp
+++ b/public/common/TracyProtocol.hpp
@@ -83,7 +83,7 @@ struct WelcomeFlag
     enum _t : uint8_t
     {
         OnDemand        = 1 << 0,
-        IsApple         = 1 << 1,
+        IgnoreMemFaults = 1 << 1,
         CodeTransfer    = 1 << 2,
         CombineSamples  = 1 << 3,
         IdentifySamples = 1 << 4,

--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -2792,7 +2792,7 @@ void Worker::Exec()
         m_captureProgram = welcome.programName;
         m_captureTime = welcome.epoch;
         m_executableTime = welcome.exectime;
-        m_ignoreMemFreeFaults = ( welcome.flags & WelcomeFlag::OnDemand ) || ( welcome.flags & WelcomeFlag::IsApple );
+        m_ignoreMemFreeFaults = ( welcome.flags & WelcomeFlag::OnDemand ) || ( welcome.flags & WelcomeFlag::IgnoreMemFaults );
         m_ignoreFrameEndFaults = welcome.flags & WelcomeFlag::OnDemand;
         m_data.cpuArch = (CpuArchitecture)welcome.cpuArch;
         m_codeTransfer = welcome.flags & WelcomeFlag::CodeTransfer;


### PR DESCRIPTION
This adds a build option `TRACY_IGNORE_MEMORY_FAULTS` to ignore mismatched alloc/free events in the trace. This is particularly useful when interposing the standard `malloc`/`free` etc. operations to add allocation events. See for example discussion https://github.com/wolfpld/tracy/issues/196

This replaces the `IsApple` flag, which was previously only used for this purpose, so no change in binary protocol.