### PR TITLE
Sort threads by ID after name

### DIFF
--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -702,7 +702,9 @@ void View::DrawOptions()
         {
             pdqsort_branchless( m_threadOrder.begin(), m_threadOrder.end(), [this] ( const auto& lhs, const auto& rhs ) {
                 if( lhs->groupHint != rhs->groupHint ) return lhs->groupHint < rhs->groupHint;
-                return strcmp( m_worker.GetThreadName( lhs->id ), m_worker.GetThreadName( rhs->id ) ) < 0;
+                const auto cmp = strcmp( m_worker.GetThreadName( lhs->id ), m_worker.GetThreadName( rhs->id ) );
+                if( cmp != 0 ) return cmp < 0;
+                return lhs->id < rhs->id;
             } );
         }
 


### PR DESCRIPTION
The "sort" button for threads uses an unstable sort, so threads with the same name will shuffle around without ever stabilizing.

Use `id` to sort after comparing the name.

![Kooha-2026-02-04-06-56-16](https://github.com/user-attachments/assets/ee87499e-9eb6-4f00-b80c-e236582065c4)
