### PR TITLE
Fix missing TracyTaggedUserlandAddress.hpp include due to it not being installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ set(common_includes
     ${TRACY_PUBLIC_DIR}/common/TracySocket.hpp
     ${TRACY_PUBLIC_DIR}/common/TracyStackFrames.hpp
     ${TRACY_PUBLIC_DIR}/common/TracySystem.hpp
+    ${TRACY_PUBLIC_DIR}/common/TracyTaggedUserlandAddress.hpp
     ${TRACY_PUBLIC_DIR}/common/TracyWinFamily.hpp
     ${TRACY_PUBLIC_DIR}/common/TracyYield.hpp)
 


### PR DESCRIPTION
Currently including the Tracy.hpp header from a set of installed Tracy headers will result in the following error:

```
In file included from <...>/tracy/include/tracy/tracy/Tracy.hpp:133:
In file included from <...>/tracy/include/tracy/tracy/../client/TracyLock.hpp:9:
In file included from <...>/tracy/include/tracy/tracy/../client/TracyProfiler.hpp:18
<...>/tracy/include/tracy/tracy/../client/../common/TracyQueue.hpp:6:10: fatal error: 'TracyTaggedUserlandAddress.hpp' file not found
    6 | #include "TracyTaggedUserlandAddress.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Apparently introduced in f981330, which included the TracyTaggedUserlandAddress.hpp header in TracyQueue.hpp without adding it to the list of installed common header. Fixed by making the necessary CMake change to install the header.

Ran into this issue while integrating Tracy as a dependency within Blender[^1], where we use the latest main instead of stable for WoA support, and use the install target to harvest the static lib and headers for our libraries.

[^1]: https://projects.blender.org/blender/blender/pulls/156661