### PR TITLE
TracyCUDA: show GPU zones for CUDA Graph-launched kernels

### DIFF
--- a/examples/CUDAGraphRepro/Makefile
+++ b/examples/CUDAGraphRepro/Makefile
@@ -10,8 +10,8 @@ LIBS         := -L$(CUPTI_LIB) -lcuda -lcupti -lpthread -ldl
 
 CXXFLAGS_REL   := -O2 -DTRACY_ENABLE
 CXXFLAGS_DBG   := -g -O0 -DTRACY_ENABLE
-NVCCFLAGS_REL  := -O2 -DTRACY_ENABLE
-NVCCFLAGS_DBG  := -g -O0 -DTRACY_ENABLE
+NVCCFLAGS_REL  := -arch=native -O2 -DTRACY_ENABLE
+NVCCFLAGS_DBG  := -arch=native -g -O0 -DTRACY_ENABLE
 
 .PHONY: all debug clean
 

--- a/examples/CUDAGraphRepro/Makefile
+++ b/examples/CUDAGraphRepro/Makefile
@@ -13,13 +13,15 @@ CXXFLAGS_DBG   := -g -O0 -DTRACY_ENABLE
 NVCCFLAGS_REL  := -arch=native -O2 -DTRACY_ENABLE
 NVCCFLAGS_DBG  := -arch=native -g -O0 -DTRACY_ENABLE
 
-.PHONY: all debug investigate clean
+.PHONY: all debug investigate investigate2 clean
 
 all: repro
 
 debug: repro_debug
 
 investigate: test_corr_reuse
+
+investigate2: test_graphid_recycle
 
 # Release build
 repro: repro.cu tracy_client.o
@@ -39,5 +41,9 @@ tracy_client_debug.o: $(TRACY_SRCS)
 test_corr_reuse: test_corr_reuse.cu
 	$(NVCC) $(NVCCFLAGS_REL) $(INCLUDES) -o $@ $< $(LIBS)
 
+# Investigation: does CUPTI recycle graphId values after cudaGraphExecDestroy?
+test_graphid_recycle: test_graphid_recycle.cu
+	$(NVCC) $(NVCCFLAGS_REL) $(INCLUDES) -o $@ $< $(LIBS)
+
 clean:
-	rm -f repro repro_debug test_corr_reuse tracy_client.o tracy_client_debug.o
+	rm -f repro repro_debug test_corr_reuse test_graphid_recycle tracy_client.o tracy_client_debug.o

--- a/examples/CUDAGraphRepro/Makefile
+++ b/examples/CUDAGraphRepro/Makefile
@@ -1,0 +1,12 @@
+NVCC := nvcc
+CFLAGS := -O2
+
+.PHONY: all clean
+
+all: repro
+
+repro: repro.cu
+	$(NVCC) $(CFLAGS) -o $@ $<
+
+clean:
+	rm -f repro

--- a/examples/CUDAGraphRepro/Makefile
+++ b/examples/CUDAGraphRepro/Makefile
@@ -1,12 +1,37 @@
-NVCC := nvcc
-CFLAGS := -O2
+TRACY_PUBLIC := ../../public
+NVCC         := nvcc
+CXX          := g++
+CUPTI_INC    := /usr/local/cuda/include
+CUPTI_LIB    := /usr/local/cuda/lib64
 
-.PHONY: all clean
+TRACY_SRCS   := $(TRACY_PUBLIC)/TracyClient.cpp
+INCLUDES     := -I$(TRACY_PUBLIC) -I$(CUPTI_INC)
+LIBS         := -L$(CUPTI_LIB) -lcuda -lcupti -lpthread -ldl
+
+CXXFLAGS_REL   := -O2 -DTRACY_ENABLE
+CXXFLAGS_DBG   := -g -O0 -DTRACY_ENABLE
+NVCCFLAGS_REL  := -O2 -DTRACY_ENABLE
+NVCCFLAGS_DBG  := -g -O0 -DTRACY_ENABLE
+
+.PHONY: all debug clean
 
 all: repro
 
-repro: repro.cu
-	$(NVCC) $(CFLAGS) -o $@ $<
+debug: repro_debug
+
+# Release build
+repro: repro.cu tracy_client.o
+	$(NVCC) $(NVCCFLAGS_REL) $(INCLUDES) -o $@ $< tracy_client.o $(LIBS)
+
+tracy_client.o: $(TRACY_SRCS)
+	$(CXX) $(CXXFLAGS_REL) $(INCLUDES) -c -o $@ $<
+
+# Debug build (asserts enabled, no NDEBUG)
+repro_debug: repro.cu tracy_client_debug.o
+	$(NVCC) $(NVCCFLAGS_DBG) $(INCLUDES) -o $@ $< tracy_client_debug.o $(LIBS)
+
+tracy_client_debug.o: $(TRACY_SRCS)
+	$(CXX) $(CXXFLAGS_DBG) $(INCLUDES) -c -o $@ $<
 
 clean:
-	rm -f repro
+	rm -f repro repro_debug tracy_client.o tracy_client_debug.o

--- a/examples/CUDAGraphRepro/Makefile
+++ b/examples/CUDAGraphRepro/Makefile
@@ -13,11 +13,13 @@ CXXFLAGS_DBG   := -g -O0 -DTRACY_ENABLE
 NVCCFLAGS_REL  := -arch=native -O2 -DTRACY_ENABLE
 NVCCFLAGS_DBG  := -arch=native -g -O0 -DTRACY_ENABLE
 
-.PHONY: all debug clean
+.PHONY: all debug investigate clean
 
 all: repro
 
 debug: repro_debug
+
+investigate: test_corr_reuse
 
 # Release build
 repro: repro.cu tracy_client.o
@@ -33,5 +35,9 @@ repro_debug: repro.cu tracy_client_debug.o
 tracy_client_debug.o: $(TRACY_SRCS)
 	$(CXX) $(CXXFLAGS_DBG) $(INCLUDES) -c -o $@ $<
 
+# Investigation: correlationId uniqueness per graph launch (no Tracy dependency)
+test_corr_reuse: test_corr_reuse.cu
+	$(NVCC) $(NVCCFLAGS_REL) $(INCLUDES) -o $@ $< $(LIBS)
+
 clean:
-	rm -f repro repro_debug tracy_client.o tracy_client_debug.o
+	rm -f repro repro_debug test_corr_reuse tracy_client.o tracy_client_debug.o

--- a/examples/CUDAGraphRepro/README.md
+++ b/examples/CUDAGraphRepro/README.md
@@ -1,0 +1,35 @@
+# Tracy CUDA Graph GPU Zone Repro
+
+Demonstrates that unpatched Tracy fails to show GPU zones for kernels
+launched via CUDA Graphs (`cudaGraphLaunch`).
+
+## Root cause
+
+When kernels are launched through CUDA Graphs, CUPTI delivers
+`CONCURRENT_KERNEL` and `MEMCPY` activity records but no corresponding
+API callback fires for the individual kernel launches. Tracy's
+`matchActivityToAPICall()` always fails, and `matchError()` silently
+drops every GPU zone.
+
+## Build and run
+
+```bash
+make
+./repro
+```
+
+## What to expect
+
+| Tracy version | GPU zones shown |
+|---|---|
+| Unpatched | 0 |
+| Patched (cuda-graph-gpu-zones.patch) | ~30 (10 launches x 3 ops) |
+
+## The graph structure
+
+Each graph launch contains:
+1. `vector_add` kernel (c = a + b)
+2. Device-to-device memcpy
+3. `vector_add` kernel (c = a + c)
+
+The graph is launched 10 times, so 30 GPU operations total.

--- a/examples/CUDAGraphRepro/repro.cu
+++ b/examples/CUDAGraphRepro/repro.cu
@@ -1,16 +1,24 @@
 // Tracy CUDA Graph GPU Zone Repro
 //
-// Demonstrates that Tracy correctly shows GPU zones for kernels launched
-// via CUDA Graphs (cuGraphLaunch). Uses TracyCUDA to create a GPU context
-// and verifies that GPU zones appear with proper CPU-to-GPU correlation.
+// Tests GPU zone correlation for CUDA Graph launches covering:
+//   - Multiple distinct graphs (different graphIds)
+//   - Multiple kernels per graph
+//   - Mixed kernel + memcpy nodes
+//   - Interleaved launches from different graphs on the same stream
+//   - Repeated launches of the same graph (cache overwrite path)
+//
+// Expected GPU zone counts:
+//   graphA (kernel + memcpy + kernel): 5 launches x 3 nodes = 15 zones
+//   graphB (kernel + kernel + kernel): 5 launches x 3 nodes = 15 zones
+//   Total graph zones: 30
+//   Plus setup memcpys, syncs, etc.
 //
 // Build:
 //   make          # release build
 //   make debug    # debug build (asserts enabled)
 //
-// Run (start tracy-capture first, then run repro):
-//   tracy-capture -o out.tracy &
-//   ./repro
+// Run:
+//   tracy-capture -o out.tracy -f & sleep 1 && ./repro
 
 #include <cstdio>
 #include <cstdlib>
@@ -21,9 +29,12 @@
 
 __global__ void vector_add(float* a, float* b, float* c, int n) {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < n) {
-        c[i] = a[i] + b[i];
-    }
+    if (i < n) c[i] = a[i] + b[i];
+}
+
+__global__ void vector_scale(float* a, float scale, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) a[i] *= scale;
 }
 
 #define CHECK_CUDA(call)                                                      \
