### PR TITLE
fix: 2x scaling on macos with ImGui 1.92

### DIFF
--- a/profiler/src/main.cpp
+++ b/profiler/src/main.cpp
@@ -164,11 +164,11 @@ static void SetupDPIScale()
     dpiFirstSetup = false;
     dpiChanged = 2;
 
-    LoadFonts( scale );
-
 #ifdef __APPLE__
-    scale = 1.0f;
+    scale = tracy::s_config.userScale;
 #endif
+
+    LoadFonts( scale );
 
     auto& style = ImGui::GetStyle();
     style = ImGuiStyle();


### PR DESCRIPTION
After change to ImGui 1.92, MacOS shows Tracy UI at 2x scale.

[Release notes](https://github.com/ocornut/imgui/releases/tag/v1.92.0) for ImGui mentions:
> Retina screen rendering works by default (with conforming backend) by updating rasterizer density.

Forcing apple platform to use userScale directly fixes this and UI scaling config works correctly.