### PR TITLE
Apple Silicon / macOS: use ARM64 CNTVCT_EL0 instruction in GetTime()

### DIFF
--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -200,7 +200,7 @@ public:
 #ifdef TRACY_HW_TIMER
 #  if defined TARGET_OS_IOS && TARGET_OS_IOS == 1
         if( HardwareSupportsInvariantTSC() ) return mach_absolute_time();
-#  elif defined(__APPLE__) && defined(__MACH__) && TARGET_CPU_ARM64
+#  elif defined __APPLE__ && defined __MACH__ && TARGET_CPU_ARM64
         if( HardwareSupportsInvariantTSC() )
         {
             uint64_t value;


### PR DESCRIPTION
This PR switches the implementation of `tracy::Profiler::GetTime()` on macOS ARM64 from using `std::chrono::high_resolution_clock` to ARM64's `CNTVCT_EL0` instruction.

Results from an **M4 Max**:
| method                       | latency  | tick rate      | resolution  |
|------------------------------|----------|----------------|-------------|
| `CNTVCT_EL0`                 | 0.237ns  | 1 tick/ns      | 17 ticks    |
| `ISB`+`CNTVCT_EL0`           | 8.703ns  | 1 tick/ns      | 17 ticks    |
| `mach_absolute_time`         | 4.057ns  | 0.024 tick/ns  | 1 tick      |
| `clock_gettime_nsec_np(RAW)` | 8.869ns  | 1 tick/ns      | 41 ticks    |
| `chrono::high_res_clock`     | 13.262ns | 1 tick/ns      | 41 ticks    |

Benchmark code/results **[here](https://gist.github.com/slomp/fdd5ceae54cbb247179725974e85131f)**; see https://github.com/wolfpld/tracy/issues/1237 for discussion.

---

**UPDATE**: It turns out that the `CNTVCT_EL0` instruction, although architecturally available on AArch64, may not be accessible from user-mode. At least on macOS running on Apple Silicon, the instruction seems to be available in user-mode, but there's no official statement/documentation from Apple on the matter as far as I know.

**UPDATE**: According to **[this snippet in the Darwin XNU code](https://github.com/apple-oss-distributions/xnu/blob/main/osfmk/arm64/machine_routines.c#L2606-L2612)**, `EL0` access from user-mode is enabled by the kernel.

---
Related links:
- https://github.com/FFTW/fftw3/pull/267#issuecomment-1161739887
- https://github.com/golang/go/issues/67937
