### PR TITLE
Fix unknown allocation message in debug due to alloc name litteral not pointing to the same location

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -49,16 +49,18 @@ void operator delete( void* ptr ) noexcept
     free( ptr );
 }
 
+// We need to have the same pointer for both TracyAllocNS and TracyFreeNS
+static const char* customAllocStr = "Custom alloc";
 void* CustomAlloc( size_t count )
 {
     auto ptr = malloc( count );
-    TracyAllocNS( ptr, count, 10, "Custom alloc" );
+    TracyAllocNS( ptr, count, 10, customAllocStr );
     return ptr;
 }
 
 void CustomFree( void* ptr )
 {
-    TracyFreeNS( ptr, 10, "Custom alloc" );
+    TracyFreeNS( ptr, 10, customAllocStr );
     free( ptr );
 }
 


### PR DESCRIPTION
Same as #1223 but for the OnlyMemory thread., sorry for sending 2 PRs, failed to see this one as I had `auto t20 = std::thread( OnlyMemory );` commented locally.