### PR TITLE
Don't truncate thread names to 15 chars on Apple platforms

### DIFF
--- a/public/common/TracySystem.cpp
+++ b/public/common/TracySystem.cpp
@@ -168,26 +168,22 @@ TRACY_API void SetThreadNameWithHint( const char* name, int32_t groupHint )
     }
 #elif defined _GNU_SOURCE && !defined __EMSCRIPTEN__
     {
+#if defined __APPLE__
+        pthread_setname_np( name );
+#else
         const auto sz = strlen( name );
         if( sz <= 15 )
         {
-#if defined __APPLE__
-            pthread_setname_np( name );
-#else
             pthread_setname_np( pthread_self(), name );
-#endif
         }
         else
         {
             char buf[16];
             memcpy( buf, name, 15 );
             buf[15] = '\0';
-#if defined __APPLE__
-            pthread_setname_np( buf );
-#else
             pthread_setname_np( pthread_self(), buf );
-#endif
         }
+#endif
     }
 #elif defined __QNX__
     {


### PR DESCRIPTION
The 15 character limit is a Linux/Android limitation. On Apple platforms, `pthread_setname_np` accepts the full name without truncation.

Fixes https://github.com/wolfpld/tracy/issues/919