### PR TITLE
Link NFD statically

### DIFF
--- a/cmake/vendor.cmake
+++ b/cmake/vendor.cmake
@@ -188,6 +188,7 @@ if(NOT NO_FILESELECTOR AND NOT EMSCRIPTEN)
         GIT_TAG 3cd252a8f7ca32419b1ca235c2990ba6a0ecba7c
         EXCLUDE_FROM_ALL TRUE
         OPTIONS
+            "BUILD_SHARED_LIBS OFF"
             "NFD_PORTAL ${NFD_PORTAL}"
     )
 endif()


### PR DESCRIPTION
Currently, the profiler will build against the git NFD, but link it as a shared library. Since libnfd is not installed when building Tracy as a distro package, it will end up actually depending on and running against an older distro-provided NFD, hitting an unresolved function error due to the newly added NFD function in git.

Other deps fetched with CPM are linked statically, avoiding this problem.