### PR TITLE
Fix #1337 : On Linux respect max sample rate

### DIFF
--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -34,9 +34,9 @@ static int GetSamplingFrequency()
 #endif
 }
 
-static int GetSamplingPeriod()
+static int SamplingFrequencyToPeriodNs(  int samplingHz )
 {
-    return 1000000000 / GetSamplingFrequency();
+    return 1000000000 / samplingHz;
 }
 
 }
@@ -174,11 +174,6 @@ void WINAPI EventRecordCallback( PEVENT_RECORD record )
     }
 }
 
-static int GetSamplingInterval()
-{
-    return GetSamplingPeriod() / 100;
-}
-
 static etw::Session session_kernel = {};
 static etw::Session session_vsync = {};
 static PROCESSTRACE_HANDLE consumer_kernel = INVALID_PROCESSTRACE_HANDLE;
@@ -207,10 +202,10 @@ bool SysTraceStart( int64_t& samplingPeriod )
 
 
 #ifndef TRACY_NO_SAMPLING
-    int microseconds = GetSamplingInterval() / 10;
+    samplingPeriod = SamplingFrequencyToPeriodNs( GetSamplingFrequency() );
+    const int microseconds = samplingPeriod / 1000;
     if( etw::EnableCPUProfiling( session_kernel, microseconds ) != ERROR_SUCCESS )
         return etw::StopSession( session_kernel ), false;
-    samplingPeriod = GetSamplingPeriod();
 #endif
 
     consumer_kernel = etw::SetupEventConsumer( session_kernel, EventRecordCallback );
@@ -659,7 +654,8 @@ bool SysTraceStart( int64_t& samplingPeriod )
     const bool noVsync = noVsyncEnv && noVsyncEnv[0] == '1';
 #endif
 
-    samplingPeriod = GetSamplingPeriod();
+    const int samplingFrequency = GetSamplingFrequency();
+    samplingPeriod = SamplingFrequencyToPeriodNs( samplingFrequency );
     uint32_t currentPid = ___tracy_magic_pid_override != 0 ? ___tracy_magic_pid_override : (uint32_t)getpid();
 
     s_numCpus = (int)std::thread::hardware_concurrency();
@@ -680,7 +676,7 @@ bool SysTraceStart( int64_t& samplingPeriod )
     pe.type = PERF_TYPE_SOFTWARE;
     pe.size = sizeof( perf_event_attr );
     pe.config = PERF_COUNT_SW_CPU_CLOCK;
-    pe.sample_freq = GetSamplingFrequency();
+    pe.sample_freq = samplingFrequency;
     pe.sample_type = PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_CALLCHAIN;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION( 4, 8, 0 )
     pe.sample_max_stack = 127;

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -654,7 +654,21 @@ bool SysTraceStart( int64_t& samplingPeriod )
     const bool noVsync = noVsyncEnv && noVsyncEnv[0] == '1';
 #endif
 
-    const int samplingFrequency = GetSamplingFrequency();
+    int samplingFrequency = GetSamplingFrequency();
+    if( samplingFrequency > 0 )
+    {
+        FILE* f = fopen( "/proc/sys/kernel/perf_event_max_sample_rate", "r" );
+        if( f )
+        {
+            int sysMax;
+            if( fscanf( f, "%d", &sysMax ) == 1 && samplingFrequency > sysMax )
+            {
+                TracyDebug( "Requested sampling frequency %d Hz is higher than system maximum of %d Hz, reducing to system maximum.", samplingFrequency, sysMax );
+                samplingFrequency = sysMax;
+            }
+            fclose( f );
+        }
+    }
     samplingPeriod = SamplingFrequencyToPeriodNs( samplingFrequency );
     uint32_t currentPid = ___tracy_magic_pid_override != 0 ? ___tracy_magic_pid_override : (uint32_t)getpid();
 

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -34,7 +34,7 @@ static int GetSamplingFrequency()
 #endif
 }
 
-static int SamplingFrequencyToPeriodNs(  int samplingHz )
+static int SamplingFrequencyToPeriodNs( int samplingHz )
 {
     return 1000000000 / samplingHz;
 }

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -657,16 +657,15 @@ bool SysTraceStart( int64_t& samplingPeriod )
     int samplingFrequency = GetSamplingFrequency();
     if( samplingFrequency > 0 )
     {
-        FILE* f = fopen( "/proc/sys/kernel/perf_event_max_sample_rate", "r" );
-        if( f )
+        const auto maxSampleRateStr = ReadFile( "/proc/sys/kernel/perf_event_max_sample_rate" );
+        if( maxSampleRateStr )
         {
-            int sysMax;
-            if( fscanf( f, "%d", &sysMax ) == 1 && samplingFrequency > sysMax )
+            const int sysMax = atoi( maxSampleRateStr );
+            if( sysMax > 0 && sysMax < samplingFrequency )
             {
                 TracyDebug( "Requested sampling frequency %d Hz is higher than system maximum of %d Hz, reducing to system maximum.", samplingFrequency, sysMax );
                 samplingFrequency = sysMax;
             }
-            fclose( f );
         }
     }
     samplingPeriod = SamplingFrequencyToPeriodNs( samplingFrequency );


### PR DESCRIPTION
On Linux, Tracy was ignoring the system's maximum perf sampling rate, which could cause dropped events — particularly on low-performance or embedded systems.

This PR reads `/proc/sys/kernel/perf_event_max_sample_rate` at startup and caps the requested frequency to the system maximum if needed. A debug message is emitted when the rate is reduced.

The refactor of `GetSamplingPeriod` → `SamplingFrequencyToPeriodNs` is included to ensure the reported `samplingPeriod` always reflects the actual (possibly capped) frequency used.

Note: `/proc/sys/kernel/perf_event_max_sample_rate`'s value is non-zero since https://github.com/torvalds/linux/commit/723478c8a471403c53cf144999701f6e0c4bbd11 but I could had a null-check if needed.