### PR TITLE
feat: display threads in a consistent order

### DIFF
--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -249,6 +249,26 @@ void View::ViewSymbol( const char* fileName, int line, uint64_t baseAddr, uint64
     m_sourceView->OpenSymbol( fileName, line, baseAddr, symAddr, m_worker, *this );
 }
 
+void View::UpdateThreadOrder()
+{
+    const auto& threadData = m_worker.GetThreadData();
+    if( threadData.size() == m_threadOrder.size() ) return;
+
+    m_threadOrder.reserve( threadData.size() );
+    // Only new threads are in the end of the worker's ThreadData vector.
+    // Threads which get reordered by received thread hints are not new, yet removed from m_threadOrder.
+    // Therefore, those are kept in m_threadReinsert and are gathered before the remaining new threads.
+    const size_t numReinsert = m_threadReinsert.size();
+    const size_t numNew = threadData.size() - m_threadOrder.size() - numReinsert;
+    for( size_t i = 0; i < numReinsert + numNew; i++ )
+    {
+        const ThreadData* td = i < numReinsert ? m_threadReinsert[i] : threadData[m_threadOrder.size()];
+        auto it = std::find_if( m_threadOrder.begin(), m_threadOrder.end(), [td]( const auto t ) { return td->groupHint < t->groupHint; } );
+        m_threadOrder.insert( it, td );
+    }
+    m_threadReinsert.clear();
+}
+
 bool View::ViewDispatch( const char* fileName, int line, uint64_t symAddr )
 {
     if( line == 0 )

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -437,6 +437,7 @@ private:
     void UpdateTitle();
 
     void ValidateSourceRegex();
+    void UpdateThreadOrder();
 
     unordered_flat_map<uint64_t, int> m_threadDepthLimit;
     unordered_flat_map<uint64_t, bool> m_visibleMsgThread;

--- a/profiler/src/profiler/TracyView_ContextSwitch.cpp
+++ b/profiler/src/profiler/TracyView_ContextSwitch.cpp
@@ -389,6 +389,8 @@ void View::DrawContextSwitchList( const TimelineContext& ctx, const std::vector<
 
 void View::DrawWaitStacks()
 {
+    UpdateThreadOrder();
+
     const auto scale = GetScale();
     ImGui::SetNextWindowSize( ImVec2( 1400 * scale, 500 * scale ), ImGuiCond_FirstUseEver );
     ImGui::Begin( "Wait stacks", &m_showWaitStacks );

--- a/profiler/src/profiler/TracyView_FlameGraph.cpp
+++ b/profiler/src/profiler/TracyView_FlameGraph.cpp
@@ -1026,7 +1026,8 @@ void View::DrawFlameGraph()
         m_flameGraphPan = 0;
     }
 
-    auto& td = m_worker.GetThreadData();
+    UpdateThreadOrder();
+    const auto& td = m_threadOrder;
     auto expand = ImGui::TreeNode( ICON_FA_SHUFFLE " Visible threads:" );
     ImGui::SameLine();
     size_t visibleThreads = 0;

--- a/profiler/src/profiler/TracyView_Messages.cpp
+++ b/profiler/src/profiler/TracyView_Messages.cpp
@@ -137,6 +137,8 @@ void View::DrawMessages()
         ImGui::Checkbox( ICON_FA_IMAGE " Show frame images", &m_showMessageImages );
     }
 
+    UpdateThreadOrder();
+
     bool threadsChanged = false;
     ImGui::AlignTextToFramePadding();
     auto expand = ImGui::TreeNodeEx( ICON_FA_SHUFFLE " Visible threads:", ImGuiTreeNodeFlags_SpanLabelWidth );

--- a/profiler/src/profiler/TracyView_Timeline.cpp
+++ b/profiler/src/profiler/TracyView_Timeline.cpp
@@ -393,24 +393,7 @@ void View::DrawTimeline()
     }
     if( m_vd.drawZones )
     {
-        const auto& threadData = m_worker.GetThreadData();
-        if( threadData.size() != m_threadOrder.size() )
-        {
-            m_threadOrder.reserve( threadData.size() );
-            // Only new threads are in the end of the worker's ThreadData vector.
-            // Threads which get reordered by received thread hints are not new, yet removed from m_threadOrder.
-            // Therefore, those are kept in the m_threadReinsert vector. As such, we will gather first threads from the
-            // reinsert vector, and afterwards the remaining ones must be new (and thus found at the end of threadData).
-            size_t numReinsert = m_threadReinsert.size();
-            size_t numNew = threadData.size() - m_threadOrder.size() - numReinsert;
-            for( size_t i = 0; i < numReinsert + numNew; i++ )
-            {
-                const ThreadData *td = i < numReinsert ? m_threadReinsert[i] : threadData[m_threadOrder.size()];
-                auto it = std::find_if( m_threadOrder.begin(), m_threadOrder.end(), [td]( const auto t ) { return td->groupHint < t->groupHint; } );
-                m_threadOrder.insert( it, td );
-            }
-            m_threadReinsert.clear();
-        }
+        UpdateThreadOrder();
         for( const auto& v : m_threadOrder )
         {
             m_tc.AddItem<TimelineItemThread>( v );


### PR DESCRIPTION
This makes the flamegraph thread picker use the same thread ordering as the timeline.

Previously, the timeline maintained `m_threadOrder`, while the flame graph visible-thread picker iterated over raw worker thread data. That made thread order differ between views.

This change:
- Extracts the timeline thread-order maintenance into `View::UpdateThreadOrder()`.
- Keeps timeline behavior unchanged by calling the shared helper.
- Makes the flame graph visible-thread picker use `m_threadOrder`.

This is especially useful for having the threads sorted in all views.

<img width="2287" height="1632" alt="image" src="https://github.com/user-attachments/assets/b03d92ef-c91f-4ade-bf45-476c222331df" />
