### PR TITLE
Change musl bits/reg.h to sys/reg.h

### DIFF
--- a/public/client/TracyElf.hpp
+++ b/public/client/TracyElf.hpp
@@ -3,11 +3,6 @@
 
 #include <stdint.h>
 
-#if !defined(__GLIBC__) && !defined(__WORDSIZE)
-// include __WORDSIZE headers for musl
-#  include <bits/reg.h>
-#endif
-
 namespace tracy
 {
 
@@ -15,14 +10,14 @@ using elf_half = uint16_t;
 using elf_word = uint32_t;
 using elf_sword = int32_t;
 
-#if __WORDSIZE == 32
-    using elf_addr = uint32_t;
-    using elf_off = uint32_t;
-    using elf_xword = uint32_t;
-#else
+#if __SIZEOF_POINTER__ == 8
     using elf_addr = uint64_t;
     using elf_off = uint64_t;
     using elf_xword = uint64_t;
+#else
+    using elf_addr = uint32_t;
+    using elf_off = uint32_t;
+    using elf_xword = uint32_t;
 #endif
 
 struct elf_ehdr

--- a/public/libbacktrace/config.h
+++ b/public/libbacktrace/config.h
@@ -1,9 +1,4 @@
-#include <limits.h>
-#if defined(__linux__) && !defined(__GLIBC__) && !defined(__WORDSIZE)
-// include __WORDSIZE headers for musl
-#  include <bits/reg.h>
-#endif
-#if __WORDSIZE == 64
+#if __SIZEOF_POINTER__ == 8
 #  define BACKTRACE_ELF_SIZE 64
 #else
 #  define BACKTRACE_ELF_SIZE 32


### PR DESCRIPTION
This is the new location for `__WORDSIZE`. `bits/reg.h` is an empty header. The change was made in 2024:
https://git.musl-libc.org/cgit/musl/commit/?id=e709a6f07ade208ba513f9225222336f30c304b0

Fixes symbol resolution on musl (particularly, postmarketOS aarch64).