### PR TITLE
Add missing cstdint include

### DIFF
--- a/server/tracy_robin_hood.h
+++ b/server/tracy_robin_hood.h
@@ -39,6 +39,7 @@
 #define ROBIN_HOOD_VERSION_PATCH 5  // for backwards-compatible bug fixes
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>


### PR DESCRIPTION
Fixes build on new gcc on Fedora 44.