### PR TITLE
Initialize LLM input pointers to nullptr

### DIFF
--- a/profiler/src/profiler/TracyLlm.cpp
+++ b/profiler/src/profiler/TracyLlm.cpp
@@ -28,7 +28,6 @@ constexpr size_t InputBufferSize = 1024;
 
 TracyLlm::TracyLlm( Worker& worker, View& view, const TracyManualData& manual )
     : m_exit( false )
-    , m_input( nullptr )
     , m_worker( worker )
 {
     if( !s_config.llm ) return;

--- a/profiler/src/profiler/TracyLlm.hpp
+++ b/profiler/src/profiler/TracyLlm.hpp
@@ -105,8 +105,8 @@ private:
     bool m_setTemperature = false;
     bool m_allThinkingRegions = false;
 
-    char* m_input;
-    char* m_apiInput;
+    char* m_input = { nullptr };
+    char* m_apiInput = { nullptr };
     std::mutex m_chatLock;
     std::vector<nlohmann::json> m_chat;
 


### PR DESCRIPTION
Fix segmentation fault in TracyLlm destructor when LLM support is disabled. 
The constructor returns early if `s_config.llm` is false, leaving `m_input `and `m_apiInput `uninitialized. 
The destructor then attempts to delete garbage pointers.