### PR TITLE
Define MAP_FAILED for Windows builds

### DIFF
--- a/profiler/src/profiler/TracyLlmEmbeddings.hpp
+++ b/profiler/src/profiler/TracyLlmEmbeddings.hpp
@@ -1,6 +1,10 @@
 #ifndef __TRACYLLMEMBEDDINGS_HPP__
 #define __TRACYLLMEMBEDDINGS_HPP__
 
+#ifdef _WIN32
+#  define MAP_FAILED ((void *) -1)
+#endif
+
 #include <stddef.h>
 #include <usearch/index_dense.hpp>
 #include <vector>

--- a/server/TracyMmap.hpp
+++ b/server/TracyMmap.hpp
@@ -10,6 +10,7 @@
 #  define PROT_READ 1
 #  define PROT_WRITE 2
 #  define MAP_SHARED 0
+#  define MAP_FAILED ((void *) -1)
 
 void* mmap( void* addr, size_t length, int prot, int flags, int fd, off_t offset );
 int munmap( void* addr, size_t length );


### PR DESCRIPTION
The _usearch_ library uses `MAP_FAILED` which is a POSIX constant not available on Windows. 
Add the definition to `TracyMmap.hpp` and `TracyLlmEmbeddings.hpp` to fix MSVC compilation errors.