### PR TITLE
Add static cast to uint64_t for std::min

### DIFF
--- a/public/client/TracyCallstack.cpp
+++ b/public/client/TracyCallstack.cpp
@@ -388,7 +388,7 @@ static uint64_t ReadElfMinLoadVaddr( const char* path )
     {
         elf_phdr phdr;
         if( read( fd, &phdr, sizeof( phdr ) ) != sizeof( phdr ) ) break;
-        if( phdr.p_type == ExtPT_LOAD ) minVaddr = std::min( minVaddr, phdr.p_vaddr );
+        if( phdr.p_type == ExtPT_LOAD ) minVaddr = std::min( minVaddr, static_cast<uint64_t>(phdr.p_vaddr) );
     }
 
     close( fd );


### PR DESCRIPTION
On 32-bit arm, phdr.p_vaddr is 32-bit, which causes a compilation error because std::min expects both arguments to be of the same type. Adding the static cast handles this case explicitly.