### PR TITLE
Reduce Profiler Worker time blocked in socket send()

### DIFF
--- a/public/common/TracySocket.cpp
+++ b/public/common/TracySocket.cpp
@@ -529,6 +529,12 @@ Socket* ListenSocket::Accept()
         setsockopt( sock, SOL_SOCKET, SO_NOSIGPIPE, &val, sizeof( val ) );
 #endif
 
+        // The default send buffer size is way too small to accommodate for the amount of
+        // data that Tracy is capable of producing, causing the Profiler Worker to "block"
+        // frequently during send().
+        int buffer_size = 32 * 1024 * 1024;
+        setsockopt( sock, SOL_SOCKET, SO_SNDBUF, (char*)&buffer_size, sizeof( buffer_size ) );
+
         auto ptr = (Socket*)tracy_malloc( sizeof( Socket ) );
         new(ptr) Socket( sock );
         return ptr;


### PR DESCRIPTION
Massive reduction in how much time the Profiler Worker spends on socket `send()` calls by increasing the socket send buffer size considerably.

(This is still a draft; I want to make `tracy::Socket::Send()` collect some stats in real-time and adjust the buffer size on the fly, as the "sweet-spot" is highly dependent on the amount of instrumentation and sampling data being generated.)

<img width="601" height="651" alt="Screenshot 2026-03-05 104328" src="https://github.com/user-attachments/assets/5d2da3f2-d825-4daf-86c2-0ddbcdb4dc0e" />
