### PR TITLE
Tests should work under TRACY_MANUAL_LIFETIME.

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -25,6 +25,9 @@ struct static_init_test_t
 {
     static_init_test_t()
     {
+#ifdef TRACY_MANUAL_LIFETIME
+        tracy::StartupProfiler();
+#endif
         ZoneScoped;
         ZoneTextF( "Static %s", "init test" );
         TracyLogString( tracy::MessageSeverity::Info, 0, TRACY_CALLSTACK, "Static init" );


### PR DESCRIPTION
This calls tracy::StartupProfiler(); before any other tracy call (in static init) if TRACY_MANUAL_LIFETIME is set