### PR TITLE
Fix warning [-Wsign-compare]

### DIFF
--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -963,7 +963,7 @@ private:
     {
         assert( len <= TargetFrameSize );
         bool ret = true;
-        if( m_bufferOffset - m_bufferStart + (int)len > TargetFrameSize )
+        if( m_bufferOffset - m_bufferStart + (int)len > (int)TargetFrameSize )
         {
             ret = CommitData();
         }


### PR DESCRIPTION
Fixes this compiler warning:
```
TracyProfiler.hpp:966:55: warning: comparison of integers of different signs: 'int' and 'const unsigned int' [-Wsign-compare]
  966 |         if( m_bufferOffset - m_bufferStart + (int)len > TargetFrameSize )
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~
1 warning generated.
```