### PR TITLE
TracyCUDA: drop UB asserts in SourceLocationMap::add (#1264)

### DIFF
--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -434,8 +434,12 @@ struct SourceLocationMap {
 
     tracy::SourceLocationData* add(std::string_view function, std::string_view file, int line, uint32_t color=0) {
         ZoneNamed(emplace, instrument);
-        assert(*function.end() == '\0');
-        assert(*file.end() == '\0');
+        // PRECONDITION: `function` and `file` must reference NUL-terminated
+        // storage. `function.data()` and `file.data()` are stored verbatim in
+        // SourceLocationData and later consumed as C strings by tracy.
+        // We cannot validate this at runtime: dereferencing string_view::end()
+        // is UB, and `data()[size()]` is also UB (the buffer can end on a
+        // page boundary, causing a fault on read). Callers are responsible.
         void* bytes = tracyMalloc(sizeof(tracy::SourceLocationData));
         auto pSrcLoc = new(bytes)tracy::SourceLocationData{ function.data(), TracyFunction, file.data(), (uint32_t)line, color };
         auto [it, inserted] = locations.emplace(function, pSrcLoc);

--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -416,6 +416,10 @@ struct StringTable {
     }
 };
 
+// NOTE: `add()` and `retrieve()` accept `std::string_view` for ergonomics, but
+// callers must back the views with NUL-terminated storage. The stored
+// SourceLocationData holds `function.data()` / `file.data()` as `const char*`
+// and tracy later consumes those as C strings. See `add()` for details.
 struct SourceLocationMap {
     static constexpr bool instrument = false;
 


### PR DESCRIPTION
Closes #1264.

`SourceLocationMap::add` in `public/tracy/TracyCUDA.hpp` asserted on `*function.end()` and `*file.end()`, which dereference a past-the-end iterator on `std::string_view`. That is UB by the standard and is observed as a runtime trap on Windows when the underlying buffer ends on a page boundary.

The obvious workaround `data()[size()]` has the same page-boundary hazard (rejected by the maintainer in the issue thread). There is no portable, safe way to verify NUL-termination of `string_view` storage at runtime, so this PR drops the asserts and documents the precondition both at the call site and at the struct level.

Both existing call sites already pass NUL-terminated storage by construction:

- L1088: `kernelSrcLoc.add(demangledName, TracyFile, TracyLine)` — `demangledName` comes from `StringTable::operator[]`, which NUL-terminates its copy at L405, and `TracyFile` is `__FILE__` (string literal).
- The other site passes `__FILE__` directly.

No behavior change in correct callers; just removes the UB.

## Hypothesis graph

Reasoning trace and prior PR signals for this repo: https://github.com/kimjune01/sweep/blob/master/repo-hypotheses/wolfpld-tracy.md
