### PR TITLE
Reduce Vulkan QueryCount for Apple devices

### DIFF
--- a/public/tracy/TracyVulkan.hpp
+++ b/public/tracy/TracyVulkan.hpp
@@ -91,7 +91,11 @@ class VkCtx
 {
     friend class VkCtxScope;
 
+#if !defined __APPLE__
     static constexpr size_t QueryCount = 64 * 1024;
+#else
+    static constexpr size_t QueryCount = 4 * 1024;
+#endif
 
 public:
 #if defined TRACY_VK_USE_SYMBOL_TABLE


### PR DESCRIPTION
I've integrated TracyVkCtx with some GPU scopes, and everything works on Android. But this is not working on macOS running via moltenVK, since metal has a lower query limit:

> VK_ERROR_OUT_OF_DEVICE_MEMORY: Could not create MTLCounterSampleBuffer of size 524288, for 65536 queries, in query pool of type VK_QUERY_TYPE_TIMESTAMP. Reverting to emulated behavior. (Error code 1): Invalid sample buffer length: 524288 B. Expected range: 8 -> 32768

The current behaviour switches to emulated scopes, which returns zero for all GPU scopes.

Reducing the number of queries ensures that the buffer allocation succeeds, and I get the correct behaviour on macOS. This is the same limit that is set for [metal](https://github.com/wolfpld/tracy/blob/ac4defb4f3d3dd763a63aa190c6af42bbdbafeb3/public/tracy/TracyMetal.hmm#L120).