### PR TITLE
Ensure executable path is inspected when looking for PDB files

### DIFF
--- a/public/client/TracyCallstack.cpp
+++ b/public/client/TracyCallstack.cpp
@@ -378,6 +378,22 @@ void InitCallstackCritical()
     ___tracy_RtlWalkFrameChainPtr = (___tracy_t_RtlWalkFrameChain)GetProcAddress( GetModuleHandleA( "ntdll.dll" ), "RtlWalkFrameChain" );
 }
 
+static void SymError( const char* function, DWORD code ) {
+    char message[1024] = {};
+    int written = snprintf( message, sizeof( message ), "ERROR: %s FAILED with code %u (0x%x) | ", function, code, code );
+    written += FormatMessageA(
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        code,
+        MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US),
+        (LPSTR)&message[written],
+        sizeof(message) - written,
+        NULL
+    );
+    fprintf( stderr, "%s\n", message );
+    OutputDebugStringA( message );
+}
+
 void DbgHelpInit()
 {
     if( s_shouldResolveSymbolsOffline ) return;
@@ -392,8 +408,23 @@ void DbgHelpInit()
     DBGHELP_LOCK;
 #endif
 
-    SymInitialize( GetCurrentProcess(), nullptr, true );
-    SymSetOptions( SYMOPT_LOAD_LINES );
+    // append executable path to the _NT_SYMBOL_PATH environment variable
+    char buffer [32767];  // max env var length on Windows (including null-terminator)
+    DWORD length = GetEnvironmentVariableA( "_NT_SYMBOL_PATH", buffer, sizeof( buffer ) );
+    buffer[length] = ';';
+    buffer[++length] = '\0';
+    length += GetModuleFileNameA( NULL, &buffer[length], sizeof( buffer ) - length );
+    while( length > 0 && buffer[--length] != '\\ ')
+        buffer[length] = '\0';
+    assert( length < sizeof( buffer ) );
+    if( SetEnvironmentVariableA( "_NT_SYMBOL_PATH", buffer ) == FALSE ) {
+        SymError( "SetEnvironmentVariableA", GetLastError() );
+    }
+
+    SymSetOptions( SymGetOptions() | SYMOPT_LOAD_LINES );
+    if( SymInitialize( GetCurrentProcess(), NULL, TRUE ) == FALSE ) {
+        SymError( "SymInitialize", GetLastError() );
+    }
 
 #ifdef TRACY_DBGHELP_LOCK
     DBGHELP_UNLOCK;


### PR DESCRIPTION
`SymInitialize()` and `SymLoadModuleEx()` appear to operate on a different set of rules when looking for matching PDB files.

---

While `SymLoadModuleEx` is able to resolve PDB files for modules (load-time and run-time) and will look at the location where the module is located, it appears to have no effect for the host executable image itself.

For the host executable, only `SymInitialize` seems to actually run logic to find an appropriate PDB file for the executable...
According to `SymInitialize` docs:
> Note that the directory that contains the executable file for the process is not automatically part of the search path.
https://learn.microsoft.com/en-us/windows/win32/api/dbghelp/nf-dbghelp-syminitialize

This is somewhat contradictory to this article:
>the symbol handler searches the directory that contains the module for which symbols are being searched.
https://learn.microsoft.com/en-us/windows/win32/debug/symbol-paths

If we put some bits and pieces of both articles together, the intuition for the search order/logic would go like this:
1. Current Working Directory (only for the executable image itself)
2. `_NT_SYMBOL_PATH`
3. `_NT_ALT_SYMBOL_PATH`
4. **The location of the module** (only for modules)

I've tried different versions of `DbgHelp.dll` and `SymSrv.dll` to no avail.

---

In addition, if an executable does not specify a full path to a pdb file in its "Debug Directories" PE section (use `dumpbin /headers <executable>` to check it), `SymInitialize` will also fail to find the pdb file, even if it is sitting at the current working directory...

---

Given all of the above, the easiest workaround is for Tracy to append the path of the executable to `_NT_SYMBOL_PATH`. I thought about passing it via the `UserSearchPath` argument to `SymInitialize`, but I'm a bit concerned that it may break the search logic for modules. The documentation is not very clear...
https://learn.microsoft.com/en-us/windows/win32/debug/initializing-the-symbol-handler