### PR TITLE
Fix frame image race condition + refactor

### DIFF
--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -106,6 +106,12 @@ class View
         int64_t total;
         uint16_t threadNum;
     };
+    
+    struct FrameImageCache
+    {
+        ImTextureID textureId = 0;
+        const void* dataPtr = nullptr;
+    };
 
 public:
     struct PlotView
@@ -247,6 +253,7 @@ private:
     void Achieve( const char* id );
 
     bool DrawImpl();
+    void DrawFrameImage( FrameImageCache& cache, const FrameImage& fi, float scale = GetScale() );
     void DrawNotificationArea();
     bool DrawConnection();
     void DrawFrames();
@@ -619,11 +626,8 @@ private:
     std::atomic<size_t> m_srcFileBytes { 0 };
     std::atomic<size_t> m_dstFileBytes { 0 };
 
-    ImTextureID m_frameTexture = 0;
-    const void* m_frameTexturePtr = nullptr;
-
-    ImTextureID m_frameTextureConn = 0;
-    const void* m_frameTextureConnPtr = nullptr;
+    FrameImageCache m_FrameTextureCache;
+    FrameImageCache m_FrameTextureCacheConnection;
 
     std::vector<std::unique_ptr<Annotation>> m_annotations;
     UserData m_userData;

--- a/profiler/src/profiler/TracyView_FrameOverview.cpp
+++ b/profiler/src/profiler/TracyView_FrameOverview.cpp
@@ -196,21 +196,8 @@ void View::DrawFrames()
                 auto fi = m_worker.GetFrameImage( *m_frames, sel );
                 if( fi )
                 {
-                    if( fi != m_frameTexturePtr )
-                    {
-                        if( !m_frameTexture ) m_frameTexture = MakeTexture();
-                        UpdateTexture( m_frameTexture, m_worker.UnpackFrameImage( *fi ), fi->w, fi->h );
-                        m_frameTexturePtr = fi;
-                    }
                     ImGui::Separator();
-                    if( fi->flip )
-                    {
-                        ImGui::Image( m_frameTexture, ImVec2( fi->w * scale, fi->h * scale ), ImVec2( 0, 1 ), ImVec2( 1, 0 ) );
-                    }
-                    else
-                    {
-                        ImGui::Image( m_frameTexture, ImVec2( fi->w * scale, fi->h * scale ) );
-                    }
+                    DrawFrameImage( m_FrameTextureCache, *fi );
                 }
                 ImGui::EndTooltip();
 

--- a/profiler/src/profiler/TracyView_FrameTimeline.cpp
+++ b/profiler/src/profiler/TracyView_FrameTimeline.cpp
@@ -153,22 +153,8 @@ void View::DrawTimelineFrames( const FrameData& frames )
                 auto fi = m_worker.GetFrameImage( frames, i );
                 if( fi )
                 {
-                    const auto scale = GetScale();
-                    if( fi != m_frameTexturePtr )
-                    {
-                        if( !m_frameTexture ) m_frameTexture = MakeTexture();
-                        UpdateTexture( m_frameTexture, m_worker.UnpackFrameImage( *fi ), fi->w, fi->h );
-                        m_frameTexturePtr = fi;
-                    }
                     ImGui::Separator();
-                    if( fi->flip )
-                    {
-                        ImGui::Image( m_frameTexture, ImVec2( fi->w * scale, fi->h * scale ), ImVec2( 0, 1 ), ImVec2( 1, 0 ) );
-                    }
-                    else
-                    {
-                        ImGui::Image( m_frameTexture, ImVec2( fi->w * scale, fi->h * scale ) );
-                    }
+                    DrawFrameImage( m_FrameTextureCache, *fi );
 
                     if( ImGui::GetIO().KeyCtrl && IsMouseClicked( 0 ) )
                     {

--- a/profiler/src/profiler/TracyView_Messages.cpp
+++ b/profiler/src/profiler/TracyView_Messages.cpp
@@ -268,20 +268,7 @@ void View::DrawMessageLine( const MessageData& msg, bool hasCallstack, int& idx 
             if( fi )
             {
                 ImGui::BeginTooltip();
-                if( fi != m_frameTexturePtr )
-                {
-                    if( !m_frameTexture ) m_frameTexture = MakeTexture();
-                    UpdateTexture( m_frameTexture, m_worker.UnpackFrameImage( *fi ), fi->w, fi->h );
-                    m_frameTexturePtr = fi;
-                }
-                if( fi->flip )
-                {
-                    ImGui::Image( m_frameTexture, ImVec2( fi->w, fi->h ), ImVec2( 0, 1 ), ImVec2( 1, 0 ) );
-                }
-                else
-                {
-                    ImGui::Image( m_frameTexture, ImVec2( fi->w, fi->h ) );
-                }
+                DrawFrameImage( m_FrameTextureCache , *fi );
                 ImGui::EndTooltip();
             }
         }


### PR DESCRIPTION
- In the connection state, retrieve the FrameImage while owning the data lock.
- Use actual image data pointer as caching key instead of the address of ImageCache which may change during executation (unstable).
- Fixes scale Messages image tooltip scale.
- Free the connection image