### PR TITLE
cmake: make ccache opt-in when Tracy is consumed as a subdirectory dependency

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -3,7 +3,17 @@ include(${CMAKE_CURRENT_LIST_DIR}/options.cmake)
 set_option(NO_ISA_EXTENSIONS "Disable ISA extensions (don't pass -march=native or -mcpu=native to the compiler)" OFF)
 set_option(NO_LTO "Disable interprocedural optimization (LTO)" OFF)
 set_option(NO_MOLD_LINKER "Disable mold linker (use default linker)" OFF)
-set_option(NO_CCACHE "Disable ccache acceleration" OFF)
+# Enable ccache by default only when Tracy is the top-level project.
+# When consumed as a subdirectory dependency the GLOBAL RULE_LAUNCH_COMPILE
+# property would infect the parent build; consumers that want ccache can
+# set -DNO_CCACHE=OFF or manage it themselves (e.g. CMAKE_CXX_COMPILER_LAUNCHER).
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(_tracy_no_ccache_default OFF)
+else()
+    set(_tracy_no_ccache_default ON)
+endif()
+set_option(NO_CCACHE "Disable ccache acceleration" ${_tracy_no_ccache_default})
+unset(_tracy_no_ccache_default)
 
 if (NOT NO_ISA_EXTENSIONS)
     include(CheckCXXCompilerFlag)


### PR DESCRIPTION
## Problem

`cmake/config.cmake` sets the **global** CMake property `RULE_LAUNCH_COMPILE ccache` whenever ccache is found and `NO_CCACHE` is off (the default). This is appropriate when building Tracy directly, but when Tracy is consumed as a subdirectory dependency via `add_subdirectory()`, the global property leaks into the parent build.

If the parent project already manages ccache — for example via `CMAKE_CXX_COMPILER_LAUNCHER` — both mechanisms activate at the same time. CMake then generates Ninja rules that double-wrap the compiler:

\`\`\`
ccache  cmake -E env CCACHE_SLOPPINESS=... ccache clang++ -c foo.cpp
\`\`\`

The outer `ccache` invocation sees `cmake` (not `clang++`) as the compiler and rejects every translation unit with **"Multiple source files"**.

**Real-world impact:** after integrating Tracy into [tenstorrent/tt-metal](https://github.com/tenstorrent/tt-metal), 1856 of 2248 compilations became uncacheable (82.6% miss rate). The project was forced to work around it with `set(NO_CCACHE ON)` before the Tracy `add_subdirectory` calls (tenstorrent/tt-metal#47617). This fix addresses the root cause upstream.

## Fix

Detect whether Tracy is the top-level CMake project at configure time:

- **Top-level:** `NO_CCACHE` defaults to `OFF` — ccache enabled, existing behavior preserved for Tracy CLI users building Tracy directly.
- **Subdirectory dependency:** `NO_CCACHE` defaults to `ON` — the global `RULE_LAUNCH_COMPILE` property is not set, preventing leakage into the parent build. Parent projects that explicitly want Tracy's ccache can still pass `-DNO_CCACHE=OFF`.

This makes ccache opt-in when Tracy is used as a dependency, matching the principle of least surprise for CMake consumers.

## Testing

Build Tracy CLI tools directly — behaviour unchanged (ccache still active by default).

Consume Tracy as a subdirectory in a project that sets `CMAKE_CXX_COMPILER_LAUNCHER=ccache` — no more double-wrapping; the parent's ccache operates correctly.