### PR TITLE
Fix android Tracy compilation

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -933,7 +933,7 @@ static Thread* s_symbolThread;
 std::atomic<bool> s_symbolThreadGone { false };
 #endif
 #ifdef TRACY_HAS_SYSTEM_TRACING
-static std::atomic<Thread*> s_sysTraceThread = nullptr;
+static std::atomic<Thread*> s_sysTraceThread {nullptr};
 #endif
 
 #if defined __linux__ && !defined TRACY_NO_CRASH_HANDLER


### PR DESCRIPTION
The build now fails because Tracy 0.13.1 added a file‑scope static:
```cpp
static std::atomic<Thread*> s_sysTraceThread = nullptr;
```

in public/client/TracyProfiler.cpp. std::atomic disables its copy constructor, and copy‑initialization (= nullptr) requires that constructor, so libc++ from NDK 27 rejects it:
```shell
error: copying variable of type 'std::atomic<Thread *>' invokes deleted constructor
```

On desktop this often slips through because some libstdc++ implementations allow the copy, but the Android toolchain enforces the standard rule and aborts the build.

Fix

Switch the declaration to direct initialization so the atomic is constructed in place:
```cpp
static std::atomic<Thread*> s_sysTraceThread{ nullptr };
```

That avoids calling the deleted copy constructor and the build succeeds again. No other Tracy flags or Meson options are involved—the failure comes solely from the new global’s initialization form.