### PR TITLE
Toggling EnableFlags after the "NT Kernel Logger" session has started

### DIFF
--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -191,7 +191,7 @@ bool SysTraceStart( int64_t& samplingPeriod )
     if( !etw::CheckAdminPrivilege() )
         return false;
 
-    session_kernel = etw::StartSingletonKernelLoggerSession();
+    session_kernel = etw::StartSingletonKernelLoggerSession( 0 );
     if( session_kernel.handle == 0 )
         return false;
 

--- a/public/client/windows/TracyETW.cpp
+++ b/public/client/windows/TracyETW.cpp
@@ -326,7 +326,7 @@ static ULONG SetCPUProfilingInterval( int microseconds )
     return ETWError( status );
 }
 
-static Session StartSingletonKernelLoggerSession( ULONGLONG EnableFlags = 0 )
+static Session StartSingletonKernelLoggerSession( ULONGLONG EnableFlags )
 {
     Session session = {};
 


### PR DESCRIPTION
These changes make the shared/singleton "NT Kernel Logger" session (`EnableFlags`) operate more similarly to a private kernel session (`EnableTraceEx2()`).

(We could also consider adding UI toggles to enable/disable system trace features on-the-fly.)