### PR TITLE
Update zstd-lib name in server.cmake

### DIFF
--- a/cmake/server.cmake
+++ b/cmake/server.cmake
@@ -29,7 +29,7 @@ list(TRANSFORM TRACY_SERVER_SOURCES PREPEND "${TRACY_SERVER_DIR}/")
 
 add_library(TracyServer STATIC EXCLUDE_FROM_ALL ${TRACY_COMMON_SOURCES} ${TRACY_SERVER_SOURCES})
 target_include_directories(TracyServer PUBLIC ${TRACY_COMMON_DIR} ${TRACY_SERVER_DIR})
-target_link_libraries(TracyServer PUBLIC TracyCapstone libzstd PPQSort::PPQSort)
+target_link_libraries(TracyServer PUBLIC TracyCapstone zstd PPQSort::PPQSort)
 if(NO_STATISTICS)
     target_compile_definitions(TracyServer PUBLIC TRACY_NO_STATISTICS)
 endif()


### PR DESCRIPTION
Simple pull request to change the name of the zstd library for correct linking.

Bakground:

Compiling the tracy server from the ground on atleast Ubuntu 25.10 and Fedora Desktop 43 results in the following linker error:

```
/usr/bin/ld: cannot find -llibzstd: No such file or directory
/usr/bin/ld: note to link with /usr/lib/gcc/x86_64-redhat-linux/15/../../../../lib64/libzstd.a use -l:libzstd.a or rename it to liblibzstd.a
collect2: error: ld returned 1 exit status
gmake[4]: *** [CMakeFiles/tracy-profiler.dir/build.make:1784: tracy-profiler] Error 1
gmake[3]: *** [CMakeFiles/Makefile2:1041: CMakeFiles/tracy-profiler.dir/all] Error 2
gmake[2]: *** [Makefile:156: all] Error 2
make[1]: *** [TracyServer.make:42: ../Build/target/External/TracyServer] Error 2
make: *** [Makefile:74: TracyServer] Error 2
```

Removing 'lib' in 'libzstd' allows the project to compile as expected.