### PR TITLE
Allow scrolling flamegraph threads

### DIFF
--- a/profiler/src/profiler/TracyView_FlameGraph.cpp
+++ b/profiler/src/profiler/TracyView_FlameGraph.cpp
@@ -837,20 +837,30 @@ void View::DrawFlameGraph()
             m_flameGraphInvariant.Reset();
         }
 
-        int idx = 0;
-        for( const auto& t : td )
+        if( tsz != 0 )
         {
-            ImGui::PushID( idx++ );
-            const auto threadColor = GetThreadColor( t->id, 0 );
-            SmallColorBox( threadColor );
-            ImGui::SameLine();
-            if( SmallCheckbox( m_worker.GetThreadName( t->id ), &FlameGraphThread( t->id ) ) ) m_flameGraphInvariant.Reset();
-            ImGui::PopID();
-            if( t->isFiber )
+            constexpr size_t MaxVisibleThreadRows = 15;
+            const auto visibleThreadRows = std::min( tsz, MaxVisibleThreadRows );
+            const auto threadListHeight =
+                ( ImGui::GetTextLineHeightWithSpacing() * visibleThreadRows ) + ( ImGui::GetStyle().WindowPadding.y * 2 );
+            ImGui::BeginChild( "##flameVisibleThreads", ImVec2( 0, threadListHeight ), true);
+
+            int idx = 0;
+            for( const auto& t : td )
             {
+                ImGui::PushID( idx++ );
+                const auto threadColor = GetThreadColor( t->id, 0 );
+                SmallColorBox( threadColor );
                 ImGui::SameLine();
-                TextColoredUnformatted( ImVec4( 0.2f, 0.6f, 0.2f, 1.f ), "Fiber" );
+                if( SmallCheckbox( m_worker.GetThreadName( t->id ), &FlameGraphThread( t->id ) ) ) m_flameGraphInvariant.Reset();
+                ImGui::PopID();
+                if( t->isFiber )
+                {
+                    ImGui::SameLine();
+                    TextColoredUnformatted( ImVec4( 0.2f, 0.6f, 0.2f, 1.f ), "Fiber" );
+                }
             }
+            ImGui::EndChild();
         }
         ImGui::TreePop();
     }


### PR DESCRIPTION
Previously, when there were many threads in the flamegraph, it could be hard to access the last threads when expanded. They would go off the bounds of the area.
Now, the threads are within a child component with a capped height. A scrollbar will appear when there are many threads, so that the bottom threads can still be reached.

<img width="2360" height="756" alt="TracyFlamegraphThreads" src="https://github.com/user-attachments/assets/9d768dda-8570-4999-a1c1-e41d4bfc47cd" />
