### PR TITLE
Link imgui against X11 libs

### DIFF
--- a/cmake/vendor.cmake
+++ b/cmake/vendor.cmake
@@ -162,6 +162,11 @@ target_link_libraries(TracyImGui PUBLIC TracyFreetype)
 target_compile_definitions(TracyImGui PRIVATE "IMGUI_ENABLE_FREETYPE")
 #target_compile_definitions(TracyImGui PUBLIC "IMGUI_DISABLE_OBSOLETE_FUNCTIONS")
 
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND LEGACY)
+    find_package(X11 REQUIRED)
+    target_link_libraries(TracyImGui PUBLIC ${X11_LIBRARIES})
+endif()
+
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(TracyImGui PRIVATE "IMGUI_DISABLE_DEBUG_TOOLS" "IMGUI_DISABLE_DEMO_WINDOWS")
 endif()


### PR DESCRIPTION
Imgui-docking >=v1.92.3 GLFW back-end requires linking against x11 libraries. This solves link failures when building tracy with the LEGACY option turned on.

Fixes Imgui bump in commit https://github.com/wolfpld/tracy/commit/9aa78b224cfc8eca2b734383a6edee8f87388dc5

See Imgui commit for more information: https://github.com/ocornut/imgui/commit/37b18acdf5dccb09251e72c5ff6e55980ca97b36