### PR TITLE
Show tooltips for multiline messages

### DIFF
--- a/profiler/src/profiler/TracyView_Messages.cpp
+++ b/profiler/src/profiler/TracyView_Messages.cpp
@@ -365,7 +365,7 @@ void View::DrawMessageLine( const MessageData& msg, bool hasCallstack, int& idx 
     const auto cw = ImGui::GetContentRegionAvail().x;
     const auto tw = ImGui::CalcTextSize( text, tend ).x;
     ImGui::TextUnformatted( text, tend );
-    if( tw > cw && ImGui::IsItemHovered() )
+    if( (tw > cw || *tend != '\0') && ImGui::IsItemHovered() )
     {
         ImGui::SetNextWindowSize( ImVec2( 1000 * GetScale(), 0 ) );
         ImGui::BeginTooltip();

--- a/profiler/src/profiler/TracyView_ZoneInfo.cpp
+++ b/profiler/src/profiler/TracyView_ZoneInfo.cpp
@@ -863,7 +863,7 @@ void View::DrawZoneInfoWindow()
                                 const auto cw = ImGui::GetContentRegionAvail().x;
                                 const auto tw = ImGui::CalcTextSize( text, tend ).x;
                                 ImGui::TextUnformatted( text, tend );
-                                if( tw > cw && ImGui::IsItemHovered() )
+                                if( (tw > cw || *tend != '\0') && ImGui::IsItemHovered() )
                                 {
                                     ImGui::SetNextWindowSize( ImVec2( 1000 * GetScale(), 0 ) );
                                     ImGui::BeginTooltip();


### PR DESCRIPTION
In `Messages` and `ZoneInfo` windows, message preview tooltip is shown only if **the first** message line doesn't fit, thus giving the impression the message only contains one line. The only way to see the full message is to find it in `ZoneTimeline`. This PR fixes that. 

Keep in mind that for multiline messages this code will always call `ImGui::IsItemHovered()`, and I'm not sure how much overhead this function may generate (btw, it would be fun to profile `tracy-profiler` itself with Tracy 👀). 

If the message doesn't fit into popup window, a scrollbar appears. However, I'm not sure how to use it since the popup moves with the mouse. 

Also, I noticed that keeping mouse pointer **stationary** over any message row in Zone info window increases cpu load (even if only 1 message is shown), while keeping it over rows in Messages window doesn't affect cpu usage at all. I observed this behaviour before my changes.