### PR TITLE
Use multi-threaded FrameImage Zstd recompression on WASM

### DIFF
--- a/server/TracyWorker.cpp
+++ b/server/TracyWorker.cpp
@@ -1347,12 +1347,11 @@ Worker::Worker( FileRead& f, EventType::Type eventMask, bool bgTasks, bool allow
                 alignas(64) std::atomic<State> state = Available;
             };
 
+            const int hc = (int)std::thread::hardware_concurrency();
 #ifdef __EMSCRIPTEN__
-            const int jobs = 1;
+            const int jobs = std::min( std::max( hc - 2, 2 ), 4 );
 #else
-            // Leave one thread for file reader, second thread for dispatch (this thread)
-            // Minimum 2 threads to have at least two buffers (one in use, second one filling up)
-            const auto jobs = std::max<int>( std::thread::hardware_concurrency() - 2, 2 );
+            const int jobs = std::max( hc - 2, 2 );
 #endif
             auto td = std::make_unique<TaskDispatch>( jobs, "FrImg Zstd" );
             auto data = std::make_unique<JobData[]>( jobs );


### PR DESCRIPTION
## Problem

When loading `.tracy` files in the WASM web viewer, FrameImage Zstd recompression is hardcoded to a single thread (`jobs = 1`), even though the Emscripten build ships with `-sPTHREAD_POOL_SIZE=8` and full pthread support.

On traces with many frame images, this serialization makes the FrameImages loading stage up to 4× slower than necessary.

## Change

- Remove the `#ifdef __EMSCRIPTEN__` branch that forced `jobs = 1`
- Cap WASM jobs to 4 to avoid exhausting the 8-thread Emscripten pthread pool (main thread, file reader, and load thread are already active)
- Fix an unsigned subtraction hazard: cast `hardware_concurrency()` to `int` before subtracting to avoid underflow when it returns 0 or 1

The FrameImage recompression workload is embarrassingly parallel — each job has its own `ZSTD_CCtx` and output buffer with no shared mutable state.

## Impact

For traces with many frame images, the FrameImages loading stage should see up to ~4× speedup in the web viewer, reducing overall trace load time.