### PR TITLE
WORKAROUND_malloc/free should properly route to tracy_malloc/free

### DIFF
--- a/public/client/tracy_concurrentqueue.h
+++ b/public/client/tracy_concurrentqueue.h
@@ -171,8 +171,8 @@ struct ConcurrentQueueDefaultTraits
 #if defined(malloc) || defined(free)
 	// Gah, this is 2015, stop defining macros that break standard code already!
 	// Work around malloc/free being special macros:
-	static inline void* WORKAROUND_malloc(size_t size) { return malloc(size); }
-	static inline void WORKAROUND_free(void* ptr) { return free(ptr); }
+	static inline void* WORKAROUND_malloc(size_t size) { return tracy::tracy_malloc(size); }
+	static inline void WORKAROUND_free(void* ptr) { return tracy::tracy_free(ptr); }
 	static inline void* (malloc)(size_t size) { return WORKAROUND_malloc(size); }
 	static inline void (free)(void* ptr) { return WORKAROUND_free(ptr); }
 #else


### PR DESCRIPTION
If the user really wants us to use their malloc/free defines, they should define `TRACY_USE_RPMALLOC` or `TRACY_HAS_CUSTOM_ALLOCATOR`.