### PR TITLE
libbacktrace: Fix missing table assignment in RLE seq decode

### DIFF
--- a/public/libbacktrace/elf.cpp
+++ b/public/libbacktrace/elf.cpp
@@ -4320,6 +4320,7 @@ elf_zstd_unpack_seq_decode (int mode,
 	decode->table_bits = 0;
 	if (!conv (&entry, 0, table))
 	  return 0;
+	decode->table = table;
       }
       break;
 


### PR DESCRIPTION
Fixes segfault when decompressing mesa debuginfo on Aeryn.

Upstream PR: https://github.com/ianlancetaylor/libbacktrace/pull/166