### PR TITLE
manual: Fix decorators in the Python listing and typo

### DIFF
--- a/manual/latex2md.sh
+++ b/manual/latex2md.sh
@@ -19,6 +19,8 @@ sed -i -e 's@\\textsigma@σ@g' _tmp.tex
 sed -i -e 's|@\\circled{a}@|(a)|g' -e 's|@\\circled{b}@|(b)|g' -e 's|@\\circled{c}@|(c)|g' _tmp.tex
 sed -i -e 's|\\circled{a}|(a)|g' -e 's|\\circled{b}|(b)|g' -e 's|\\circled{c}|(c)|g' _tmp.tex
 sed -i -e 's|@\\ldots@|…|g' _tmp.tex
+# pandoc doens't recognize this lstlisting option and emits it verbatim
+sed -i -e 's|,\?escapeinside={}{}||g' _tmp.tex
 
 sed -i -e 's@\\nameref{quicklook}@A quick look at Tracy Profiler@g' _tmp.tex
 sed -i -e 's@\\nameref{firststeps}@First steps@g' _tmp.tex

--- a/manual/tracy.md
+++ b/manual/tracy.md
@@ -2205,82 +2205,84 @@ An especially powerful feature is the ability to profile Python code and any oth
 
 An example of how to use the Tracy-Client bindings is shown below:
 
-    #!/usr/bin/env python3
-    # -*- coding: utf-8 -*-
+``` {.python language="Python"}
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
-    from time import sleep
+from time import sleep
 
-    import numpy as np
+import numpy as np
 
-    import tracy_client as tracy
-
-
-    @tracy.ScopedFrameDecorator("framed")
-    @tracy.ScopedZoneDecorator(name="work", color=tracy.ColorType.Red4)
-    def work():
-        sleep(0.05)
+import tracy_client as tracy
 
 
-    def main():
-        assert tracy.program_name("MyApp")
-        assert tracy.app_info("this is a python app")
+@tracy.ScopedFrameDecorator("framed")
+@tracy.ScopedZoneDecorator(name="work", color=tracy.ColorType.Red4)
+def work():
+    sleep(0.05)
 
-        tracy.thread_name("python")  # main thread so bit useless
 
-        plot_id = tracy.plot_config("plot", tracy.PlotFormatType.Number)
-        assert plot_id is not None
+def main():
+    assert tracy.program_name("MyApp")
+    assert tracy.app_info("this is a python app")
 
-        mem_id = None
+    tracy.thread_name("python")  # main thread so bit useless
 
-        index = 0
-        while True:
-            with tracy.ScopedZone(name="test", color=tracy.ColorType.Coral) as zone:
-                index += 1
+    plot_id = tracy.plot_config("plot", tracy.PlotFormatType.Number)
+    assert plot_id is not None
 
-                tracy.frame_mark()
+    mem_id = None
 
-                inner = tracy.ScopedZone(depth=5, color=tracy.ColorType.Coral)
-                inner.color(index % 5)
-                inner.name(str(index))
-                inner.enter()
+    index = 0
+    while True:
+        with tracy.ScopedZone(name="test", color=tracy.ColorType.Coral) as zone:
+            index += 1
 
-                if index % 2:
-                    tracy.alloc(44, index)
+            tracy.frame_mark()
+
+            inner = tracy.ScopedZone(depth=5, color=tracy.ColorType.Coral)
+            inner.color(index % 5)
+            inner.name(str(index))
+            inner.enter()
+
+            if index % 2:
+                tracy.alloc(44, index)
+            else:
+                tracy.free(44)
+
+            if not index % 2:
+                if mem_id is None:
+                    mem_id = tracy.alloc(1337000000, index, name="named", depth=4)
+                    assert mem_id is not None
                 else:
-                    tracy.free(44)
+                    tracy.alloc(1337000000, index, id=mem_id, depth=4)
+            else:
+                tracy.free(1337000000, mem_id, 4)
 
-                if not index % 2:
-                    if mem_id is None:
-                        mem_id = tracy.alloc(1337000000, index, name="named", depth=4)
-                        assert mem_id is not None
-                    else:
-                        tracy.alloc(1337000000, index, id=mem_id, depth=4)
-                else:
-                    tracy.free(1337000000, mem_id, 4)
+            with tracy.ScopedFrame("custom"):
 
-                with tracy.ScopedFrame("custom"):
+                image = np.full([400, 400, 4], index, dtype=np.uint8)
+                assert tracy.frame_image(image.tobytes(), 400, 400)
 
-                    image = np.full([400, 400, 4], index, dtype=np.uint8)
-                    assert tracy.frame_image(image.tobytes(), 400, 400)
+            inner.exit()
 
-                inner.exit()
+            zone.text(index)
 
-                zone.text(index)
+            assert tracy.message(f"we are at index {index}")
+            assert tracy.message(f"we are at index {index}", tracy.ColorType.Coral)
 
-                assert tracy.message(f"we are at index {index}")
-                assert tracy.message(f"we are at index {index}", tracy.ColorType.Coral)
+            assert tracy.plot(plot_id, index)
 
-                assert tracy.plot(plot_id, index)
+            work()
 
-                work()
-
-                sleep(0.1)
+            sleep(0.1)
 
 
-    if __name__ == "__main__":
-        main()
+if __name__ == "__main__":
+    main()
+```
 
-Please not the use of ids as way to cope with the need for unique pointers for certain features of the Tracy profiler, see section [3.1.2](#uniquepointers).
+Please note the use of ids as way to cope with the need for unique pointers for certain features of the Tracy profiler, see section [3.1.2](#uniquepointers).
 
 ### Building the Python package
 

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -2482,7 +2482,7 @@ An especially powerful feature is the ability to profile Python code and any oth
 
 An example of how to use the Tracy-Client bindings is shown below:
 
-\begin{lstlisting}
+\begin{lstlisting}[language=Python,escapeinside={}{}]
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -2559,7 +2559,7 @@ if __name__ == "__main__":
     main()
 \end{lstlisting}
 
-Please not the use of ids as way to cope with the need for unique pointers for certain features of the Tracy profiler, see section~\ref{uniquepointers}.
+Please note the use of ids as way to cope with the need for unique pointers for certain features of the Tracy profiler, see section~\ref{uniquepointers}.
 
 \subsubsection{Building the Python package}
 


### PR DESCRIPTION
Something I noticed when browsing the Python section.

The listings are set to treat `@` as a LaTeX escape character. This breaks Python decorators, so escaping needs to be disabled on this listing via `escapeinside={}{}`. Unfortunately, pandoc trips up on this flag and emits it verbatim into the .md, so it needs to be stripped during preprocessing.

I also set the language to Python while I was at it, which caused the .md to change from indented to backticked code.

Also with current Arch packages, pandoc produces a bunch of irrelevant indentation changes on the .md so I only kept the listing itself in the diff.

| Before | After |
| --- | --- |
| <img width="787" height="349" alt="image" src="https://github.com/user-attachments/assets/3228a8f5-49e4-4ea1-a985-07c386b6ab18" /> | <img width="787" height="349" alt="image" src="https://github.com/user-attachments/assets/2bcb4fdf-3273-46d6-b9cd-829291b63750" /> |