### PR TITLE
Drop sys/param.h dependency for BSD detection

### DIFF
--- a/public/client/TracyCallstack.h
+++ b/public/client/TracyCallstack.h
@@ -3,10 +3,6 @@
 
 #ifndef TRACY_NO_CALLSTACK
 
-#  if !defined _WIN32
-#    include <sys/param.h>
-#  endif
-
 #  if defined _WIN32
 #    include "../common/TracyWinFamily.hpp"
 #    if !defined TRACY_WIN32_NO_DESKTOP
@@ -26,7 +22,7 @@
 #    endif
 #  elif defined __APPLE__
 #    define TRACY_HAS_CALLSTACK 4
-#  elif defined BSD
+#  elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 #    define TRACY_HAS_CALLSTACK 6
 #  endif
 

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -15,7 +15,6 @@
 #  endif
 #else
 #  include <sys/time.h>
-#  include <sys/param.h>
 #endif
 
 #ifdef _GNU_SOURCE
@@ -29,7 +28,7 @@
 #  include <sys/syscall.h>
 #endif
 
-#if defined __APPLE__ || defined BSD
+#if defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 #  include <sys/types.h>
 #  include <sys/sysctl.h>
 #endif
@@ -447,7 +446,7 @@ static const char* GetProcessName()
 #  endif
 #elif defined __linux__ && defined _GNU_SOURCE
     if( program_invocation_short_name ) processName = program_invocation_short_name;
-#elif defined __APPLE__ || defined BSD
+#elif defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     auto buf = getprogname();
     if( buf ) processName = buf;
 #elif defined __QNX__
@@ -725,7 +724,7 @@ static const char* GetHostInfo()
     size_t sz = sizeof( memSize );
     sysctlbyname( "hw.memsize", &memSize, &sz, nullptr, 0 );
     ptr += sprintf( ptr, "RAM: %zu MB\n", memSize / 1024 / 1024 );
-#elif defined BSD
+#elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     size_t memSize;
     size_t sz = sizeof( memSize );
     sysctlbyname( "hw.physmem", &memSize, &sz, nullptr, 0 );
@@ -1534,7 +1533,7 @@ Profiler::Profiler()
 
 #ifndef _WIN32
     pipe(m_pipe);
-#  if defined __APPLE__ || defined BSD
+#  if defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     // FreeBSD/XNU don't have F_SETPIPE_SZ, so use the default
     m_pipeBufSize = 16384;
 #  else

--- a/public/client/TracySysTime.cpp
+++ b/public/client/TracySysTime.cpp
@@ -11,7 +11,7 @@
 #  elif defined __APPLE__
 #    include <mach/mach_host.h>
 #    include <mach/host_info.h>
-#  elif defined BSD
+#  elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 #    include <sys/types.h>
 #    include <sys/sysctl.h>
 #  endif
@@ -79,7 +79,7 @@ void SysTime::ReadTimes()
     idle = info.cpu_ticks[CPU_STATE_IDLE];
 }
 
-#  elif defined BSD
+#  elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 
 void SysTime::ReadTimes()
 {
@@ -109,7 +109,7 @@ float SysTime::Get()
 
 #if defined _WIN32
     return diffUsed == 0 ? -1 : ( diffUsed - diffIdle ) * 100.f / diffUsed;
-#elif defined __linux__ || defined __APPLE__ || defined BSD
+#elif defined __linux__ || defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     const auto total = diffUsed + diffIdle;
     return total == 0 ? -1 : diffUsed * 100.f / total;
 #endif

--- a/public/client/TracySysTime.hpp
+++ b/public/client/TracySysTime.hpp
@@ -1,13 +1,7 @@
 #ifndef __TRACYSYSTIME_HPP__
 #define __TRACYSYSTIME_HPP__
 
-#if defined _WIN32 || defined __linux__ || defined __APPLE__
-#  define TRACY_HAS_SYSTIME
-#else
-#  include <sys/param.h>
-#endif
-
-#ifdef BSD
+#if defined _WIN32 || defined __linux__ || defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 #  define TRACY_HAS_SYSTIME
 #endif
 

--- a/public/common/TracySocket.cpp
+++ b/public/common/TracySocket.cpp
@@ -27,7 +27,6 @@
 #else
 #  include <arpa/inet.h>
 #  include <sys/socket.h>
-#  include <sys/param.h>
 #  include <errno.h>
 #  include <fcntl.h>
 #  include <netinet/in.h>
@@ -509,7 +508,7 @@ bool ListenSocket::Listen( uint16_t port, int backlog )
 #if defined _WIN32
     unsigned long val = 0;
     setsockopt( m_sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&val, sizeof( val ) );
-#elif defined BSD
+#elif defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     int val = 0;
     setsockopt( m_sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&val, sizeof( val ) );
     val = 1;

--- a/server/TracySysUtil.cpp
+++ b/server/TracySysUtil.cpp
@@ -6,7 +6,7 @@
 #  include <windows.h>
 #elif defined __linux__
 #  include <sys/sysinfo.h>
-#elif defined __APPLE__ || defined BSD
+#elif defined __APPLE__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
 #  include <sys/types.h>
 #  include <sys/sysctl.h>
 #endif
@@ -30,7 +30,7 @@ size_t GetPhysicalMemorySize()
     size_t sz = sizeof( memSize );
     sysctlbyname( "hw.memsize", &memSize, &sz, nullptr, 0 );
     return memSize;
-#elif defined BSD
+#elif defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__ || defined __DragonFly__
     size_t memSize;
     size_t sz = sizeof( memSize );
     sysctlbyname( "hw.physmem", &memSize, &sz, nullptr, 0 );


### PR DESCRIPTION
Replace `#ifdef BSD` (which requires including `<sys/param.h>` first) with explicit checks for `__FreeBSD__`, `__NetBSD__`, `__OpenBSD__` and `__DragonFly__`, matching how these BSDs are already enumerated elsewhere in the codebase (OS name strings, thread id helpers, etc.).

This also avoids leaking the `sys/param.h` requirement through public headers (`TracySysTime.hpp`, `TracyCallstack.h`), where consumers would otherwise need it to correctly see `TRACY_HAS_SYSTIME` / `TRACY_HAS_CALLSTACK`. `libbacktrace/config.h` is left as-is — it's third-party and only included from .c files where the `BSD` macro can still be picked up locally.

Note: for `setsockopt( m_sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&val, sizeof( val ) );` I added `__APPLE__` too since this was the only place where it was not checked explicitely.