@@ -44,62 +55,83 @@ int main() {
 
     const int N = 1 << 20;
     const size_t bytes = N * sizeof(float);
+    const int threads = 256;
+    const int blocks  = (N + threads - 1) / threads;
 
-    float *d_a, *d_b, *d_c;
-    CHECK_CUDA(cudaMalloc(&d_a, bytes));
-    CHECK_CUDA(cudaMalloc(&d_b, bytes));
-    CHECK_CUDA(cudaMalloc(&d_c, bytes));
+    float *d_a, *d_b, *d_c, *d_tmp;
+    CHECK_CUDA(cudaMalloc(&d_a,   bytes));
+    CHECK_CUDA(cudaMalloc(&d_b,   bytes));
+    CHECK_CUDA(cudaMalloc(&d_c,   bytes));
+    CHECK_CUDA(cudaMalloc(&d_tmp, bytes));
 
     float* h_a = (float*)malloc(bytes);
     float* h_b = (float*)malloc(bytes);
-    for (int i = 0; i < N; i++) {
-        h_a[i] = 1.0f;
-        h_b[i] = 2.0f;
-    }
+    for (int i = 0; i < N; i++) { h_a[i] = 1.0f; h_b[i] = 2.0f; }
     CHECK_CUDA(cudaMemcpy(d_a, h_a, bytes, cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemcpy(d_b, h_b, bytes, cudaMemcpyHostToDevice));
 
-    // --- Create a CUDA Graph via stream capture ---
     cudaStream_t stream;
     CHECK_CUDA(cudaStreamCreate(&stream));
 
+    // --- Graph A: kernel(add) + memcpy + kernel(add) ---
+    // 3 nodes, graphId will be assigned by CUPTI
     CHECK_CUDA(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+    vector_add<<<blocks, threads, 0, stream>>>(d_a, d_b, d_c, N);
+    CHECK_CUDA(cudaMemcpyAsync(d_tmp, d_c, bytes, cudaMemcpyDeviceToDevice, stream));
+    vector_add<<<blocks, threads, 0, stream>>>(d_a, d_tmp, d_c, N);
+    cudaGraph_t    graphA;
+    cudaGraphExec_t execA;
+    CHECK_CUDA(cudaStreamEndCapture(stream, &graphA));
+    CHECK_CUDA(cudaGraphInstantiate(&execA, graphA, nullptr, nullptr, 0));
 
-    int threadsPerBlock = 256;
-    int blocksPerGrid = (N + threadsPerBlock - 1) / threadsPerBlock;
-    vector_add<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(d_a, d_b, d_c, N);
-    CHECK_CUDA(cudaMemcpyAsync(d_c, d_c, bytes, cudaMemcpyDeviceToDevice, stream));
-    vector_add<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(d_a, d_c, d_c, N);
+    // --- Graph B: kernel(scale) + kernel(add) + kernel(scale) ---
+    // 3 nodes, different graphId from A
+    CHECK_CUDA(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+    vector_scale<<<blocks, threads, 0, stream>>>(d_c, 0.5f, N);
+    vector_add  <<<blocks, threads, 0, stream>>>(d_a, d_b, d_c, N);
+    vector_scale<<<blocks, threads, 0, stream>>>(d_c, 2.0f, N);
+    cudaGraph_t     graphB;
+    cudaGraphExec_t execB;
+    CHECK_CUDA(cudaStreamEndCapture(stream, &graphB));
+    CHECK_CUDA(cudaGraphInstantiate(&execB, graphB, nullptr, nullptr, 0));
 
-    cudaGraph_t graph;
-    CHECK_CUDA(cudaStreamEndCapture(stream, &graph));
+    printf("Graph A: kernel + memcpy + kernel  (3 nodes)\n");
+    printf("Graph B: scale  + add   + scale    (3 nodes)\n");
+    printf("Interleaving 5 launches each...\n");
 
-    cudaGraphExec_t graphExec;
-    CHECK_CUDA(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
-
-    printf("CUDA Graph created with 3 nodes (kernel + memcpy + kernel)\n");
-    printf("Launching graph 10 times...\n");
-
-    // Each launch should produce 3 GPU zones (2 kernels + 1 memcpy), all
-    // correlated back to the cuGraphLaunch CPU call site.
-    for (int i = 0; i < 10; i++) {
-        ZoneScopedN("cuGraphLaunch iteration");
-        CHECK_CUDA(cudaGraphLaunch(graphExec, stream));
+    // Interleave launches: A, B, A, B, ... to stress graphId cache switching
+    for (int i = 0; i < 5; i++) {
+        {
+            ZoneScopedN("graphA launch");
+            CHECK_CUDA(cudaGraphLaunch(execA, stream));
+        }
+        {
+            ZoneScopedN("graphB launch");
+            CHECK_CUDA(cudaGraphLaunch(execB, stream));
+        }
     }
     CHECK_CUDA(cudaStreamSynchronize(stream));
 
-    printf("Done. Expected 30 GPU zones in Tracy (10 launches x 3 ops).\n");
+    printf("Done.\n");
+    printf("Expected GPU zones:\n");
+    printf("  graphA: 5 launches x 3 nodes = 15\n");
+    printf("  graphB: 5 launches x 3 nodes = 15\n");
+    printf("  Total graph zones: 30\n");
 
+    // Verify correctness
     float* h_c = (float*)malloc(bytes);
     CHECK_CUDA(cudaMemcpy(h_c, d_c, bytes, cudaMemcpyDeviceToHost));
-    printf("Result check: c[0] = %.1f (expected 4.0)\n", h_c[0]);
+    printf("Result check: c[0] = %.1f (expected 6.0: (a+b)*2 after last graphB)\n", h_c[0]);
 
-    CHECK_CUDA(cudaGraphExecDestroy(graphExec));
-    CHECK_CUDA(cudaGraphDestroy(graph));
+    CHECK_CUDA(cudaGraphExecDestroy(execA));
+    CHECK_CUDA(cudaGraphExecDestroy(execB));
+    CHECK_CUDA(cudaGraphDestroy(graphA));
+    CHECK_CUDA(cudaGraphDestroy(graphB));
     CHECK_CUDA(cudaStreamDestroy(stream));
     CHECK_CUDA(cudaFree(d_a));
     CHECK_CUDA(cudaFree(d_b));
     CHECK_CUDA(cudaFree(d_c));
+    CHECK_CUDA(cudaFree(d_tmp));
     free(h_a);
     free(h_b);
     free(h_c);

--- a/examples/CUDAGraphRepro/repro.cu
+++ b/examples/CUDAGraphRepro/repro.cu
@@ -1,23 +1,24 @@
 // Tracy CUDA Graph GPU Zone Repro
 //
-// Demonstrates that Tracy (unpatched) fails to show GPU zones for kernels
-// launched via CUDA Graphs. The CUPTI activity records arrive but have no
-// matching API callback correlation, so matchActivityToAPICall() fails and
-// matchError() silently drops every GPU zone.
+// Demonstrates that Tracy correctly shows GPU zones for kernels launched
+// via CUDA Graphs (cuGraphLaunch). Uses TracyCUDA to create a GPU context
+// and verifies that GPU zones appear with proper CPU-to-GPU correlation.
 //
 // Build:
-//   nvcc -o repro repro.cu -lcuda -lcupti -I/path/to/tracy/public \
-//        -DTRACY_ENABLE -DTRACY_ON_DEMAND
+//   make          # release build
+//   make debug    # debug build (asserts enabled)
 //
-// Run with Tracy profiler connected to see:
-//   - Unpatched: 0 GPU zones from the graph-launched kernels
-//   - Patched:   GPU zones appear for each kernel invocation
+// Run (start tracy-capture first, then run repro):
+//   tracy-capture -o out.tracy &
+//   ./repro
 
 #include <cstdio>
 #include <cstdlib>
 #include <cuda_runtime.h>
 
-// A trivial kernel — just increments each element.
+#include "tracy/Tracy.hpp"
+#include "tracy/TracyCUDA.hpp"
+
 __global__ void vector_add(float* a, float* b, float* c, int n) {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < n) {
@@ -36,16 +37,19 @@ __global__ void vector_add(float* a, float* b, float* c, int n) {
     } while (0)
 
 int main() {
-    const int N = 1 << 20;  // 1M elements
+    ZoneScoped;
+
+    auto ctx = TracyCUDAContext();
+    TracyCUDAStartProfiling(ctx);
+
+    const int N = 1 << 20;
     const size_t bytes = N * sizeof(float);
 
-    // Allocate device memory
     float *d_a, *d_b, *d_c;
     CHECK_CUDA(cudaMalloc(&d_a, bytes));
     CHECK_CUDA(cudaMalloc(&d_b, bytes));
     CHECK_CUDA(cudaMalloc(&d_c, bytes));
 
-    // Initialize with some data
     float* h_a = (float*)malloc(bytes);
     float* h_b = (float*)malloc(bytes);
     for (int i = 0; i < N; i++) {
@@ -59,44 +63,37 @@ int main() {
     cudaStream_t stream;
     CHECK_CUDA(cudaStreamCreate(&stream));
 
-    // Begin capture
     CHECK_CUDA(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
 
-    // Record operations into the graph
     int threadsPerBlock = 256;
     int blocksPerGrid = (N + threadsPerBlock - 1) / threadsPerBlock;
     vector_add<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(d_a, d_b, d_c, N);
     CHECK_CUDA(cudaMemcpyAsync(d_c, d_c, bytes, cudaMemcpyDeviceToDevice, stream));
     vector_add<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(d_a, d_c, d_c, N);
 
-    // End capture
     cudaGraph_t graph;
     CHECK_CUDA(cudaStreamEndCapture(stream, &graph));
 
-    // Instantiate the graph
     cudaGraphExec_t graphExec;
     CHECK_CUDA(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
 
     printf("CUDA Graph created with 3 nodes (kernel + memcpy + kernel)\n");
     printf("Launching graph 10 times...\n");
 
-    // --- Launch the graph multiple times ---
-    // With unpatched Tracy, these produce 0 GPU zones.
-    // With patched Tracy, each launch produces 3 GPU zones (2 kernels + 1 memcpy).
+    // Each launch should produce 3 GPU zones (2 kernels + 1 memcpy), all
+    // correlated back to the cuGraphLaunch CPU call site.
     for (int i = 0; i < 10; i++) {
+        ZoneScopedN("cuGraphLaunch iteration");
         CHECK_CUDA(cudaGraphLaunch(graphExec, stream));
     }
     CHECK_CUDA(cudaStreamSynchronize(stream));
 
-    printf("Done. Expected ~30 GPU zones in Tracy (10 launches x 3 ops).\n");
-    printf("Unpatched Tracy will show 0 GPU zones.\n");
+    printf("Done. Expected 30 GPU zones in Tracy (10 launches x 3 ops).\n");
 
-    // Verify correctness
     float* h_c = (float*)malloc(bytes);
     CHECK_CUDA(cudaMemcpy(h_c, d_c, bytes, cudaMemcpyDeviceToHost));
-    printf("Result check: c[0] = %.1f (expected 4.0 after two additions)\n", h_c[0]);
+    printf("Result check: c[0] = %.1f (expected 4.0)\n", h_c[0]);
 
-    // Cleanup
     CHECK_CUDA(cudaGraphExecDestroy(graphExec));
     CHECK_CUDA(cudaGraphDestroy(graph));
     CHECK_CUDA(cudaStreamDestroy(stream));
@@ -106,6 +103,9 @@ int main() {
     free(h_a);
     free(h_b);
     free(h_c);
+
+    TracyCUDAStopProfiling(ctx);
+    TracyCUDAContextDestroy(ctx);
 
     return 0;
 }

--- a/examples/CUDAGraphRepro/repro.cu
+++ b/examples/CUDAGraphRepro/repro.cu
@@ -1,0 +1,111 @@
+// Tracy CUDA Graph GPU Zone Repro
+//
+// Demonstrates that Tracy (unpatched) fails to show GPU zones for kernels
+// launched via CUDA Graphs. The CUPTI activity records arrive but have no
+// matching API callback correlation, so matchActivityToAPICall() fails and
+// matchError() silently drops every GPU zone.
+//
+// Build:
+//   nvcc -o repro repro.cu -lcuda -lcupti -I/path/to/tracy/public \
+//        -DTRACY_ENABLE -DTRACY_ON_DEMAND
+//
+// Run with Tracy profiler connected to see:
+//   - Unpatched: 0 GPU zones from the graph-launched kernels
+//   - Patched:   GPU zones appear for each kernel invocation
+
+#include <cstdio>
+#include <cstdlib>
+#include <cuda_runtime.h>
+
+// A trivial kernel — just increments each element.
+__global__ void vector_add(float* a, float* b, float* c, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        c[i] = a[i] + b[i];
+    }
+}
+
+#define CHECK_CUDA(call)                                                      \
+    do {                                                                       \
+        cudaError_t err = (call);                                              \
+        if (err != cudaSuccess) {                                              \
+            fprintf(stderr, "CUDA error at %s:%d: %s\n", __FILE__, __LINE__,  \
+                    cudaGetErrorString(err));                                   \
+            exit(1);                                                           \
+        }                                                                      \
+    } while (0)
+
+int main() {
+    const int N = 1 << 20;  // 1M elements
+    const size_t bytes = N * sizeof(float);
+
+    // Allocate device memory
+    float *d_a, *d_b, *d_c;
+    CHECK_CUDA(cudaMalloc(&d_a, bytes));
+    CHECK_CUDA(cudaMalloc(&d_b, bytes));
+    CHECK_CUDA(cudaMalloc(&d_c, bytes));
+
+    // Initialize with some data
+    float* h_a = (float*)malloc(bytes);
+    float* h_b = (float*)malloc(bytes);
+    for (int i = 0; i < N; i++) {
+        h_a[i] = 1.0f;
+        h_b[i] = 2.0f;
+    }
+    CHECK_CUDA(cudaMemcpy(d_a, h_a, bytes, cudaMemcpyHostToDevice));
+    CHECK_CUDA(cudaMemcpy(d_b, h_b, bytes, cudaMemcpyHostToDevice));
+
+    // --- Create a CUDA Graph via stream capture ---
+    cudaStream_t stream;
+    CHECK_CUDA(cudaStreamCreate(&stream));
+
+    // Begin capture
+    CHECK_CUDA(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+
+    // Record operations into the graph
+    int threadsPerBlock = 256;
+    int blocksPerGrid = (N + threadsPerBlock - 1) / threadsPerBlock;
+    vector_add<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(d_a, d_b, d_c, N);
+    CHECK_CUDA(cudaMemcpyAsync(d_c, d_c, bytes, cudaMemcpyDeviceToDevice, stream));
+    vector_add<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(d_a, d_c, d_c, N);
+
+    // End capture
+    cudaGraph_t graph;
+    CHECK_CUDA(cudaStreamEndCapture(stream, &graph));
+
+    // Instantiate the graph
+    cudaGraphExec_t graphExec;
+    CHECK_CUDA(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+    printf("CUDA Graph created with 3 nodes (kernel + memcpy + kernel)\n");
+    printf("Launching graph 10 times...\n");
+
+    // --- Launch the graph multiple times ---
+    // With unpatched Tracy, these produce 0 GPU zones.
+    // With patched Tracy, each launch produces 3 GPU zones (2 kernels + 1 memcpy).
+    for (int i = 0; i < 10; i++) {
+        CHECK_CUDA(cudaGraphLaunch(graphExec, stream));
+    }
+    CHECK_CUDA(cudaStreamSynchronize(stream));
+
+    printf("Done. Expected ~30 GPU zones in Tracy (10 launches x 3 ops).\n");
+    printf("Unpatched Tracy will show 0 GPU zones.\n");
+
+    // Verify correctness
+    float* h_c = (float*)malloc(bytes);
+    CHECK_CUDA(cudaMemcpy(h_c, d_c, bytes, cudaMemcpyDeviceToHost));
+    printf("Result check: c[0] = %.1f (expected 4.0 after two additions)\n", h_c[0]);
+
+    // Cleanup
+    CHECK_CUDA(cudaGraphExecDestroy(graphExec));
+    CHECK_CUDA(cudaGraphDestroy(graph));
+    CHECK_CUDA(cudaStreamDestroy(stream));
+    CHECK_CUDA(cudaFree(d_a));
+    CHECK_CUDA(cudaFree(d_b));
+    CHECK_CUDA(cudaFree(d_c));
+    free(h_a);
+    free(h_b);
+    free(h_c);
+
+    return 0;
+}

--- a/examples/CUDAGraphRepro/test_corr_reuse.cu
+++ b/examples/CUDAGraphRepro/test_corr_reuse.cu
@@ -1,0 +1,106 @@
+// Investigate: does relaunching the same cudaGraphExec produce a new correlationId
+// each time, or is the correlationId reused/fixed per exec handle?
+//
+// Also checks: do different graphExec handles for the same graph share graphId?
+#include <cstdio>
+#include <cuda_runtime.h>
+#include <cupti.h>
+
+#define CHECK(x) do { cudaError_t e=(x); if(e!=cudaSuccess){fprintf(stderr,"CUDA %s:%d: %s\n",__FILE__,__LINE__,cudaGetErrorString(e));exit(1);} } while(0)
+#define CHECK_CUPTI(x) do { CUptiResult e=(x); if(e!=CUPTI_SUCCESS){const char*s;cuptiGetResultString(e,&s);fprintf(stderr,"CUPTI %s:%d: %s\n",__FILE__,__LINE__,s);exit(1);} } while(0)
+
+struct Record { uint32_t corr; uint32_t graphId; };
+static Record records[64];
+static int nrecords = 0;
+
+static void CUPTIAPI bufferRequested(uint8_t** buf, size_t* size, size_t* maxNumRecords) {
+    *size = 1 << 20; *buf = (uint8_t*)malloc(*size); *maxNumRecords = 0;
+}
+static void CUPTIAPI bufferCompleted(CUcontext ctx, uint32_t streamId,
+                                      uint8_t* buf, size_t size, size_t validSize) {
+    CUpti_Activity* record = nullptr;
+    while (cuptiActivityGetNextRecord(buf, validSize, &record) == CUPTI_SUCCESS) {
+        if (record->kind == CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL) {
+            auto* k = (CUpti_ActivityKernel9*)record;
+            if (nrecords < 64)
+                records[nrecords++] = { k->correlationId, k->graphId };
+        }
+    }
+    free(buf);
+}
+
+__global__ void dummy(int* x) { atomicAdd(x, 1); }
+
+static uint32_t launchCorrId[32];
+static int nlaunch = 0;
+
+// Intercept cudaGraphLaunch via CUPTI callback to capture the correlationId
+// assigned to each launch on the CPU side
+static void CUPTIAPI onCallback(void* userdata, CUpti_CallbackDomain domain,
+                                 CUpti_CallbackId cbid, const void* cbdata) {
+    if (domain != CUPTI_CB_DOMAIN_RUNTIME_API) return;
+    if (cbid != CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000) return;
+    auto* api = (CUpti_CallbackData*)cbdata;
+    if (api->callbackSite == CUPTI_API_ENTER && nlaunch < 32)
+        launchCorrId[nlaunch++] = api->correlationId;
+}
+
+int main() {
+    CHECK_CUPTI(cuptiActivityRegisterCallbacks(bufferRequested, bufferCompleted));
+    CHECK_CUPTI(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+
+    CUpti_SubscriberHandle sub;
+    CHECK_CUPTI(cuptiSubscribe(&sub, onCallback, nullptr));
+    CHECK_CUPTI(cuptiEnableCallback(1, sub, CUPTI_CB_DOMAIN_RUNTIME_API,
+                                    CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000));
+
+    cudaStream_t stream; CHECK(cudaStreamCreate(&stream));
+    int* d_x; CHECK(cudaMalloc(&d_x, sizeof(int)));
+
+    // Build a simple graph with one kernel
+    cudaGraph_t graph; cudaGraphExec_t exec;
+    CHECK(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+    dummy<<<1,1,0,stream>>>(d_x);
+    CHECK(cudaStreamEndCapture(stream, &graph));
+    CHECK(cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+    // Launch the SAME exec handle 5 times
+    printf("=== Same exec, 5 launches ===\n");
+    for (int i = 0; i < 5; i++)
+        CHECK(cudaGraphLaunch(exec, stream));
+    CHECK(cudaStreamSynchronize(stream));
+    CHECK_CUPTI(cuptiActivityFlushAll(1));
+
+    printf("CPU-side launch correlationIds:\n");
+    for (int i = 0; i < nlaunch; i++)
+        printf("  launch[%d] corr=%u\n", i, launchCorrId[i]);
+    printf("GPU activity records (CONCURRENT_KERNEL):\n");
+    for (int i = 0; i < nrecords; i++)
+        printf("  kernel[%d] corr=%-4u graphId=%u\n", i, records[i].corr, records[i].graphId);
+
+    // Check: do CPU launch corrIds match GPU activity corrIds?
+    bool allMatch = (nlaunch == nrecords);
+    for (int i = 0; allMatch && i < nlaunch; i++)
+        allMatch = (launchCorrId[i] == records[i].corr);
+    printf("All launch corrIds match kernel corrIds: %s\n", allMatch ? "YES" : "NO (order may differ)");
+
+    // Now test: two different exec handles from the same graph — same graphId?
+    printf("\n=== Two exec handles from same graph ===\n");
+    nlaunch = 0; nrecords = 0;
+    cudaGraphExec_t exec2;
+    CHECK(cudaGraphInstantiate(&exec2, graph, nullptr, nullptr, 0));
+    CHECK(cudaGraphLaunch(exec,  stream));
+    CHECK(cudaGraphLaunch(exec2, stream));
+    CHECK(cudaStreamSynchronize(stream));
+    CHECK_CUPTI(cuptiActivityFlushAll(1));
+    for (int i = 0; i < nrecords; i++)
+        printf("  kernel[%d] corr=%-4u graphId=%u\n", i, records[i].corr, records[i].graphId);
+
+    CHECK(cudaGraphExecDestroy(exec));
+    CHECK(cudaGraphExecDestroy(exec2));
+    CHECK(cudaGraphDestroy(graph));
+    CHECK(cudaFree(d_x));
+    CHECK(cudaStreamDestroy(stream));
+    CHECK_CUPTI(cuptiUnsubscribe(sub));
+    return 0;
+}

--- a/examples/CUDAGraphRepro/test_graphid_recycle.cu
+++ b/examples/CUDAGraphRepro/test_graphid_recycle.cu
@@ -1,0 +1,139 @@
+// test_graphid_recycle.cu
+//
+// Investigates whether CUPTI recycles graphId values after cudaGraphExecDestroy.
+//
+// Question: Can two *different* graph exec handles ever produce the same graphId?
+// (If yes, the graphLaunchCache in TracyCUDA.hpp could serve stale entries.)
+//
+// Rounds:
+//   Round 1: create + instantiate + launch + destroy graph A → record graphId
+//   Round 2: create + instantiate + launch + destroy graph B → does it reuse A's graphId?
+//   Round 3: 20 rapid create/launch/destroy cycles → attempt to exhaust any counter
+
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <vector>
+#include <set>
+#include <cuda_runtime.h>
+#include <cupti.h>
+
+#define CHECK_CUDA(call)                                                       \
+    do {                                                                       \
+        cudaError_t err = (call);                                              \
+        if (err != cudaSuccess) {                                              \
+            fprintf(stderr, "CUDA error at %s:%d: %s\n",                      \
+                    __FILE__, __LINE__, cudaGetErrorString(err));              \
+            exit(1);                                                           \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_CUPTI(call)                                                      \
+    do {                                                                       \
+        CUptiResult err = (call);                                              \
+        if (err != CUPTI_SUCCESS) {                                            \
+            const char* msg;                                                   \
+            cuptiGetResultString(err, &msg);                                   \
+            fprintf(stderr, "CUPTI error at %s:%d: %s\n",                     \
+                    __FILE__, __LINE__, msg);                                  \
+            exit(1);                                                           \
+        }                                                                      \
+    } while (0)
+
+static std::vector<uint32_t> g_observed_graphIds;
+
+static void CUPTIAPI bufferRequested(uint8_t** buffer, size_t* size, size_t* maxNumRecords) {
+    *size = 1 << 20;
+    *buffer = (uint8_t*)malloc(*size);
+    *maxNumRecords = 0;
+}
+
+static void CUPTIAPI bufferCompleted(CUcontext ctx, uint32_t streamId,
+                                     uint8_t* buffer, size_t size, size_t validSize) {
+    CUpti_Activity* record = nullptr;
+    while (cuptiActivityGetNextRecord(buffer, validSize, &record) == CUPTI_SUCCESS) {
+        if (record->kind == CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL) {
+            auto* kernel = (CUpti_ActivityKernel9*)record;
+            g_observed_graphIds.push_back(kernel->graphId);
+        }
+    }
+    free(buffer);
+}
+
+__global__ void dummy_kernel() {}
+
+static uint32_t launchAndGetGraphId(cudaStream_t stream) {
+    size_t before = g_observed_graphIds.size();
+
+    cudaGraph_t graph;
+    cudaGraphExec_t exec;
+    CHECK_CUDA(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+    dummy_kernel<<<1, 1, 0, stream>>>();
+    CHECK_CUDA(cudaStreamEndCapture(stream, &graph));
+    CHECK_CUDA(cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+    CHECK_CUDA(cudaGraphLaunch(exec, stream));
+    CHECK_CUDA(cudaStreamSynchronize(stream));
+    CHECK_CUPTI(cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
+
+    CHECK_CUDA(cudaGraphExecDestroy(exec));
+    CHECK_CUDA(cudaGraphDestroy(graph));
+
+    if (g_observed_graphIds.size() <= before) {
+        fprintf(stderr, "ERROR: No CONCURRENT_KERNEL record received\n");
+        return 0;
+    }
+    return g_observed_graphIds.back();
+}
+
+int main() {
+    // Initialize CUDA context
+    cudaFree(0);
+
+    CHECK_CUPTI(cuptiActivityRegisterCallbacks(bufferRequested, bufferCompleted));
+    CHECK_CUPTI(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+
+    cudaStream_t stream;
+    CHECK_CUDA(cudaStreamCreate(&stream));
+
+    // Round 1
+    uint32_t id1 = launchAndGetGraphId(stream);
+    printf("Round 1 graphId: %u\n", id1);
+
+    // Round 2: new exec after round 1 destroyed
+    uint32_t id2 = launchAndGetGraphId(stream);
+    printf("Round 2 graphId: %u\n", id2);
+
+    if (id1 == id2) {
+        printf("*** RECYCLE DETECTED: id1 == id2 == %u ***\n", id1);
+    } else {
+        printf("Round 2 got different graphId (no recycle after 1 destroy)\n");
+    }
+
+    // Round 3: 20 rapid cycles — try to exhaust monotonic counter
+    printf("\nRound 3: 20 rapid create/launch/destroy cycles\n");
+    std::set<uint32_t> seen;
+    seen.insert(id1);
+    seen.insert(id2);
+    bool recycle_seen = false;
+    for (int i = 0; i < 20; i++) {
+        uint32_t id = launchAndGetGraphId(stream);
+        printf("  cycle %2d: graphId = %u", i + 1, id);
+        if (seen.count(id)) {
+            printf("  *** RECYCLED (seen before) ***");
+            recycle_seen = true;
+        }
+        printf("\n");
+        seen.insert(id);
+    }
+
+    if (!recycle_seen) {
+        printf("\nNo graphId recycling observed across %zu total launches.\n", seen.size());
+        printf("graphId appears to be a monotonically increasing counter.\n");
+        printf("Min=%u  Max=%u  Count=%zu\n",
+               *seen.begin(), *seen.rbegin(), seen.size());
+    }
+
+    CHECK_CUDA(cudaStreamDestroy(stream));
+    CHECK_CUPTI(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+    return 0;
+}

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -1110,6 +1110,11 @@ namespace tracy
             {
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[malloc/free]", instrument);
                 CUpti_ActivityMemory3* memory3 = (CUpti_ActivityMemory3*)record;
+                // NOTE: CUpti_ActivityMemory3 has no graphId field, so matchGraphActivityToAPICall
+                // cannot be used here. Graph-launched memory alloc nodes (cudaGraphAddMemAllocNode)
+                // share the launch's correlationId and CUPTI emits multiple MEMORY2 records per node.
+                // The first record consumes the cudaCallSiteInfo entry; subsequent ones will fire a
+                // spurious matchError and skip memory tracking. This is a known limitation.
                 APICallInfo apiCall;
                 if (!matchActivityToAPICall(memory3->correlationId, apiCall)) {
                     return matchError(memory3->correlationId, "MEMORY");

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -360,6 +360,11 @@ struct ConcurrentHashMap {
         auto lock = acquire_write_lock();
         return mapping.erase(key);
     }
+    auto insert_or_assign(TKey key, TValue value) {
+        ZoneNamed(insert_or_assign, instrument);
+        auto lock = acquire_write_lock();
+        return mapping.insert_or_assign(std::move(key), std::move(value));
+    }
 };
 
 #if TRACY_CUDA_ENABLE_CUDA_CALL_STATS
@@ -917,9 +922,7 @@ namespace tracy
                     return false;
                 }
             } else if (graphId != 0) {
-                auto& cache = PersistentState::Get().cudaGraphCurrentLaunch;
-                cache.erase(graphId);
-                cache.emplace(graphId, apiCallInfo);
+                PersistentState::Get().cudaGraphCurrentLaunch.insert_or_assign(graphId, apiCallInfo);
             }
             return true;
         }

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -819,9 +819,10 @@ namespace tracy
                         { CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_ptsz_v7000,     GET_STREAM_FUNC(cudaLaunchKernel_ptsz_v7000_params, stream) },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060,      GET_STREAM_FUNC(cudaLaunchKernelExC_v11060_params, config->stream) },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_ptsz_v11060, GET_STREAM_FUNC(cudaLaunchKernelExC_ptsz_v11060_params, config->stream) },
-                        // Runtime: Memory
-                        { CUPTI_RUNTIME_TRACE_CBID_cudaMalloc_v3020, NON_STREAM_FUNC() },
-                        { CUPTI_RUNTIME_TRACE_CBID_cudaFree_v3020,   NON_STREAM_FUNC() },
+                        // Runtime: Memory — NOT tracked here. The MEMORY2 handler
+                        // only needs address/size/timestamp from the activity record
+                        // and never calls EmitGpuZone, so there is no consumer for
+                        // the cudaCallSiteInfo entry. Tracking them would leak entries.
                         // Runtime: Memcpy
                         { CUPTI_RUNTIME_TRACE_CBID_cudaMemcpy_v3020,      NON_STREAM_FUNC() },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaMemcpyAsync_v3020, GET_STREAM_FUNC(cudaMemcpyAsync_v3020_params, stream) },
@@ -856,11 +857,7 @@ namespace tracy
                         { CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel_ptsz,   GET_STREAM_FUNC(cuLaunchKernel_ptsz_params, hStream)} ,
                         { CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx,      GET_STREAM_FUNC(cuLaunchKernelEx_params, config->hStream) },
                         { CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx_ptsz, GET_STREAM_FUNC(cuLaunchKernelEx_params, config->hStream) },
-                        // Driver: Memory
-                        { CUPTI_DRIVER_TRACE_CBID_cuMemAlloc_v2,         NON_STREAM_FUNC() },
-                        { CUPTI_DRIVER_TRACE_CBID_cuMemAllocManaged,     NON_STREAM_FUNC() },
-                        { CUPTI_DRIVER_TRACE_CBID_cuMemAllocPitch_v2,    NON_STREAM_FUNC() },
-                        { CUPTI_DRIVER_TRACE_CBID_cuMemFree_v2,          NON_STREAM_FUNC() },
+                        // Driver: Memory — NOT tracked (see Runtime: Memory comment above).
                         // Driver: Memcpy - Synchronous
                         { CUPTI_DRIVER_TRACE_CBID_cuMemcpy,              NON_STREAM_FUNC() },
                         { CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoD_v2,       NON_STREAM_FUNC() },

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -786,6 +786,10 @@ namespace tracy
                         { CUPTI_RUNTIME_TRACE_CBID_cudaEventQuery_v3020,        NON_STREAM_FUNC() },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaStreamWaitEvent_v3020,   NON_STREAM_FUNC() },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaDeviceSynchronize_v3020, NON_STREAM_FUNC() },
+                        // Graph launch: tracked so we can correlate GPU activities back to
+                        // the cudaGraphLaunch call site via CUPTI_ACTIVITY_KIND_GRAPH_TRACE
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000,      GET_STREAM_FUNC(cudaGraphLaunch_v10000_params, stream) },
+                        { CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_ptsz_v10000, GET_STREAM_FUNC(cudaGraphLaunch_v10000_params, stream) },
                     };
                     #undef NON_STREAM_FUNC
                     #undef GET_STREAM_FUNC

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -1110,13 +1110,13 @@ namespace tracy
             {
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[malloc/free]", instrument);
                 CUpti_ActivityMemory3* memory3 = (CUpti_ActivityMemory3*)record;
-                // Memory alloc/free records may not have a matching API call entry —
-                // e.g. allocations made before profiling started, or nodes inside a
-                // CUDA graph launch (CUpti_ActivityMemory3 has no graphId field).
-                // The handler only needs address, size, and timestamp from the activity
-                // record, so we proceed regardless of whether correlation succeeds.
-                APICallInfo apiCall;
-                matchActivityToAPICall(memory3->correlationId, apiCall);
+                // Do NOT call matchActivityToAPICall here. The handler only needs
+                // address, size, and timestamp — apiCall is never used. More importantly,
+                // consuming the cudaCallSiteInfo entry would break kernel/memcpy zone
+                // correlation for graphs that mix alloc nodes with other node types: all
+                // activities in one graph launch share the same correlationId, so consuming
+                // it here would prevent matchGraphActivityToAPICall from finding it for the
+                // subsequent kernel or memcpy records from the same launch.
                 static constexpr const char* graph_name = "CUDA Memory Allocation";
                 if (memory3->memoryOperationType == CUPTI_ACTIVITY_MEMORY_OPERATION_TYPE_ALLOCATION){
                     auto& memAllocAddress = PersistentState::Get().memAllocAddress;

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -660,15 +660,44 @@ namespace tracy
             FlushActivityAsync();
         }
 
+        // Returns the graphId field from activity record kinds that carry one,
+        // or 0 for records that are not graph-launched or don't have the field.
+        static uint32_t getGraphIdFromRecord(const CUpti_Activity* record) {
+            switch (record->kind) {
+                case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL:
+                    return reinterpret_cast<const CUpti_ActivityKernel9*>(record)->graphId;
+                case CUPTI_ACTIVITY_KIND_MEMCPY:
+                    return reinterpret_cast<const CUpti_ActivityMemcpy5*>(record)->graphId;
+                case CUPTI_ACTIVITY_KIND_MEMSET:
+                    return reinterpret_cast<const CUpti_ActivityMemset4*>(record)->graphId;
+                default:
+                    return 0;
+            }
+        }
+
         static void CUPTIAPI OnBufferCompleted(CUcontext ctx, uint32_t streamId, uint8_t* buffer, size_t size, size_t validSize)
         {
             // CUDA 6.0 onwards: all buffers from this callback are "global" buffers
             // (i.e. there is no context/stream specific buffer; ctx is always NULL)
             ZoneScoped;
             tracy::SetThreadName("NVIDIA CUPTI Worker");
+            // Check if any graph execs are pending retirement before entering
+            // the record loop — avoids the graphIdsSeenInBuffer heap allocation
+            // on the hot path when no execs have been destroyed.
+            bool trackRetirement;
+            {
+                auto& state = PersistentState::Get();
+                std::lock_guard<std::mutex> lock(state.graphRetireMutex);
+                trackRetirement = !state.graphExecPendingRetire.empty();
+            }
             CUptiResult status;
             CUpti_Activity* record = nullptr;
+            std::unordered_set<uint32_t> graphIdsSeenInBuffer;
             while ((status = cuptiActivityGetNextRecord(buffer, validSize, &record)) == CUPTI_SUCCESS) {
+                if (trackRetirement) {
+                    uint32_t gId = getGraphIdFromRecord(record);
+                    if (gId != 0) graphIdsSeenInBuffer.insert(gId);
+                }
                 DoProcessDeviceEvent(record);
             }
             if (status != CUPTI_ERROR_MAX_LIMIT_REACHED) {
@@ -678,6 +707,28 @@ namespace tracy
             CUPTI_API_CALL(cuptiActivityGetNumDroppedRecords(ctx, streamId, &dropped));
             assert(dropped == 0);
             tracyFree(buffer);
+
+            // Retire cudaGraphCurrentLaunch entries for destroyed exec handles.
+            // We defer erasure until a buffer arrives that contains no records
+            // from the exec: if the graphId still appears here, more records may
+            // be in flight. Once a full buffer passes with no records for that
+            // graphId, all in-flight activity for that exec has been delivered.
+            // Note: holds graphRetireMutex then acquires cudaGraphCurrentLaunch's
+            // internal shared_mutex — lock order is always outer→inner, no deadlock.
+            if (trackRetirement) {
+                auto& state = PersistentState::Get();
+                std::lock_guard<std::mutex> lock(state.graphRetireMutex);
+                for (auto it = state.graphExecPendingRetire.begin();
+                     it != state.graphExecPendingRetire.end(); ) {
+                    if (graphIdsSeenInBuffer.count(*it) == 0) {
+                        state.cudaGraphCurrentLaunch.erase(*it);
+                        it = state.graphExecPendingRetire.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+            }
+
             PersistentState::Get().profilerHost->OnEventsProcessed();
         }
 
@@ -872,6 +923,30 @@ namespace tracy
                 auto& entryFlags = *apiInfo->correlationData;
                 assert(entryFlags == 0);
                 entryFlags |= trackDeviceActivity ? 0x8000 : 0;
+
+                // On graph exec destruction, record the graphId for deferred
+                // retirement of its cudaGraphCurrentLaunch cache entry.
+                // cuptiGetGraphExecId must be called here (ENTER), while the
+                // handle is still valid — at EXIT it has already been freed.
+                // Actual erasure is deferred to OnBufferCompleted so we don't
+                // race with CUPTI activity records that are still in-flight.
+                {
+                    uint32_t retireGraphId = 0;
+                    if (domain == CUPTI_CB_DOMAIN_RUNTIME_API &&
+                        cbid == CUPTI_RUNTIME_TRACE_CBID_cudaGraphExecDestroy_v10000) {
+                        auto* p = (cudaGraphExecDestroy_v10000_params*)apiInfo->functionParams;
+                        CUPTI_API_CALL(cuptiGetGraphExecId((CUgraphExec)p->graphExec, &retireGraphId));
+                    } else if (domain == CUPTI_CB_DOMAIN_DRIVER_API &&
+                               cbid == CUPTI_DRIVER_TRACE_CBID_cuGraphExecDestroy) {
+                        auto* p = (cuGraphExecDestroy_params*)apiInfo->functionParams;
+                        CUPTI_API_CALL(cuptiGetGraphExecId(p->hGraphExec, &retireGraphId));
+                    }
+                    if (retireGraphId != 0) {
+                        auto& state = PersistentState::Get();
+                        std::lock_guard<std::mutex> lock(state.graphRetireMutex);
+                        state.graphExecPendingRetire.insert(retireGraphId);
+                    }
+                }
             }
 
             if (apiInfo->callbackSite == CUPTI_API_EXIT) {
@@ -1307,6 +1382,11 @@ namespace tracy
             ConcurrentHashMap<CorrelationID, APICallInfo> cudaCallSiteInfo;
             ConcurrentHashMap<uint32_t, APICallInfo> cudaGraphCurrentLaunch;
             ConcurrentHashMap<uintptr_t, int> memAllocAddress;
+            // Pending retirement: graphIds whose exec handles have been destroyed.
+            // Entries are erased from cudaGraphCurrentLaunch in OnBufferCompleted
+            // once no further activity records for the exec arrive in a buffer.
+            std::mutex graphRetireMutex;
+            std::unordered_set<uint32_t> graphExecPendingRetire;
             CUpti_SubscriberHandle subscriber = {};
             CUDACtx* profilerHost = nullptr;
 

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -903,6 +903,27 @@ namespace tracy
             return true;
         }
 
+        // Like matchActivityToAPICall, but also handles graph-launched activities.
+        // All activities in one cuGraphLaunch share the launch's correlationId, so
+        // the first activity consumes the cudaCallSiteInfo entry and caches it by
+        // graphId; subsequent activities from the same launch find it via graphId.
+        // Returns false (and emits a Tracy error message) only if no match is found
+        // via either path.
+        static bool matchGraphActivityToAPICall(uint32_t correlationId, uint32_t graphId,
+                                                APICallInfo& apiCallInfo, const char* kind) {
+            if (!matchActivityToAPICall(correlationId, apiCallInfo)) {
+                if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCallInfo)) {
+                    matchError(correlationId, kind);
+                    return false;
+                }
+            } else if (graphId != 0) {
+                auto& cache = PersistentState::Get().cudaGraphCurrentLaunch;
+                cache.erase(graphId);
+                cache.emplace(graphId, apiCallInfo);
+            }
+            return true;
+        }
+
         static void matchError(uint32_t correlationId, const char* kind) {
             char msg [128];
             snprintf(msg, sizeof(msg), "ERROR: device activity '%s' has no matching CUDA API call (id=%u).", kind, correlationId);
@@ -1005,20 +1026,8 @@ namespace tracy
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[kernel]", instrument);
                 CUpti_ActivityKernel9* kernel9 = (CUpti_ActivityKernel9*) record;
                 APICallInfo apiCall;
-                if (!matchActivityToAPICall(kernel9->correlationId, apiCall)) {
-                    // All kernels in one cuGraphLaunch share the launch's correlationId.
-                    // The first kernel consumes the cudaCallSiteInfo entry; subsequent
-                    // ones find the cached APICallInfo in cudaGraphCurrentLaunch[graphId].
-                    uint32_t graphId = kernel9->graphId;
-                    if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCall)) {
-                        return matchError(kernel9->correlationId, "KERNEL");
-                    }
-                } else if (kernel9->graphId != 0) {
-                    // Cache the APICallInfo for the other kernels in this graph launch
-                    // that share the same correlationId (which was just erased above).
-                    auto& cache = PersistentState::Get().cudaGraphCurrentLaunch;
-                    cache.erase(kernel9->graphId);
-                    cache.emplace(kernel9->graphId, apiCall);
+                if (!matchGraphActivityToAPICall(kernel9->correlationId, kernel9->graphId, apiCall, "KERNEL")) {
+                    return;
                 }
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, kernel9->start, kernel9->end, getKernelSourceLocation(kernel9->name), kernel9->contextId, kernel9->streamId);
                 auto latency_ms = (kernel9->start - apiCall.cupti) / 1'000'000.0;
@@ -1031,15 +1040,8 @@ namespace tracy
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[memcpy]", instrument);
                 CUpti_ActivityMemcpy5* memcpy5 = (CUpti_ActivityMemcpy5*) record;
                 APICallInfo apiCall;
-                if (!matchActivityToAPICall(memcpy5->correlationId, apiCall)) {
-                    uint32_t graphId = memcpy5->graphId;
-                    if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCall)) {
-                        return matchError(memcpy5->correlationId, "MEMCPY");
-                    }
-                } else if (memcpy5->graphId != 0) {
-                    auto& cache = PersistentState::Get().cudaGraphCurrentLaunch;
-                    cache.erase(memcpy5->graphId);
-                    cache.emplace(memcpy5->graphId, apiCall);
+                if (!matchGraphActivityToAPICall(memcpy5->correlationId, memcpy5->graphId, apiCall, "MEMCPY")) {
+                    return;
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemcpy { "CUDA::memcpy", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memcpy5->start, memcpy5->end, &TracyCUPTISrcLocDeviceMemcpy, memcpy5->contextId, memcpy5->streamId);
@@ -1054,15 +1056,8 @@ namespace tracy
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[memset]", instrument);
                 CUpti_ActivityMemset4* memset4 = (CUpti_ActivityMemset4*) record;
                 APICallInfo apiCall;
-                if (!matchActivityToAPICall(memset4->correlationId, apiCall)) {
-                    uint32_t graphId = memset4->graphId;
-                    if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCall)) {
-                        return matchError(memset4->correlationId, "MEMSET");
-                    }
-                } else if (memset4->graphId != 0) {
-                    auto& cache = PersistentState::Get().cudaGraphCurrentLaunch;
-                    cache.erase(memset4->graphId);
-                    cache.emplace(memset4->graphId, apiCall);
+                if (!matchGraphActivityToAPICall(memset4->correlationId, memset4->graphId, apiCall, "MEMSET")) {
+                    return;
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemset { "CUDA::memset", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memset4->start, memset4->end, &TracyCUPTISrcLocDeviceMemset, memset4->contextId, memset4->streamId);

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -998,7 +998,12 @@ namespace tracy
                 CUpti_ActivityKernel9* kernel9 = (CUpti_ActivityKernel9*) record;
                 APICallInfo apiCall;
                 if (!matchActivityToAPICall(kernel9->correlationId, apiCall)) {
-                    return matchError(kernel9->correlationId, "KERNEL");
+                    // Fallback for CUDA Graph-launched kernels: create GPU zone
+                    // using kernel timestamps when no API callback correlation exists.
+                    auto* host = PersistentState::Get().profilerHost;
+                    if (!host) return;
+                    TracyTimestamp cpuTime = tracyFromCUpti(kernel9->start);
+                    apiCall = APICallInfo{ cpuTime, cpuTime, kernel9->start, host };
                 }
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, kernel9->start, kernel9->end, getKernelSourceLocation(kernel9->name), kernel9->contextId, kernel9->streamId);
                 auto latency_ms = (kernel9->start - apiCall.cupti) / 1'000'000.0;
@@ -1012,7 +1017,12 @@ namespace tracy
                 CUpti_ActivityMemcpy5* memcpy5 = (CUpti_ActivityMemcpy5*) record;
                 APICallInfo apiCall;
                 if (!matchActivityToAPICall(memcpy5->correlationId, apiCall)) {
-                    return matchError(memcpy5->correlationId, "MEMCPY");
+                    // Fallback for CUDA Graph memcpy: create GPU zone using
+                    // activity timestamps when no API callback correlation exists.
+                    auto* host = PersistentState::Get().profilerHost;
+                    if (!host) return;
+                    TracyTimestamp cpuTime = tracyFromCUpti(memcpy5->start);
+                    apiCall = APICallInfo{ cpuTime, cpuTime, memcpy5->start, host };
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemcpy { "CUDA::memcpy", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memcpy5->start, memcpy5->end, &TracyCUPTISrcLocDeviceMemcpy, memcpy5->contextId, memcpy5->streamId);
@@ -1028,7 +1038,12 @@ namespace tracy
                 CUpti_ActivityMemset4* memset4 = (CUpti_ActivityMemset4*) record;
                 APICallInfo apiCall;
                 if (!matchActivityToAPICall(memset4->correlationId, apiCall)) {
-                    return matchError(memset4->correlationId, "MEMSET");
+                    // Fallback for CUDA Graph memset: create GPU zone using
+                    // activity timestamps when no API callback correlation exists.
+                    auto* host = PersistentState::Get().profilerHost;
+                    if (!host) return;
+                    TracyTimestamp cpuTime = tracyFromCUpti(memset4->start);
+                    apiCall = APICallInfo{ cpuTime, cpuTime, memset4->start, host };
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemset { "CUDA::memset", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memset4->start, memset4->end, &TracyCUPTISrcLocDeviceMemset, memset4->contextId, memset4->streamId);

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -661,9 +661,18 @@ namespace tracy
             ZoneScoped;
             tracy::SetThreadName("NVIDIA CUPTI Worker");
             CUptiResult status;
+            // Two-pass processing: GRAPH_TRACE records complete last on the GPU (after
+            // all their child kernels), so they appear at the end of the buffer. Process
+            // them first to populate the graphId->APICallInfo map before kernels look it up.
             CUpti_Activity* record = nullptr;
+            while (cuptiActivityGetNextRecord(buffer, validSize, &record) == CUPTI_SUCCESS) {
+                if (record->kind == CUPTI_ACTIVITY_KIND_GRAPH_TRACE)
+                    DoProcessDeviceEvent(record);
+            }
+            record = nullptr;
             while ((status = cuptiActivityGetNextRecord(buffer, validSize, &record)) == CUPTI_SUCCESS) {
-                DoProcessDeviceEvent(record);
+                if (record->kind != CUPTI_ACTIVITY_KIND_GRAPH_TRACE)
+                    DoProcessDeviceEvent(record);
             }
             if (status != CUPTI_ERROR_MAX_LIMIT_REACHED) {
                 CUptiCallChecked(status, "cuptiActivityGetNextRecord", TracyFile, TracyLine);
@@ -833,6 +842,10 @@ namespace tracy
                         { CUPTI_DRIVER_TRACE_CBID_cuEventSynchronize,    NON_STREAM_FUNC() },
                         { CUPTI_DRIVER_TRACE_CBID_cuCtxSynchronize,      NON_STREAM_FUNC() },
                         { CUPTI_DRIVER_TRACE_CBID_cuStreamWaitEvent,     GET_STREAM_FUNC(cuStreamWaitEvent_params, hStream) },
+                        // Graph launch: tracked so we can correlate GPU activities back to
+                        // the cuGraphLaunch call site via CUPTI_ACTIVITY_KIND_GRAPH_TRACE
+                        { CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch,          GET_STREAM_FUNC(cuGraphLaunch_params, hStream) },
+                        { CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch_ptsz,     GET_STREAM_FUNC(cuGraphLaunch_params, hStream) },
                     };
                     #undef NON_STREAM_FUNC
                     #undef GET_STREAM_FUNC
@@ -998,12 +1011,12 @@ namespace tracy
                 CUpti_ActivityKernel9* kernel9 = (CUpti_ActivityKernel9*) record;
                 APICallInfo apiCall;
                 if (!matchActivityToAPICall(kernel9->correlationId, apiCall)) {
-                    // Fallback for CUDA Graph-launched kernels: create GPU zone
-                    // using kernel timestamps when no API callback correlation exists.
-                    auto* host = PersistentState::Get().profilerHost;
-                    if (!host) return;
-                    TracyTimestamp cpuTime = tracyFromCUpti(kernel9->start);
-                    apiCall = APICallInfo{ cpuTime, cpuTime, kernel9->start, host };
+                    uint32_t graphId = kernel9->graphId;
+                    if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCall)) {
+                        return matchError(kernel9->correlationId, "KERNEL");
+                    }
+                    // Don't erase cudaGraphCurrentLaunch: multiple kernels in the same
+                    // graph launch share this APICallInfo entry.
                 }
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, kernel9->start, kernel9->end, getKernelSourceLocation(kernel9->name), kernel9->contextId, kernel9->streamId);
                 auto latency_ms = (kernel9->start - apiCall.cupti) / 1'000'000.0;
@@ -1017,12 +1030,10 @@ namespace tracy
                 CUpti_ActivityMemcpy5* memcpy5 = (CUpti_ActivityMemcpy5*) record;
                 APICallInfo apiCall;
                 if (!matchActivityToAPICall(memcpy5->correlationId, apiCall)) {
-                    // Fallback for CUDA Graph memcpy: create GPU zone using
-                    // activity timestamps when no API callback correlation exists.
-                    auto* host = PersistentState::Get().profilerHost;
-                    if (!host) return;
-                    TracyTimestamp cpuTime = tracyFromCUpti(memcpy5->start);
-                    apiCall = APICallInfo{ cpuTime, cpuTime, memcpy5->start, host };
+                    uint32_t graphId = memcpy5->graphId;
+                    if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCall)) {
+                        return matchError(memcpy5->correlationId, "MEMCPY");
+                    }
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemcpy { "CUDA::memcpy", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memcpy5->start, memcpy5->end, &TracyCUPTISrcLocDeviceMemcpy, memcpy5->contextId, memcpy5->streamId);
@@ -1038,12 +1049,10 @@ namespace tracy
                 CUpti_ActivityMemset4* memset4 = (CUpti_ActivityMemset4*) record;
                 APICallInfo apiCall;
                 if (!matchActivityToAPICall(memset4->correlationId, apiCall)) {
-                    // Fallback for CUDA Graph memset: create GPU zone using
-                    // activity timestamps when no API callback correlation exists.
-                    auto* host = PersistentState::Get().profilerHost;
-                    if (!host) return;
-                    TracyTimestamp cpuTime = tracyFromCUpti(memset4->start);
-                    apiCall = APICallInfo{ cpuTime, cpuTime, memset4->start, host };
+                    uint32_t graphId = memset4->graphId;
+                    if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCall)) {
+                        return matchError(memset4->correlationId, "MEMSET");
+                    }
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemset { "CUDA::memset", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memset4->start, memset4->end, &TracyCUPTISrcLocDeviceMemset, memset4->contextId, memset4->streamId);
@@ -1117,6 +1126,18 @@ namespace tracy
                 }
                 break;
             }
+            case CUPTI_ACTIVITY_KIND_GRAPH_TRACE:
+            {
+                // Correlate the cuGraphLaunch API call to the graph's graphId so that
+                // kernel/memcpy/memset activities can look it up via their graphId field.
+                // cuGraphLaunch's correlationId == graphTrace->correlationId (per CUPTI docs).
+                auto* graphTrace = (CUpti_ActivityGraphTrace2*)record;
+                APICallInfo apiCall;
+                if (matchActivityToAPICall(graphTrace->correlationId, apiCall)) {
+                    PersistentState::Get().cudaGraphCurrentLaunch.emplace(graphTrace->graphId, apiCall);
+                }
+                break;
+            }
             case CUPTI_ACTIVITY_KIND_CUDA_EVENT :
             {
                 // NOTE(marcos): a byproduct of CUPTI_ACTIVITY_KIND_SYNCHRONIZATION
@@ -1151,6 +1172,7 @@ namespace tracy
             CUPTI_ACTIVITY_KIND_MEMSET,
             CUPTI_ACTIVITY_KIND_SYNCHRONIZATION,
             CUPTI_ACTIVITY_KIND_MEMORY2,
+            CUPTI_ACTIVITY_KIND_GRAPH_TRACE,
             //CUPTI_ACTIVITY_KIND_MEMCPY2,
             //CUPTI_ACTIVITY_KIND_OVERHEAD,
             //CUPTI_ACTIVITY_KIND_INTERNAL_LAUNCH_API,
@@ -1279,6 +1301,7 @@ namespace tracy
             // NOTE(marcos): these objects do not need to persist, but their relative
             // footprint is trivial enough that we don't care if we let them leak
             ConcurrentHashMap<CorrelationID, APICallInfo> cudaCallSiteInfo;
+            ConcurrentHashMap<uint32_t, APICallInfo> cudaGraphCurrentLaunch;
             ConcurrentHashMap<uintptr_t, int> memAllocAddress;
             CUpti_SubscriberHandle subscriber = {};
             CUDACtx* profilerHost = nullptr;

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -661,18 +661,9 @@ namespace tracy
             ZoneScoped;
             tracy::SetThreadName("NVIDIA CUPTI Worker");
             CUptiResult status;
-            // Two-pass processing: GRAPH_TRACE records complete last on the GPU (after
-            // all their child kernels), so they appear at the end of the buffer. Process
-            // them first to populate the graphId->APICallInfo map before kernels look it up.
             CUpti_Activity* record = nullptr;
-            while (cuptiActivityGetNextRecord(buffer, validSize, &record) == CUPTI_SUCCESS) {
-                if (record->kind == CUPTI_ACTIVITY_KIND_GRAPH_TRACE)
-                    DoProcessDeviceEvent(record);
-            }
-            record = nullptr;
             while ((status = cuptiActivityGetNextRecord(buffer, validSize, &record)) == CUPTI_SUCCESS) {
-                if (record->kind != CUPTI_ACTIVITY_KIND_GRAPH_TRACE)
-                    DoProcessDeviceEvent(record);
+                DoProcessDeviceEvent(record);
             }
             if (status != CUPTI_ERROR_MAX_LIMIT_REACHED) {
                 CUptiCallChecked(status, "cuptiActivityGetNextRecord", TracyFile, TracyLine);
@@ -1015,12 +1006,19 @@ namespace tracy
                 CUpti_ActivityKernel9* kernel9 = (CUpti_ActivityKernel9*) record;
                 APICallInfo apiCall;
                 if (!matchActivityToAPICall(kernel9->correlationId, apiCall)) {
+                    // All kernels in one cuGraphLaunch share the launch's correlationId.
+                    // The first kernel consumes the cudaCallSiteInfo entry; subsequent
+                    // ones find the cached APICallInfo in cudaGraphCurrentLaunch[graphId].
                     uint32_t graphId = kernel9->graphId;
                     if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCall)) {
                         return matchError(kernel9->correlationId, "KERNEL");
                     }
-                    // Don't erase cudaGraphCurrentLaunch: multiple kernels in the same
-                    // graph launch share this APICallInfo entry.
+                } else if (kernel9->graphId != 0) {
+                    // Cache the APICallInfo for the other kernels in this graph launch
+                    // that share the same correlationId (which was just erased above).
+                    auto& cache = PersistentState::Get().cudaGraphCurrentLaunch;
+                    cache.erase(kernel9->graphId);
+                    cache.emplace(kernel9->graphId, apiCall);
                 }
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, kernel9->start, kernel9->end, getKernelSourceLocation(kernel9->name), kernel9->contextId, kernel9->streamId);
                 auto latency_ms = (kernel9->start - apiCall.cupti) / 1'000'000.0;
@@ -1038,6 +1036,10 @@ namespace tracy
                     if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCall)) {
                         return matchError(memcpy5->correlationId, "MEMCPY");
                     }
+                } else if (memcpy5->graphId != 0) {
+                    auto& cache = PersistentState::Get().cudaGraphCurrentLaunch;
+                    cache.erase(memcpy5->graphId);
+                    cache.emplace(memcpy5->graphId, apiCall);
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemcpy { "CUDA::memcpy", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memcpy5->start, memcpy5->end, &TracyCUPTISrcLocDeviceMemcpy, memcpy5->contextId, memcpy5->streamId);
@@ -1057,6 +1059,10 @@ namespace tracy
                     if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCall)) {
                         return matchError(memset4->correlationId, "MEMSET");
                     }
+                } else if (memset4->graphId != 0) {
+                    auto& cache = PersistentState::Get().cudaGraphCurrentLaunch;
+                    cache.erase(memset4->graphId);
+                    cache.emplace(memset4->graphId, apiCall);
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemset { "CUDA::memset", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memset4->start, memset4->end, &TracyCUPTISrcLocDeviceMemset, memset4->contextId, memset4->streamId);
@@ -1130,18 +1136,6 @@ namespace tracy
                 }
                 break;
             }
-            case CUPTI_ACTIVITY_KIND_GRAPH_TRACE:
-            {
-                // Correlate the cuGraphLaunch API call to the graph's graphId so that
-                // kernel/memcpy/memset activities can look it up via their graphId field.
-                // cuGraphLaunch's correlationId == graphTrace->correlationId (per CUPTI docs).
-                auto* graphTrace = (CUpti_ActivityGraphTrace2*)record;
-                APICallInfo apiCall;
-                if (matchActivityToAPICall(graphTrace->correlationId, apiCall)) {
-                    PersistentState::Get().cudaGraphCurrentLaunch.emplace(graphTrace->graphId, apiCall);
-                }
-                break;
-            }
             case CUPTI_ACTIVITY_KIND_CUDA_EVENT :
             {
                 // NOTE(marcos): a byproduct of CUPTI_ACTIVITY_KIND_SYNCHRONIZATION
@@ -1176,7 +1170,10 @@ namespace tracy
             CUPTI_ACTIVITY_KIND_MEMSET,
             CUPTI_ACTIVITY_KIND_SYNCHRONIZATION,
             CUPTI_ACTIVITY_KIND_MEMORY2,
-            CUPTI_ACTIVITY_KIND_GRAPH_TRACE,
+            // NOTE: CUPTI_ACTIVITY_KIND_GRAPH_TRACE must NOT be enabled alongside
+            // CONCURRENT_KERNEL — enabling it suppresses per-kernel activity records
+            // for graph-launched kernels, replacing them with graph-level summaries.
+            //CUPTI_ACTIVITY_KIND_GRAPH_TRACE,
             //CUPTI_ACTIVITY_KIND_MEMCPY2,
             //CUPTI_ACTIVITY_KIND_OVERHEAD,
             //CUPTI_ACTIVITY_KIND_INTERNAL_LAUNCH_API,

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -1110,15 +1110,13 @@ namespace tracy
             {
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[malloc/free]", instrument);
                 CUpti_ActivityMemory3* memory3 = (CUpti_ActivityMemory3*)record;
-                // NOTE: CUpti_ActivityMemory3 has no graphId field, so matchGraphActivityToAPICall
-                // cannot be used here. Graph-launched memory alloc nodes (cudaGraphAddMemAllocNode)
-                // share the launch's correlationId and CUPTI emits multiple MEMORY2 records per node.
-                // The first record consumes the cudaCallSiteInfo entry; subsequent ones will fire a
-                // spurious matchError and skip memory tracking. This is a known limitation.
+                // Memory alloc/free records may not have a matching API call entry —
+                // e.g. allocations made before profiling started, or nodes inside a
+                // CUDA graph launch (CUpti_ActivityMemory3 has no graphId field).
+                // The handler only needs address, size, and timestamp from the activity
+                // record, so we proceed regardless of whether correlation succeeds.
                 APICallInfo apiCall;
-                if (!matchActivityToAPICall(memory3->correlationId, apiCall)) {
-                    return matchError(memory3->correlationId, "MEMORY");
-                }
+                matchActivityToAPICall(memory3->correlationId, apiCall);
                 static constexpr const char* graph_name = "CUDA Memory Allocation";
                 if (memory3->memoryOperationType == CUPTI_ACTIVITY_MEMORY_OPERATION_TYPE_ALLOCATION){
                     auto& memAllocAddress = PersistentState::Get().memAllocAddress;

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -361,11 +361,6 @@ struct ConcurrentHashMap {
         auto lock = acquire_write_lock();
         return mapping.erase(key);
     }
-    auto insert_or_assign(TKey key, TValue value) {
-        ZoneNamed(insert_or_assign, instrument);
-        auto lock = acquire_write_lock();
-        return mapping.insert_or_assign(std::move(key), std::move(value));
-    }
 };
 
 #if TRACY_CUDA_ENABLE_CUDA_CALL_STATS
@@ -648,6 +643,8 @@ namespace tracy
         }
 
         struct CUPTI {
+        using GraphID = uint32_t;
+
         static void CUPTIAPI OnBufferRequested(uint8_t **buffer, size_t *size, size_t *maxNumRecords)
         {
             ZoneScoped;
@@ -662,7 +659,7 @@ namespace tracy
 
         // Returns the graphId field from activity record kinds that carry one,
         // or 0 for records that are not graph-launched or don't have the field.
-        static uint32_t getGraphIdFromRecord(const CUpti_Activity* record) {
+        static GraphID getGraphIdFromRecord(const CUpti_Activity* record) {
             switch (record->kind) {
                 case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL:
                     return reinterpret_cast<const CUpti_ActivityKernel9*>(record)->graphId;
@@ -692,10 +689,10 @@ namespace tracy
             }
             CUptiResult status;
             CUpti_Activity* record = nullptr;
-            std::unordered_set<uint32_t> graphIdsSeenInBuffer;
+            std::unordered_set<GraphID> graphIdsSeenInBuffer;
             while ((status = cuptiActivityGetNextRecord(buffer, validSize, &record)) == CUPTI_SUCCESS) {
                 if (trackRetirement) {
-                    uint32_t gId = getGraphIdFromRecord(record);
+                    GraphID gId = getGraphIdFromRecord(record);
                     if (gId != 0) graphIdsSeenInBuffer.insert(gId);
                 }
                 DoProcessDeviceEvent(record);
@@ -928,7 +925,7 @@ namespace tracy
                 // Actual erasure is deferred to OnBufferCompleted so we don't
                 // race with CUPTI activity records that are still in-flight.
                 {
-                    uint32_t retireGraphId = 0;
+                    GraphID retireGraphId = 0;
                     if (domain == CUPTI_CB_DOMAIN_RUNTIME_API &&
                         cbid == CUPTI_RUNTIME_TRACE_CBID_cudaGraphExecDestroy_v10000) {
                         auto* p = (cudaGraphExecDestroy_v10000_params*)apiInfo->functionParams;
@@ -985,18 +982,15 @@ namespace tracy
         // All activities in one cuGraphLaunch share the launch's correlationId, so
         // the first activity consumes the cudaCallSiteInfo entry and caches it by
         // graphId; subsequent activities from the same launch find it via graphId.
-        // Returns false (and emits a Tracy error message) only if no match is found
-        // via either path.
-        static bool matchGraphActivityToAPICall(uint32_t correlationId, uint32_t graphId,
-                                                APICallInfo& apiCallInfo, const char* kind) {
+        static bool matchGraphActivityToAPICall(uint32_t correlationId, GraphID graphId,
+                                                APICallInfo& apiCallInfo) {
             auto& graphLaunchCache = PersistentState::Get().cudaGraphCurrentLaunch;
             if (!matchActivityToAPICall(correlationId, apiCallInfo)) {
                 if (graphId == 0 || !graphLaunchCache.fetch(graphId, apiCallInfo)) {
-                    matchError(correlationId, kind);
                     return false;
                 }
             } else if (graphId != 0) {
-                graphLaunchCache.insert_or_assign(graphId, apiCallInfo);
+                graphLaunchCache[graphId] = apiCallInfo;
             }
             return true;
         }
@@ -1103,8 +1097,8 @@ namespace tracy
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[kernel]", instrument);
                 CUpti_ActivityKernel9* kernel9 = (CUpti_ActivityKernel9*) record;
                 APICallInfo apiCall;
-                if (!matchGraphActivityToAPICall(kernel9->correlationId, kernel9->graphId, apiCall, "KERNEL")) {
-                    return;
+                if (!matchGraphActivityToAPICall(kernel9->correlationId, kernel9->graphId, apiCall)) {
+                    return matchError(kernel9->correlationId, "KERNEL");
                 }
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, kernel9->start, kernel9->end, getKernelSourceLocation(kernel9->name), kernel9->contextId, kernel9->streamId);
                 auto latency_ms = (kernel9->start - apiCall.cupti) / 1'000'000.0;
@@ -1117,8 +1111,8 @@ namespace tracy
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[memcpy]", instrument);
                 CUpti_ActivityMemcpy5* memcpy5 = (CUpti_ActivityMemcpy5*) record;
                 APICallInfo apiCall;
-                if (!matchGraphActivityToAPICall(memcpy5->correlationId, memcpy5->graphId, apiCall, "MEMCPY")) {
-                    return;
+                if (!matchGraphActivityToAPICall(memcpy5->correlationId, memcpy5->graphId, apiCall)) {
+                    return matchError(memcpy5->correlationId, "MEMCPY");
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemcpy { "CUDA::memcpy", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memcpy5->start, memcpy5->end, &TracyCUPTISrcLocDeviceMemcpy, memcpy5->contextId, memcpy5->streamId);
@@ -1133,8 +1127,8 @@ namespace tracy
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[memset]", instrument);
                 CUpti_ActivityMemset4* memset4 = (CUpti_ActivityMemset4*) record;
                 APICallInfo apiCall;
-                if (!matchGraphActivityToAPICall(memset4->correlationId, memset4->graphId, apiCall, "MEMSET")) {
-                    return;
+                if (!matchGraphActivityToAPICall(memset4->correlationId, memset4->graphId, apiCall)) {
+                    return matchError(memset4->correlationId, "MEMSET");
                 }
                 static constexpr tracy::SourceLocationData TracyCUPTISrcLocDeviceMemset { "CUDA::memset", TracyFunction, TracyFile, (uint32_t)TracyLine, tracy::Color::Blue };
                 apiCall.host->EmitGpuZone(apiCall.start, apiCall.end, memset4->start, memset4->end, &TracyCUPTISrcLocDeviceMemset, memset4->contextId, memset4->streamId);
@@ -1377,13 +1371,13 @@ namespace tracy
             // NOTE(marcos): these objects do not need to persist, but their relative
             // footprint is trivial enough that we don't care if we let them leak
             ConcurrentHashMap<CorrelationID, APICallInfo> cudaCallSiteInfo;
-            ConcurrentHashMap<uint32_t, APICallInfo> cudaGraphCurrentLaunch;
+            ConcurrentHashMap<GraphID, APICallInfo> cudaGraphCurrentLaunch;
             ConcurrentHashMap<uintptr_t, int> memAllocAddress;
             // Pending retirement: graphIds whose exec handles have been destroyed.
             // Entries are erased from cudaGraphCurrentLaunch in OnBufferCompleted
             // once no further activity records for the exec arrive in a buffer.
             std::mutex graphRetireMutex;
-            std::unordered_set<uint32_t> graphExecPendingRetire;
+            std::unordered_set<GraphID> graphExecPendingRetire;
             CUpti_SubscriberHandle subscriber = {};
             CUDACtx* profilerHost = nullptr;
 

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -686,12 +686,8 @@ namespace tracy
             // Check if any graph execs are pending retirement before entering
             // the record loop — avoids the graphIdsSeenInBuffer heap allocation
             // on the hot path when no execs have been destroyed.
-            bool trackRetirement;
-            {
-                auto& state = PersistentState::Get();
-                std::lock_guard<std::mutex> lock(state.graphRetireMutex);
-                trackRetirement = !state.graphExecPendingRetire.empty();
-            }
+            // Uses an atomic flag so we skip the mutex entirely in the common case.
+            bool trackRetirement = PersistentState::Get().graphRetirePending.load(std::memory_order_acquire);
             CUptiResult status;
             CUpti_Activity* record = nullptr;
             std::unordered_set<GraphID> graphIdsSeenInBuffer;
@@ -728,6 +724,9 @@ namespace tracy
                     } else {
                         ++it;
                     }
+                }
+                if (state.graphExecPendingRetire.empty()) {
+                    state.graphRetirePending.store(false, std::memory_order_release);
                 }
             }
 
@@ -944,6 +943,7 @@ namespace tracy
                         auto& state = PersistentState::Get();
                         std::lock_guard<std::mutex> lock(state.graphRetireMutex);
                         state.graphExecPendingRetire.insert(retireGraphId);
+                        state.graphRetirePending.store(true, std::memory_order_release);
                     }
                 }
             }
@@ -1376,11 +1376,16 @@ namespace tracy
             // NOTE(marcos): these objects do not need to persist, but their relative
             // footprint is trivial enough that we don't care if we let them leak
             ConcurrentHashMap<CorrelationID, APICallInfo> cudaCallSiteInfo;
+            // Graph launch cache: entries are retired via graphExecPendingRetire
+            // when the corresponding cudaGraphExec is destroyed.
             ConcurrentHashMap<GraphID, APICallInfo> cudaGraphCurrentLaunch;
             ConcurrentHashMap<uintptr_t, int> memAllocAddress;
             // Pending retirement: graphIds whose exec handles have been destroyed.
             // Entries are erased from cudaGraphCurrentLaunch in OnBufferCompleted
             // once no further activity records for the exec arrive in a buffer.
+            // graphRetirePending is an atomic dirty-flag so OnBufferCompleted can
+            // skip the mutex on the hot path when no execs have been destroyed.
+            std::atomic<bool> graphRetirePending{false};
             std::mutex graphRetireMutex;
             std::unordered_set<GraphID> graphExecPendingRetire;
             CUpti_SubscriberHandle subscriber = {};

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -337,6 +337,7 @@ struct ConcurrentHashMap {
     }
     auto fetch(TKey key, TValue& value) {
         ZoneNamed(fetch, instrument);
+        auto lock = acquire_read_lock();
         auto it = mapping.find(key);
         if (it != mapping.end()) {
             value = it->second;
@@ -782,8 +783,8 @@ namespace tracy
                         { CUPTI_RUNTIME_TRACE_CBID_cudaEventQuery_v3020,        NON_STREAM_FUNC() },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaStreamWaitEvent_v3020,   NON_STREAM_FUNC() },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaDeviceSynchronize_v3020, NON_STREAM_FUNC() },
-                        // Graph launch: tracked so we can correlate GPU activities back to
-                        // the cudaGraphLaunch call site via CUPTI_ACTIVITY_KIND_GRAPH_TRACE
+                        // Graph launch: tracked so all CONCURRENT_KERNEL/MEMCPY/MEMSET activities
+                        // sharing the launch's correlationId can be correlated back to this call site.
                         { CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_v10000,      GET_STREAM_FUNC(cudaGraphLaunch_v10000_params, stream) },
                         { CUPTI_RUNTIME_TRACE_CBID_cudaGraphLaunch_ptsz_v10000, GET_STREAM_FUNC(cudaGraphLaunch_v10000_params, stream) },
                     };
@@ -842,8 +843,8 @@ namespace tracy
                         { CUPTI_DRIVER_TRACE_CBID_cuEventSynchronize,    NON_STREAM_FUNC() },
                         { CUPTI_DRIVER_TRACE_CBID_cuCtxSynchronize,      NON_STREAM_FUNC() },
                         { CUPTI_DRIVER_TRACE_CBID_cuStreamWaitEvent,     GET_STREAM_FUNC(cuStreamWaitEvent_params, hStream) },
-                        // Graph launch: tracked so we can correlate GPU activities back to
-                        // the cuGraphLaunch call site via CUPTI_ACTIVITY_KIND_GRAPH_TRACE
+                        // Graph launch: tracked so all CONCURRENT_KERNEL/MEMCPY/MEMSET activities
+                        // sharing the launch's correlationId can be correlated back to this call site.
                         { CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch,          GET_STREAM_FUNC(cuGraphLaunch_params, hStream) },
                         { CUPTI_DRIVER_TRACE_CBID_cuGraphLaunch_ptsz,     GET_STREAM_FUNC(cuGraphLaunch_params, hStream) },
                     };
@@ -916,13 +917,14 @@ namespace tracy
         // via either path.
         static bool matchGraphActivityToAPICall(uint32_t correlationId, uint32_t graphId,
                                                 APICallInfo& apiCallInfo, const char* kind) {
+            auto& graphLaunchCache = PersistentState::Get().cudaGraphCurrentLaunch;
             if (!matchActivityToAPICall(correlationId, apiCallInfo)) {
-                if (graphId == 0 || !PersistentState::Get().cudaGraphCurrentLaunch.fetch(graphId, apiCallInfo)) {
+                if (graphId == 0 || !graphLaunchCache.fetch(graphId, apiCallInfo)) {
                     matchError(correlationId, kind);
                     return false;
                 }
             } else if (graphId != 0) {
-                PersistentState::Get().cudaGraphCurrentLaunch.insert_or_assign(graphId, apiCallInfo);
+                graphLaunchCache.insert_or_assign(graphId, apiCallInfo);
             }
             return true;
         }

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -1181,13 +1181,10 @@ namespace tracy
             {
                 ZoneNamedN(kernel, "tracy::CUDACtx::DoProcessDeviceEvent[malloc/free]", instrument);
                 CUpti_ActivityMemory3* memory3 = (CUpti_ActivityMemory3*)record;
-                // Do NOT call matchActivityToAPICall here. The handler only needs
-                // address, size, and timestamp — apiCall is never used. More importantly,
-                // consuming the cudaCallSiteInfo entry would break kernel/memcpy zone
-                // correlation for graphs that mix alloc nodes with other node types: all
-                // activities in one graph launch share the same correlationId, so consuming
-                // it here would prevent matchGraphActivityToAPICall from finding it for the
-                // subsequent kernel or memcpy records from the same launch.
+                // No API call correlation needed — this handler only uses address,
+                // size, and timestamp directly from the activity record. Memory
+                // API CBIDs are intentionally excluded from cbidRuntimeTrackers /
+                // cbidDriverTrackers so no cudaCallSiteInfo entry is created.
                 static constexpr const char* graph_name = "CUDA Memory Allocation";
                 if (memory3->memoryOperationType == CUPTI_ACTIVITY_MEMORY_OPERATION_TYPE_ALLOCATION){
                     auto& memAllocAddress = PersistentState::Get().memAllocAddress;

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -361,6 +361,11 @@ struct ConcurrentHashMap {
         auto lock = acquire_write_lock();
         return mapping.erase(key);
     }
+    auto insert_or_assign(TKey key, TValue value) {
+        ZoneNamed(insert_or_assign, instrument);
+        auto lock = acquire_write_lock();
+        return mapping.insert_or_assign(std::move(key), std::move(value));
+    }
 };
 
 #if TRACY_CUDA_ENABLE_CUDA_CALL_STATS
@@ -990,7 +995,7 @@ namespace tracy
                     return false;
                 }
             } else if (graphId != 0) {
-                graphLaunchCache[graphId] = apiCallInfo;
+                graphLaunchCache.insert_or_assign(graphId, apiCallInfo);
             }
             return true;
         }


### PR DESCRIPTION
## Problem

When kernels are launched via CUDA Graphs (`cudaGraphLaunch` / `cuGraphLaunch`), Tracy shows 0 GPU zones. CUPTI delivers `CONCURRENT_KERNEL` and `MEMCPY` activity records but no per-kernel API callback fires, so `matchActivityToAPICall()` always fails and every zone is silently dropped.

## Root cause

Each activity record has a `correlationId` that Tracy matches against API callbacks stored in `cudaCallSiteInfo`. For CUDA Graph launches there are no individual-kernel callbacks, so the map has no entries for those correlation IDs.

## Key CUPTI finding (discovered during implementation)

**All kernels in one `cuGraphLaunch` call share the same `correlationId` as the launch itself.** This was confirmed by instrumenting both the API callback and activity buffer simultaneously:

```
cudaGraphLaunch ENTER corr=9
KERNEL graphId=2  corr=9   ← same as launch
KERNEL graphId=2  corr=9   ← same as launch
```

This means the fix is straightforward once `cuGraphLaunch` is tracked in the API callback machinery.

**Note:** `CUPTI_ACTIVITY_KIND_GRAPH_TRACE` was investigated but must **not** be enabled — it suppresses individual `CONCURRENT_KERNEL` records for graph-launched kernels, replacing them with graph-level summaries.

## Fix

### Core graph correlation

- Add `cudaGraphLaunch_v10000` / `cuGraphLaunch` (both runtime and driver API variants) to the existing callback tracker maps so their CPU call site is captured in `cudaCallSiteInfo`
- Introduce `matchGraphActivityToAPICall()` helper (analogous to `matchActivityToAPICall()`):
  - For the **first** kernel/memcpy/memset from a graph launch, `matchActivityToAPICall` succeeds normally (consuming the launch entry) and the result is cached in `cudaGraphCurrentLaunch[graphId]`
  - **Subsequent** operations from the same launch (same `correlationId`, same `graphId`) find the cached `APICallInfo` via `graphId`
  - Each new launch of the same graph overwrites the cache entry via `insert_or_assign`, which acquires the write lock only once
  - If neither path succeeds, the caller emits a diagnostic `matchError()` in the profiler timeline (same behaviour as for non-graph activity)
- `using GraphID = uint32_t` typedef used throughout for graphId-typed variables

### Cache retirement (prevents unbounded growth)

- On `cudaGraphExecDestroy` (ENTER callback, while handle is still valid): call `cuptiGetGraphExecId` to translate exec handle → graphId and add to a pending-retirement set (`graphExecPendingRetire`)
- Erasure is deferred to `OnBufferCompleted` because `cudaGraphExecDestroy` doesn't wait for GPU completion — CUPTI may still have undelivered activity records in its buffers
- A graphId is erased only when a full buffer arrives containing no records bearing that graphId, indicating all in-flight records have been delivered
- `getGraphIdFromRecord()` helper extracts the graphId field from `CONCURRENT_KERNEL` / `MEMCPY` / `MEMSET` activity records for per-buffer tracking
- `std::atomic<bool> graphRetirePending` dirty flag lets `OnBufferCompleted` skip the retirement mutex on the hot path (no pending retirements = no lock acquired)

### ConcurrentHashMap fixes

- `ConcurrentHashMap`: added `insert_or_assign` wrapping `std::unordered_map::insert_or_assign` under a single write lock
- `ConcurrentHashMap::fetch()`: fixed a pre-existing missing read lock — `mapping.find()` was called without holding any lock, a data race now exercised on every graph activity record

### Memory tracking cleanup

- Remove `cudaMalloc`/`cudaFree`/`cuMemAlloc_v2`/`cuMemFree_v2` (6 CBIDs total) from `cbidRuntimeTrackers` / `cbidDriverTrackers` — the MEMORY2 handler never calls `matchActivityToAPICall` and never emits GPU zones, so these entries leaked indefinitely
- MEMORY2 handler: removed the early return on failed `matchActivityToAPICall` — `CUpti_ActivityMemory3` has no `graphId` field, so graph-launched alloc nodes (`cudaGraphAddMemAllocNode`) and pre-profiling allocations can never be correlated to an API call. The handler only needs address, size, and timestamp from the activity record

### Other

- `CUPTI_ACTIVITY_KIND_SYNCHRONIZATION` handler: confirmed correct as-is. In-graph event record/wait nodes produce no `SYNCHRONIZATION` activity records (empirically verified on H100)
- `examples/CUDAGraphRepro/Makefile`: added `-arch=native` so NVCC auto-detects the target GPU architecture

## Results

Tested on H100, CUDA 13.1, driver 580.105.08.

**Single graph (10 launches × 3 nodes):**

| Tracy version | GPU zones |
|---|---|
| Unpatched | 0 |
| This PR | 30 ✅ (20 `vector_add` + 10 `CUDA::memcpy`) |

**Multiple graphs, interleaved launches** — two distinct graphs launched alternately (A, B, A, B, …) to stress graphId cache switching:

- Graph A: `kernel(add)` + `memcpy` + `kernel(add)` — 3 nodes, 5 launches = 15 zones
- Graph B: `kernel(scale)` + `kernel(add)` + `kernel(scale)` — 3 nodes, 5 launches = 15 zones

| Zone type | Expected | Got |
|---|---|---|
| `vector_add` | 15 | 15 ✅ |
| `vector_scale` | 10 | 10 ✅ |
| `CUDA::memcpy` (graph) | 5 | 5 ✅ |
| Computation result `c[0]` | 6.0 | 6.0 ✅ |

**Regular (non-graph) CUDA operations** — verified that memory CBID tracker removal doesn't regress normal profiling:

| Metric | Expected | Got |
|---|---|---|
| GPU zones | 31 | 31 ✅ |
| Memory allocs | 36 | 36 ✅ |
| Memory frees | 36 | 36 ✅ |

GPU zones are correctly correlated to the `cuGraphLaunch` CPU call site: selecting a GPU zone highlights the corresponding CPU time range in the timeline.

Debug build of `tracy-capture` (asserts enabled) confirmed no assertions fire at `server/TracyWorker.cpp:5988`.

## Note on GPU zone source locations

All CUDA Graph GPU zones point to `TracyCUDA.hpp` rather than the user's call site. This is the same behaviour as regular CUDA zones — CUPTI delivers activity records asynchronously in a background thread that has no knowledge of the original call stack.

## Files changed

- `public/tracy/TracyCUDA.hpp` — core fix
- `examples/CUDAGraphRepro/repro.cu` — updated to use TracyCUDA headers and verify zones
- `examples/CUDAGraphRepro/Makefile` — release and debug variants; `-arch=native` for GPU arch detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)