### PR TITLE
Fix ProfilerWorker hang when TRACY_HAS_CALLSTACK is not defined

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1971,8 +1971,12 @@ void Profiler::Worker()
         }
 
 #ifdef TRACY_ON_DEMAND
+#  ifdef TRACY_HAS_CALLSTACK
+        // Only wait on m_symbolsBusy if the symbol worker thread exists; otherwise nobody
+        // ever resets the flag and we'd spin forever on the second connection.
         while( m_symbolsBusy.load( std::memory_order_acquire ) ) { YieldThread(); }
         m_symbolsBusy.store( true, std::memory_order_release );
+#  endif
         const auto currentTime = GetTime();
         ClearQueues( token );
         m_connectionId.fetch_add( 1, std::memory_order_release );


### PR DESCRIPTION
Currently the profiler worker will hang when `TRACY_HAS_CALLSTACK` is not defined since there is no symbol worker.

The whole thing should probably using some other synchronization method (perhaps something tied to `m_connectionId`? And should do an actual OS wait instead of spinning), but the current fix is enough to at least make it so that we can reconnect.