### PR TITLE
Bump CMake min version to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 # Run version helper script
 include(cmake/version.cmake)


### PR DESCRIPTION
## What

This bumps the minimum CMake version from `3.10` to `3.13`.

## Goal

Hiding this warning message:

```
[cmake] CMake Warning (dev) at vendor/tracy/CMakeLists.txt:16 (option):
[cmake]   Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
[cmake]   --help-policy CMP0077" for policy details.  Use the cmake_policy command to
[cmake]   set the policy and suppress this warning.
[cmake] 
[cmake]   For compatibility with older versions of CMake, option is clearing the
[cmake]   normal variable 'TRACY_STATIC'.
[cmake] This warning is for project developers.  Use -Wno-dev to suppress it.
```

## Why

Different versions of CMake comes with different policies enabled by default.

As of 3.13.0, CMake introduced the policy [CMP0077](https://cmake.org/cmake/help/latest/policy/CMP0077.html) which, because this project is on an older version, wants users vendoring `tracy` to specify whether they prefer the `OLD` or `NEW` behavior, resulting in either `set(CMAKE_POLICY_DEFAULT_CMP0077 X)` before `add_subdirectory(vendor/tracy)` or `cmake_policy(CMP0077 X)` for their whole project.

## Explanation

The `NEW` behavior (that version 3.13.0 introduced) is sane and desirable for everybody.

Prior, `option()` was copying identically named variables into the cache and then ignoring any future mutations unless re-configuring the project. Now, `option()` prefers to do nothing, not even caching, essentially honoring at all times what the early variable definition requested (that option() would've normally set).

This allows for users to properly configure tracy's option()s even though it's a subdirectory and to not worry about possible overrides or left over cache headaches.

e.g. another example with set() this time:

```
set(TRACY_STATIC ON)
add_subdirectory(vendor/tracy)
target_add_library(example PRIVATE TracyClient)
```

## Backwards compatibility

* Users that explicitly want to keep the old behavior would've already needed the policy line and the version upgrade wont distrupt their choice. That's the whole point of having configurable CMake policies.

* Everybody else on newer CMake versions that didn't pick a policy accidently rely on the new behavior and therefore not impacted by the new version because the default maintains that behavior.

## Notes

It seems 3.10 was in 2017 and 3.13 in 2018. Both are old enough that probably everyone and all the major distros are well beyond. Personally, I use MinGW a lot and am on 4.2.0, while officially the latest is 4.3.3.

## Previous similar PRs from me:

* https://github.com/recp/cglm/pull/430 (CGLM, Highly Optimized 2D / 3D Graphics Math for C)
* https://github.com/zpl-c/enet/pull/77 (ENet, reliable UDP networking library)
* https://github.com/mackron/miniaudio/pull/1133 (Miniaudio, Audio playback and capture library)