### PR TITLE
Fix TracyETW_compat.h structs and values based on docs

### DIFF
--- a/public/client/windows/TracyETW_compat.h
+++ b/public/client/windows/TracyETW_compat.h
@@ -18,28 +18,28 @@ typedef ULONGLONG CONTROLTRACE_ID;
 // EVENT_FILTER_EVENT_ID struct for event filtering
 typedef struct _EVENT_FILTER_EVENT_ID {
     BOOLEAN FilterIn;
-    ULONG Reserved;
-    ULONG Count;
+    UCHAR Reserved;
+    USHORT Count;
     USHORT Events[ANYSIZE_ARRAY];
 } EVENT_FILTER_EVENT_ID, *PEVENT_FILTER_EVENT_ID;
 
 // Event filter type constants
-#define EVENT_FILTER_TYPE_EVENT_ID (3)
+#define EVENT_FILTER_TYPE_EVENT_ID (0x80000200) // Event IDs.
 
 // Enable property constants
-#define EVENT_ENABLE_PROPERTY_IGNORE_KEYWORD_0 (0x1)
+#define EVENT_ENABLE_PROPERTY_IGNORE_KEYWORD_0 (0x00000010)
 
 // System provider GUIDs
 // MinGW's DEFINE_GUID only declares the GUID, we need to define it with actual storage
 // Using GUID format: {l, w1, w2, d1, d2, d3, d4, d5, d6, d7, d8} where d1-d8 are bytes
-static const GUID SystemProcessProviderGuid = {0x22d6d368, 0x560a, 0x4a9b, {0x81, 0x4e, 0xd3, 0x6b, 0x5e, 0x88, 0x8c, 0x4e}};
-static const GUID SystemProfileProviderGuid = {0xb6d70bbb, 0x4867, 0x4c13, {0x81, 0x93, 0x1d, 0x25, 0x2e, 0x5d, 0x5c, 0x7b}};
-static const GUID SystemSchedulerProviderGuid = {0x69ff631b, 0xf8b7, 0x41f8, {0xb0, 0x5f, 0xf9, 0x2e, 0x7e, 0x8d, 0x29, 0x3d}};
+static const GUID SystemProcessProviderGuid = { 0x151f55dc, 0x467d, 0x471f, { 0x83, 0xb5, 0x5f, 0x88, 0x9d, 0x46, 0xff, 0x66 } };
+static const GUID SystemProfileProviderGuid = { 0xbfeb0324, 0x1cee, 0x496f, { 0xa4, 0x9, 0x2a, 0xc2, 0xb4, 0x8a, 0x63, 0x22 } };
+static const GUID SystemSchedulerProviderGuid = { 0x599a2a76, 0x4d91, 0x4910, { 0x9a, 0xc7, 0x7d, 0x33, 0xf2, 0xe9, 0x7a, 0x6c } };
 
 // System provider keyword constants
-#define SYSTEM_PROCESS_KW_THREAD (0x0000000400000000ULL)
-#define SYSTEM_SCHEDULER_KW_CONTEXT_SWITCH (0x0000000000000001ULL)
-#define SYSTEM_SCHEDULER_KW_DISPATCHER (0x0000000000000002ULL)
+#define SYSTEM_PROCESS_KW_THREAD (0x0000000000000800)
+#define SYSTEM_SCHEDULER_KW_DISPATCHER (0x0000000000000002)
+#define SYSTEM_SCHEDULER_KW_CONTEXT_SWITCH (0x0000000000000200)
 
 #endif // __MINGW32__
 


### PR DESCRIPTION
https://learn.microsoft.com/fr-fr/windows/win32/api/evntprov/ns-evntprov-event_filter_event_id 
https://learn.microsoft.com/fr-fr/windows/win32/etw/system-providers

Note: WinSDK does not use ULL in keyword constants so I removed them too.