### PR TITLE
feat(mcp): default to streamable-http transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ profiler/build/win32/Tracy.aps
 extra/vswhere.exe
 extra/tracy-build
 .cache
+.uv-cache/
+.venv/
 compile_commands.json
 profiler/build/wasm/Tracy-release.*
 profiler/build/wasm/Tracy-debug.*

--- a/extra/mcp/tracy_mcp.py
+++ b/extra/mcp/tracy_mcp.py
@@ -30,6 +30,7 @@ _HERE = os.path.dirname(os.path.abspath(__file__))
 _PORT_FILE = os.path.join(_HERE, "tracy_mcp.port")
 _PID_FILE  = os.path.join(_HERE, "tracy_mcp.pid")
 _PREFERRED_PORT = int(os.environ.get("TRACY_MCP_PORT", "47380"))
+_TRANSPORT = os.environ.get("TRACY_MCP_TRANSPORT", "streamable-http").strip().lower()
 
 # Shared documentation surfaces. system.prompt.md is Tracy Assist's source
 # system prompt; exposing it as an MCP resource keeps analysis guidance in
@@ -677,6 +678,13 @@ async def shutdown_server() -> str:
 if __name__ == "__main__":
     atexit.register(_cleanup_pid_files)
 
+    if _TRANSPORT not in ("sse", "streamable-http"):
+        print(
+            "TRACY_MCP_TRANSPORT must be 'sse' or 'streamable-http'.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     running, existing_port = _is_our_server_running()
     if running:
         print(
@@ -689,12 +697,17 @@ if __name__ == "__main__":
     port = _find_free_port()
     _write_pid_and_port(port)
 
-    print(f"Tracy MCP listening on http://127.0.0.1:{port}/sse", file=sys.stderr)
+    path = (
+        mcp_server.settings.sse_path
+        if _TRANSPORT == "sse"
+        else mcp_server.settings.streamable_http_path
+    )
+    print(f"Tracy MCP listening on http://127.0.0.1:{port}{path}", file=sys.stderr)
 
     mcp_server.settings.host = "127.0.0.1"
     mcp_server.settings.port = port
     try:
-        mcp_server.run(transport="sse")
+        mcp_server.run(transport=_TRANSPORT)
     except KeyboardInterrupt:
         print("\nTracy MCP server stopped.", file=sys.stderr)
         sys.exit(0)

--- a/manual/tracy.md
+++ b/manual/tracy.md
@@ -2315,21 +2315,22 @@ Set the following environment variables before launching (or export them in your
     PYTHONPATH=/path/to/tracy/build/python/Release
     TRACY_CAPTURES_DIR=/path/to/captures   # enables list_captures
     TRACY_MCP_PORT=47380                   # optional; default 47380
+    TRACY_MCP_TRANSPORT=streamable-http    # optional; streamable-http or sse
 
 ### Integrating with an AI assistant
 
-The server runs as a singleton on SSE transport (port 47380 by default). Only one process loads `TracyServerBindings` regardless of how many editor windows are open; subsequent launches detect the port is taken and exit immediately.
+The server runs as a singleton on Streamable HTTP transport (port 47380 by default). Only one process loads `TracyServerBindings` regardless of how many editor windows are open; subsequent launches detect the port is taken and exit immediately. Set `TRACY_MCP_TRANSPORT=sse` before launching to use the legacy SSE transport instead.
 
 The server prints its URL on startup and writes it to `extra/mcp/tracy_mcp.port`:
 
-    Tracy MCP listening on http://127.0.0.1:47380/sse
+    Tracy MCP listening on http://127.0.0.1:47380/mcp
 
 Configure your AI assistant using that URL. For example, for a JSON-based MCP configuration:
 
     {
       "mcpServers": {
         "tracy": {
-          "url": "http://127.0.0.1:47380/sse"
+          "url": "http://127.0.0.1:47380/mcp"
         }
       }
     }

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -2599,16 +2599,17 @@ Set the following environment variables before launching (or export them in your
 PYTHONPATH=/path/to/tracy/build/python/Release
 TRACY_CAPTURES_DIR=/path/to/captures   # enables list_captures
 TRACY_MCP_PORT=47380                   # optional; default 47380
+TRACY_MCP_TRANSPORT=streamable-http    # optional; streamable-http or sse
 \end{lstlisting}
 
 \subsubsection{Integrating with an AI assistant}
 
-The server runs as a singleton on SSE transport (port 47380 by default). Only one process loads \texttt{TracyServerBindings} regardless of how many editor windows are open; subsequent launches detect the port is taken and exit immediately.
+The server runs as a singleton on Streamable HTTP transport (port 47380 by default). Only one process loads \texttt{TracyServerBindings} regardless of how many editor windows are open; subsequent launches detect the port is taken and exit immediately. Set \texttt{TRACY\_MCP\_TRANSPORT=sse} before launching to use the legacy SSE transport instead.
 
 The server prints its URL on startup and writes it to \texttt{extra/mcp/tracy\_mcp.port}:
 
 \begin{lstlisting}
-Tracy MCP listening on http://127.0.0.1:47380/sse
+Tracy MCP listening on http://127.0.0.1:47380/mcp
 \end{lstlisting}
 
 Configure your AI assistant using that URL. For example, for a JSON-based MCP configuration:
@@ -2617,7 +2618,7 @@ Configure your AI assistant using that URL. For example, for a JSON-based MCP co
 {
   "mcpServers": {
     "tracy": {
-      "url": "http://127.0.0.1:47380/sse"
+      "url": "http://127.0.0.1:47380/mcp"
     }
   }
 }


### PR DESCRIPTION
From [OpenAI docs](https://openai.github.io/openai-agents-python/mcp/#3-http-with-sse-mcp-servers):
> The MCP project has deprecated the Server-Sent Events transport. Prefer Streamable HTTP or stdio for new integrations and keep SSE only for legacy servers.

Switching to Streamable HTTP transport allows to use Tracy MCP Server with Codex. SSE can still be used by setting the `TRACY_MCP_TRANSPORT=sse` environment variable. 