### PR TITLE
Have Touchpad gestures either scroll or zoom the timeline, but not both together

### DIFF
--- a/profiler/src/profiler/TracyView_Timeline.cpp
+++ b/profiler/src/profiler/TracyView_Timeline.cpp
@@ -87,7 +87,7 @@ void View::HandleTimelineMouse( int64_t timespan, const ImVec2& wpos, float w )
         }
     }
 
-    const bool wheel_scroll = abs(io.MouseWheelH) > abs(io.MouseWheel);
+    const bool wheel_scroll = abs( io.MouseWheelH ) > abs( io.MouseWheel );
     if( IsMouseDragging( 1 ) || wheel_scroll )
     {
         m_viewMode = ViewMode::Paused;
@@ -119,7 +119,7 @@ void View::HandleTimelineMouse( int64_t timespan, const ImVec2& wpos, float w )
         }
     }
 
-    const bool wheel_zoom = abs(io.MouseWheel) > abs(io.MouseWheelH);
+    const bool wheel_zoom = abs( io.MouseWheel ) > abs( io.MouseWheelH );
     if( wheel_zoom )
     {
         const auto wheel = io.MouseWheel;


### PR DESCRIPTION
This makes using Tracy with a touchpad/trackpad much more bearable.
Before this change, a touchpad zoom gesture would coming with a horizontal scroll gesture, making navigation disorienting and frustrating.
For mouse usage, this has virtually no effect (unless the user is spinning the horizontal wheel and the regular wheel simultaneously, but even then, I wager it's best to prioritize one or the other).