### PR TITLE
Fix #1243 compatibility with WinSDK < 10.0.26100

### DIFF
--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -59,9 +59,7 @@ static int SamplingFrequencyToPeriodNs( int samplingHz )
 #    include "../common/TracySystem.hpp"
 #    include "TracyProfiler.hpp"
 #    include "TracyThread.hpp"
-#    ifdef __MINGW32__
-#      include "windows/TracyETW_compat.h"
-#    endif
+#    include "windows/TracyETW_compat.h"
 #    include "windows/TracyETW.cpp"
 
 namespace tracy

--- a/public/client/windows/TracyETW_compat.h
+++ b/public/client/windows/TracyETW_compat.h
@@ -1,13 +1,13 @@
 #ifndef __TRACY_ETW_COMPAT_H__
 #define __TRACY_ETW_COMPAT_H__
 
-// Compatibility definitions for MinGW-w64 which lacks some ETW types
+// Compatibility definitions for older Windows SDKs and MinGW-w64 which lacks some ETW types
 // present in Microsoft's Windows SDK
 
 #ifdef __MINGW32__
 
 // CONTROLTRACE_ID - ETW trace session handle type
-typedef ULONGLONG CONTROLTRACE_ID;
+typedef ULONG64 CONTROLTRACE_ID;
 
 // PROCESSTRACE_HANDLE - ETW process trace handle type
 // MinGW defines INVALID_PROCESSTRACE_HANDLE but not the type itself
@@ -40,6 +40,17 @@ static const GUID SystemSchedulerProviderGuid = { 0x599a2a76, 0x4d91, 0x4910, { 
 #define SYSTEM_PROCESS_KW_THREAD (0x0000000000000800)
 #define SYSTEM_SCHEDULER_KW_DISPATCHER (0x0000000000000002)
 #define SYSTEM_SCHEDULER_KW_CONTEXT_SWITCH (0x0000000000000200)
+
+#else // __MINGW32__
+
+// Backcompat with older sdk versions
+// SDK 10.0.26100 introduced those two and marked TRACEHANDLE obsolete
+// SDK 10.0.26100 is the first one to define NTDDI_VERSION and WDK_NTDDI_VERSION to NTDDI_WIN11_GE, while older ones will have lower versions and NTDDI_WIN11_GE undefined.
+// Just in case we check both definition and value.
+#if !(defined NTDDI_WIN11_GE && WDK_NTDDI_VERSION >= NTDDI_WIN11_GE)
+typedef ULONG64 PROCESSTRACE_HANDLE;
+typedef ULONG64 CONTROLTRACE_ID;
+#endif
 
 #endif // __MINGW32__
 


### PR DESCRIPTION
After investigating (downloading and installing) all publicly available SDKs at https://learn.microsoft.com/en-us/windows/apps/windows-sdk/downloads-archive I concluded the `TRACEHANDLE` deprecation started in `10.0.26100`. This defines `PROCESSTRACE_HANDLE` and `CONTROLTRACE_ID` as done by the SDK when using older versions. 

Using `WDK_NTDDI_VERSION` (and not `NTDDI_VERSION` which may change based on `_WIN32_WINNT` or user input seems to be the most reliable way to do it. While it says "WDK" it's been part of the SDK in `shared\sdkddkver.h`. Note it doesn't work for MinGW because it updates half of its sdk files for some reason. 

Tested with both 10.0.26100 and 10.0.22621.0 which is the last one I found without the new types. Also changes CONTROLTRACE_ID to ULONG64 on mingw which is correct (type used by `TRACEHANDLE` too in mingw https://github.com/mingw-w64/mingw-w64/blob/fe2763863a9bc40da24f2668ab5bdceb29c0201d/mingw-w64-headers/include/evntrace.h#L60 )