### PR TITLE
fix: header definition of start/end sampling profiling

### DIFF
--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -378,8 +378,8 @@ TRACY_API void ___tracy_custom_name_lockable_ctx( struct __tracy_lockable_contex
 
 #define TracyCIsConnected ___tracy_connected()
 
-TRACY_API int ___tracy_begin_sampling_profiler( void );
-TRACY_API void ___tracy_end_sampling_profiler( void );
+TRACY_API int ___tracy_begin_sampling_profiling( void );
+TRACY_API void ___tracy_end_sampling_profiling( void );
 
 #define TracyCBeginSamplingProfiling() ___tracy_begin_sampling_profiling()
 #define TracyCEndSamplingProfiling() ___tracy_end_sampling_profiling()


### PR DESCRIPTION
Hey, thanks for this great project! It seems like #1126 had a typo in the header definition since it is defined as `___tracy_begin_sampling_profiling` not `___tracy_begin_sampling_profiler` and same with `end`.

https://github.com/wolfpld/tracy/blob/365c99e601fece4a7694c2d7a39cd534b67dbd2d/public/client/TracyProfiler.cpp#L5217-L5223