### PR TITLE
Required lib-curl version to 8.17.0 in vendor.cmake pkg-config

### DIFF
--- a/cmake/vendor.cmake
+++ b/cmake/vendor.cmake
@@ -271,7 +271,7 @@ if(NOT EMSCRIPTEN)
 
     # libcurl
 
-    pkg_check_modules(LIBCURL libcurl)
+    pkg_check_modules(LIBCURL libcurl>=7.87.0)
     if (LIBCURL_FOUND AND NOT DOWNLOAD_LIBCURL)
         add_library(TracyLibcurl INTERFACE)
         target_include_directories(TracyLibcurl INTERFACE ${LIBCURL_INCLUDE_DIRS})


### PR DESCRIPTION

Resolving compiling issue when building with previous version of lib-curl.
    
If locally is present an older version of lib-curl the profiler build fails with:
    
    ```
       29 |     curl_easy_setopt( curl, CURLOPT_CA_CACHE_TIMEOUT, 604800L );
          |                             ^~~~~~~~~~~~~~~~~~~~~~~~
          |                             CURLOPT_DNS_CACHE_TIMEOUT
    include/curl/curl.h:3109:68: note: expanded from macro 'curl_easy_setopt'
     3109 | #define curl_easy_setopt(handle,opt,param) curl_easy_setopt(handle,opt,param)
          |                                                                    ^
    include/curl/curl.h:1398:11: note: 'CURLOPT_DNS_CACHE_TIMEOUT' declared here
     1398 |   CURLOPT(CURLOPT_DNS_CACHE_TIMEOUT, CURLOPTTYPE_LONG, 92),
          |           ^
    tracy/profiler/src/profiler/TracyLlmApi.cpp:144:46: error: use of undeclared identifier 'CURL_WRITEFUNC_ERROR'; did you mean 'CURLE_WRITE_ERROR'?
      144 |             if( !v.callback( json ) ) return CURL_WRITEFUNC_ERROR;
          |                                              ^~~~~~~~~~~~~~~~~~~~
          |                                              CURLE_WRITE_ERROR
    include/curl/curl.h:524:3: note: 'CURLE_WRITE_ERROR' declared here
      524 |   CURLE_WRITE_ERROR,             /* 23 */
          |   ^
    2 errors generated.
    ```
    
Now checking the version will avoid such issues:
   
```   
    -- Checking for module 'libcurl>=8.17.0'
    --   Package dependency requirement 'libcurl >= 8.17.0' could not be satisfied.
    Package 'libcurl' has version '7.84.0', required version is '>= 8.17.0'
    -- CPM: Adding package libcurl@ (curl-8_17_0 to ...)
```    