### PR TITLE
capture: Display current query backlog

### DIFF
--- a/capture/src/capture.cpp
+++ b/capture/src/capture.cpp
@@ -218,6 +218,7 @@ int main( int argc, char** argv )
         const auto mbps = worker.GetMbpsData().back();
         const auto compRatio = worker.GetCompRatio();
         const auto netTotal = worker.GetDataTransferred();
+        const auto queueSize = worker.GetSendQueueSize();
         lock.unlock();
 
         // Output progress info only if destination is a TTY to avoid bloating
@@ -248,6 +249,8 @@ int main( int argc, char** argv )
             }
             printf( " | ");
             AnsiPrintf( ANSI_RED, "%s", tracy::TimeToString( worker.GetLastTime() - firstTime ) );
+            printf( " | ");
+            AnsiPrintf( ANSI_RED ANSI_BOLD, "%s query backlog", tracy::RealToString( queueSize ) );
             fflush( stdout );
         }
 


### PR DESCRIPTION
When profiling alloc-heavy applications, I find it particularly useful to display current query backlog so that I know *when* to shutdown recording after reaching steady-state and getting all the frames correctly resolved. It took me a while to realise that it is very easy to overload the server with alloc-related events and I would get frustrated that I would get partially resolved frames. Anyhow, lemme know if you find that useful!