### PR TITLE
fix: UI zoom scale not applying on macOS

### DIFF
--- a/profiler/src/main.cpp
+++ b/profiler/src/main.cpp
@@ -161,13 +161,13 @@ static void SetupDPIScale()
 {
     auto scale = dpiScale * tracy::s_config.userScale;
 
-    if( !dpiFirstSetup && prevScale == scale ) return;
-    dpiFirstSetup = false;
-    dpiChanged = 2;
-
 #ifdef __APPLE__
     scale = tracy::s_config.userScale;
 #endif
+
+    if( !dpiFirstSetup && prevScale == scale ) return;
+    dpiFirstSetup = false;
+    dpiChanged = 2;
 
     LoadFonts( scale );
 


### PR DESCRIPTION
On macOS with Retina displays, dpiScale is 2.0 but gets overridden to userScale alone under __APPLE__. The early-return check compared prevScale against the pre-override value (dpiScale * userScale), which for 50% zoom evaluates to 2.0 * 0.5 = 1.0, matching the previous prevScale of 1.0 and causing an early return before the scale change could take effect. Moving the __APPLE__ override before the early-return check ensures the comparison uses the actual effective scale.

Created with AI, tested locally and it fixes the scaling on my M2 macbook air. Feel free to make changes.