### PR TITLE
NVCC (with MSVC/cl.exe) build fix

### DIFF
--- a/public/client/tracy_concurrentqueue.h
+++ b/public/client/tracy_concurrentqueue.h
@@ -975,7 +975,7 @@ private:
 				auto block = this->tailBlock;
 				do {
 					block = block->next;
-					if (block->ConcurrentQueue::Block::is_empty()) {
+					if (block->is_empty()) {
 						continue;
 					}
 
@@ -1020,10 +1020,10 @@ private:
         inline void enqueue_begin_alloc(index_t currentTailIndex)
         {
             // We reached the end of a block, start a new one
-            if (this->tailBlock != nullptr && this->tailBlock->next->ConcurrentQueue::Block::is_empty()) {
+            if (this->tailBlock != nullptr && this->tailBlock->next->is_empty()) {
                 // We can re-use the block ahead of us, it's empty!
                 this->tailBlock = this->tailBlock->next;
-                this->tailBlock->ConcurrentQueue::Block::reset_empty();
+                this->tailBlock->reset_empty();
 
                 // We'll put the block on the block index (guaranteed to be room since we're conceptually removing the
                 // last block from it first -- except instead of removing then adding, we can just overwrite).
@@ -1042,7 +1042,7 @@ private:
 
                 // Insert a new block in the circular linked list
                 auto newBlock = this->parent->ConcurrentQueue::requisition_block();
-                newBlock->ConcurrentQueue::Block::reset_empty();
+                newBlock->reset_empty();
                 if (this->tailBlock == nullptr) {
                     newBlock->next = newBlock;
                 }
@@ -1124,7 +1124,7 @@ private:
 						processData( (*block)[index], sz );
 						index += sz;
 
-						block->ConcurrentQueue::Block::set_many_empty(firstIndexInBlock, static_cast<size_t>(endIndex - firstIndexInBlock));
+						block->set_many_empty(firstIndexInBlock, static_cast<size_t>(endIndex - firstIndexInBlock));
 						indexIndex = (indexIndex + 1) & (localBlockIndex->size - 1);
 					} while (index != firstIndex + actualCount);
 


### PR DESCRIPTION
NVCC complains about the following on Windows (piggy-backing on MSVC/cl.exe):
```
tracy_concurrentqueue.h(978): error C2039: 'ConcurrentQueue': is not a member of 'tracy::moodycamel::ConcurrentQueue<tracy::QueueItem,tracy::moodycamel::ConcurrentQueueDefaultTraits>::Block'
tracy_concurrentqueue.h(754): note: see declaration of 'tracy::moodycamel::ConcurrentQueue<tracy::QueueItem,tracy::moodycamel::ConcurrentQueueDefaultTraits>::Block'
tracy_concurrentqueue.h(978): note: the template instantiation context (the oldest one first) is
tracy_concurrentqueue.h(411): note: while compiling class 'tracy::moodycamel::ConcurrentQueue<tracy::QueueItem,tracy::moodycamel::ConcurrentQueueDefaultTraits>::ExplicitProducer'
tracy_concurrentqueue.h(955): note: while compiling class template member function 'tracy::moodycamel::ConcurrentQueue<tracy::QueueItem,tracy::moodycamel::ConcurrentQueueDefaultTraits>::ExplicitProducer::~ExplicitProducer(void)'
tracy_concurrentqueue.h(978): error C2039: 'Block': is not a member of '`global namespace''
tracy_concurrentqueue.h(978): error C3083: 'Block': the symbol to the left of a '::' must be a type
tracy_concurrentqueue.h(978): error C2039: 'is_empty': is not a member of '`global namespace''
tracy_concurrentqueue.h(978): error C2065: 'is_empty': undeclared identifier
tracy_concurrentqueue.h(978): error C2275: 'Traits': expected an expression instead of a type
```
This seems to be a quirk of the NVCC portion of the compiler, since MSVC/cl by itself can compile that code just fine.

Unless I am missing something, we should not need the scope qualifiers here anyway.

In the [upstream moodycamel repository](https://github.com/search?q=repo%3Acameron314%2Fconcurrentqueue%20ConcurrentQueue%3A%3ABlock%3A%3A&type=code), the `ConcurrentQueue::Block::` scope qualifier is followed by `template` in order to adhere to dependent template name lookup spec rules. The modified version in Tracy drops the template argument of the methods in question, so there's no dependent name lookup, and we can just call the methods directly.