### PR TITLE
Better tracefs detection

### DIFF
--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -563,7 +563,7 @@ static char* GetTraceFsPath()
     char* ret = nullptr;
     while( auto ent = getmntent( f ) )
     {
-        if( strcmp( ent->mnt_fsname, "tracefs" ) == 0 )
+        if( strcmp( ent->mnt_type, "tracefs" ) == 0 )
         {
             auto len = strlen( ent->mnt_dir );
             ret = (char*)tracy_malloc( len + 1 );

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -572,13 +572,12 @@ static char* GetTraceFsPath()
             ret[len] = '\0';
             break;
         }
-        else if( strcmp( ent->mnt_type, "debugfs" ) == 0 )
+        else if( !ret && strcmp( ent->mnt_type, "debugfs" ) == 0 )
         {
             const char* tracingDirName = "tracing";
             const size_t tracingDirNameLen = strlen( tracingDirName );
             auto debugFsPathLen = strlen( ent->mnt_dir );
-            // Typically there should be at most one debugfs, entry, but still possible to have multiple? hence realloc
-            ret = (char*)tracy_realloc( ret, debugFsPathLen + 1 + tracingDirNameLen + 1 );
+            ret = (char*)tracy_malloc( debugFsPathLen + 1 + tracingDirNameLen + 1 );
             memcpy( ret, ent->mnt_dir, debugFsPathLen );
             ret[debugFsPathLen] = '/';
             memcpy( ret + debugFsPathLen + 1, tracingDirName, tracingDirNameLen );

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -596,16 +596,18 @@ bool SysTraceStart( int64_t& samplingPeriod )
 #endif
 
     const auto paranoidLevelStr = ReadFile( "/proc/sys/kernel/perf_event_paranoid" );
-    if( !paranoidLevelStr ) {
+    if( !paranoidLevelStr )
+    {
         TracyDebug( "Failed to read perf_event_paranoid, cannot setup system tracing." );
         return false;
     }
-    
+
     const int paranoidLevel = atoi( paranoidLevelStr );
     TracyDebug( "perf_event_paranoid: %i", paranoidLevel );
 
     auto traceFsPath = GetTraceFsPath();
-    if( !traceFsPath ) {
+    if( !traceFsPath )
+    {
         TracyDebug( "Failed to get tracefs path, cannot setup system tracing." );
         return false;
     }

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -583,15 +583,19 @@ bool SysTraceStart( int64_t& samplingPeriod )
 #endif
 
     const auto paranoidLevelStr = ReadFile( "/proc/sys/kernel/perf_event_paranoid" );
-    if( !paranoidLevelStr ) return false;
-#ifdef TRACY_VERBOSE
-    int paranoidLevel = 2;
-    paranoidLevel = atoi( paranoidLevelStr );
+    if( !paranoidLevelStr ) {
+        TracyDebug( "Failed to read perf_event_paranoid, cannot setup system tracing." );
+        return false;
+    }
+    
+    const int paranoidLevel = atoi( paranoidLevelStr );
     TracyDebug( "perf_event_paranoid: %i", paranoidLevel );
-#endif
 
     auto traceFsPath = GetTraceFsPath();
-    if( !traceFsPath ) return false;
+    if( !traceFsPath ) {
+        TracyDebug( "Failed to get tracefs path, cannot setup system tracing." );
+        return false;
+    }
     TracyDebug( "tracefs path: %s", traceFsPath );
 
     int switchId = -1, wakingId = -1, vsyncId = -1;

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -566,10 +566,24 @@ static char* GetTraceFsPath()
         if( strcmp( ent->mnt_type, "tracefs" ) == 0 )
         {
             auto len = strlen( ent->mnt_dir );
-            ret = (char*)tracy_malloc( len + 1 );
+            // ret may be != nullptr if we already saw a debugfs entry
+            ret = (char*)tracy_realloc( ret, len + 1 );
             memcpy( ret, ent->mnt_dir, len );
             ret[len] = '\0';
             break;
+        }
+        else if( strcmp( ent->mnt_type, "debugfs" ) == 0 )
+        {
+            const char* tracingDirName = "tracing";
+            const size_t tracingDirNameLen = strlen( tracingDirName );
+            auto debugFsPathLen = strlen( ent->mnt_dir );
+            // Typically there should be at most one debugfs, entry, but still possible to have multiple? hence realloc
+            ret = (char*)tracy_realloc( ret, debugFsPathLen + 1 + tracingDirNameLen + 1 );
+            memcpy( ret, ent->mnt_dir, debugFsPathLen );
+            ret[debugFsPathLen] = '/';
+            memcpy( ret + debugFsPathLen + 1, tracingDirName, tracingDirNameLen );
+            ret[debugFsPathLen + 1 + tracingDirNameLen] = '\0';
+            // Don't break to allow for tracefs to be found later as it is the preferred path
         }
     }
     endmntent( f );


### PR DESCRIPTION

On older kernels and some systems (e.g. Android, embedded), `tracefs` is not mounted directly but is accessible under `debugfs` at `<debugfs>/tracing`. Users may also have been instructed to use ` sudo mount -t debugfs debugfs /sys/kernel/debug`. Tracy would fail to find it and silently skip system tracing.

- Switch tracefs detection from `mnt_fsname` to `mnt_type`, consistent with `libtracefs`. A `tracefs` mount with a custom source name (e.g. `mount -t tracefs nodev /path`) would previously be missed.
- When no direct `tracefs` mount is found, fall back to `<debugfs>/tracing` if debugfs is present. Continues iterating `/proc/mounts` after a debugfs hit so a later tracefs entry still takes priority.
- Also logs the reason when `SysTraceStart` fails to help users diagnose missing systrace information.
