### PR TITLE
Fix non desktop win32 build

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -10,7 +10,9 @@
 #  include <inttypes.h>
 #  include <intrin.h>
 #  include "../common/TracyWinFamily.hpp"
-#  ifndef _MSC_VER
+#  if defined(_MSC_VER) // https://devblogs.microsoft.com/oldnewthing/20200730-00/?p=104021/
+#    define fileno _fileno
+#  else
 #    include <excpt.h>
 #  endif
 #else

--- a/public/common/TracySystem.cpp
+++ b/public/common/TracySystem.cpp
@@ -374,9 +374,11 @@ TRACY_API const char* GetUserFullName()
 #if defined TRACY_HAS_CUSTOM_USER_INFO
     return PlatformGetUserFullName();
 #elif defined _WIN32
+#  if !defined TRACY_WIN32_NO_DESKTOP
     static char buf[1024];
     ULONG size = sizeof( buf );
     if( GetUserNameExA( NameDisplay, buf, &size ) ) return buf;
+#  endif
     return nullptr;
 #elif defined __ANDROID__
     const auto passwd = getpwuid( getuid() );


### PR DESCRIPTION
Use `_fileno` when `_MSC_VER` is defined.
Properly gate `GetUserNameExA` behind `TRACY_WIN32_NO_DESKTOP`.