### PR TITLE
fix(mcp): recover from hangs and evict idle files

### DIFF
--- a/extra/mcp/eval_guide.md
+++ b/extra/mcp/eval_guide.md
@@ -97,11 +97,14 @@ frees it just because your conversation ends.
 - `list_instances` reports `idle_seconds`, `connected`, and `background_done`
   per instance; use it to spot stale ones before starting a new session,
   especially if you're about to load several captures for comparison.
-- The server does provide two backstops, both configurable via environment
+- The server provides three backstops, all configurable via environment
   variables at startup: it evicts the least-recently-used *evictable*
   instance (disconnected live sessions, or any loaded file capture — never
   a still-connected live one) once the instance count reaches
-  `TRACY_MCP_MAX_INSTANCES` (default 4), and it drops a disconnected live
+  `TRACY_MCP_MAX_INSTANCES` (default 4); it drops a disconnected live
   instance that's sat idle for `TRACY_MCP_DISCONNECTED_TTL_S` (default
   1800s / 30 min) so a session is still there for analysis right after the
-  target disconnects, but doesn't linger forever if forgotten.
+  target disconnects, but doesn't linger forever if forgotten; and it drops
+  a file-loaded capture that's sat idle for `TRACY_MCP_FILE_IDLE_TTL_S`
+  (default 1800s) — safe to let expire since it's already durably on disk,
+  just `load_capture` it again.

--- a/extra/mcp/tracy_mcp.py
+++ b/extra/mcp/tracy_mcp.py
@@ -251,6 +251,7 @@ except ImportError:
 
 _MAX_INSTANCES = int(os.environ.get("TRACY_MCP_MAX_INSTANCES", "4"))
 _DISCONNECTED_TTL_S = float(os.environ.get("TRACY_MCP_DISCONNECTED_TTL_S", "1800"))
+_FILE_IDLE_TTL_S = float(os.environ.get("TRACY_MCP_FILE_IDLE_TTL_S", "1800"))
 _SWEEP_INTERVAL_S = float(os.environ.get("TRACY_MCP_SWEEP_INTERVAL_S", "300"))
 
 
@@ -303,17 +304,22 @@ def _shutdown_worker(worker: object | None) -> None:
         pass
 
 
-def _evict_disconnected_idle() -> list[str]:
-    """Unload live instances that disconnected and have sat idle past the TTL.
-
-    Runs on the periodic sweep. A grace period (_DISCONNECTED_TTL_S) is kept
-    so a capture is still around for post-session analysis right after the
-    target disconnects — this only reclaims sessions that were forgotten.
+def _evict_idle() -> list[str]:
+    """Unload instances idle past their TTL: disconnected live instances
+    past _DISCONNECTED_TTL_S, file-loaded captures past _FILE_IDLE_TTL_S
+    (safe — already durably on disk). Connected live instances are never
+    touched here.
     """
     now = time.time()
     evicted = []
     for name, inst in list(instances.items()):
-        if inst.path is not None or inst.worker is None:
+        if inst.path is not None:
+            if now - inst.last_used >= _FILE_IDLE_TTL_S:
+                del instances[name]
+                _shutdown_worker(inst.worker)
+                evicted.append(name)
+            continue
+        if inst.worker is None:
             continue
         try:
             connected = inst.worker.is_connected()
@@ -359,7 +365,7 @@ async def _sweep_loop() -> None:
     while True:
         await asyncio.sleep(_SWEEP_INTERVAL_S)
         try:
-            evicted = _evict_disconnected_idle()
+            evicted = _evict_idle()
         except Exception:
             evicted = None
         print(
@@ -424,10 +430,12 @@ async def list_instances() -> list[dict]:
     process runs (it's a singleton shared across all MCP clients) until
     unloaded. `idle_seconds` is how long since this instance was last used
     via `eval`/`save_trace` — call `unload_capture` on ones you no longer
-    need instead of waiting for automatic eviction. Automatic eviction only
-    kicks in at the `TRACY_MCP_MAX_INSTANCES` cap (LRU, connected live
-    instances are never evicted) or after a disconnected live instance sits
-    idle past `TRACY_MCP_DISCONNECTED_TTL_S`.
+    need instead of waiting for automatic eviction. Automatic eviction kicks
+    in at the `TRACY_MCP_MAX_INSTANCES` cap (LRU, connected live instances
+    are never evicted), after a disconnected live instance sits idle past
+    `TRACY_MCP_DISCONNECTED_TTL_S`, or after a file-loaded capture sits idle
+    past `TRACY_MCP_FILE_IDLE_TTL_S` — it's already durably on disk, so
+    nothing is lost; just `load_capture` it again.
 
     `background_done: false` means a just-loaded capture is still building
     zone/symbol statistics on a background thread — `get_all_zone_stats`

--- a/extra/mcp/tracy_mcp.py
+++ b/extra/mcp/tracy_mcp.py
@@ -5,6 +5,7 @@ import asyncio
 import atexit
 import builtins
 import concurrent.futures
+import faulthandler
 import glob
 import io
 import os
@@ -14,6 +15,8 @@ import socket
 import struct
 import sys
 import time
+import urllib.error
+import urllib.request
 import uuid
 from contextlib import asynccontextmanager, redirect_stdout
 
@@ -29,6 +32,7 @@ logging.getLogger("starlette").setLevel(logging.CRITICAL)
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _PORT_FILE = os.path.join(_HERE, "tracy_mcp.port")
 _PID_FILE  = os.path.join(_HERE, "tracy_mcp.pid")
+_CRASH_LOG_FILE = os.path.join(_HERE, "tracy_mcp.crash.log")
 _PREFERRED_PORT = int(os.environ.get("TRACY_MCP_PORT", "47380"))
 _TRANSPORT = os.environ.get("TRACY_MCP_TRANSPORT", "streamable-http").strip().lower()
 
@@ -156,10 +160,26 @@ async def _listen_broadcasts(timeout_s: float = 1.5) -> list[dict]:
     return list(seen.values())
 
 
-def _is_our_server_running() -> tuple[bool, int]:
+def _http_ping(port: int, timeout_s: float = 2.0) -> bool:
+    """Confirms the server answers HTTP, not just that its PID exists — a
+    deadlocked process still passes os.kill(pid, 0). Any response, even an
+    error one, proves the transport is alive; only a timeout or refused
+    connection means it's not.
     """
-    Check the PID file to see if our server is already running.
-    Returns (running, port). Uses os.kill(pid, 0) to confirm the process is alive.
+    path = mcp_server.settings.sse_path if _TRANSPORT == "sse" else mcp_server.settings.streamable_http_path
+    try:
+        urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=timeout_s)
+        return True
+    except urllib.error.HTTPError:
+        return True
+    except Exception:
+        return False
+
+
+def _is_our_server_running() -> tuple[bool, int]:
+    """Check whether our server is running: PID alive AND responding to
+    an HTTP self-ping (a hung process still passes os.kill(pid, 0)).
+    Returns (running, port).
     """
     try:
         with open(_PID_FILE) as f:
@@ -167,9 +187,19 @@ def _is_our_server_running() -> tuple[bool, int]:
         with open(_PORT_FILE) as f:
             port = int(f.read().strip())
         os.kill(pid, 0)   # raises OSError if process is gone
-        return True, port
     except Exception:
         return False, 0
+    if not _http_ping(port):
+        print(
+            f"Tracy MCP process {pid} is alive (PID check passed) but isn't "
+            f"responding on port {port} within {2.0:.0f}s -- likely hung/deadlocked, "
+            f"not just busy. Starting a fresh server on a new port; kill PID {pid} "
+            f"manually once you're able to (it's still holding the port and the "
+            f"TracyServerBindings.pyd file lock).",
+            file=sys.stderr,
+        )
+        return False, 0
+    return True, port
 
 
 def _find_free_port() -> int:
@@ -320,12 +350,25 @@ def _evict_for_capacity(exclude: str | None = None) -> str | None:
 
 
 async def _sweep_loop() -> None:
+    """Periodic eviction sweep, doubling as a heartbeat — distinguishes a
+    crashed process (see faulthandler) from a hung one (stops producing
+    these lines). flush=True since a hang is exactly when buffering would
+    hide the last known-good timestamp.
+    """
+    start = time.time()
     while True:
         await asyncio.sleep(_SWEEP_INTERVAL_S)
         try:
-            _evict_disconnected_idle()
+            evicted = _evict_disconnected_idle()
         except Exception:
-            pass
+            evicted = None
+        print(
+            f"[heartbeat] uptime={int(time.time() - start)}s "
+            f"instances={len(instances)} tasks={len(tasks)} "
+            f"evicted={evicted or 'none'}",
+            file=sys.stderr,
+            flush=True,
+        )
 
 
 @asynccontextmanager
@@ -822,6 +865,13 @@ async def shutdown_server() -> str:
 
 
 if __name__ == "__main__":
+    # Enabled before anything touches the native bindings, so a genuine
+    # fatal crash (segfault etc.) writes a thread-state traceback to disk
+    # before the process dies — works on Windows via
+    # SetUnhandledExceptionFilter, same mechanism as POSIX signals.
+    _crash_log_fh = open(_CRASH_LOG_FILE, "a", encoding="utf-8")
+    faulthandler.enable(file=_crash_log_fh, all_threads=True)
+
     atexit.register(_cleanup_pid_files)
 
     if _TRANSPORT not in ("sse", "streamable-http"):


### PR DESCRIPTION
## Summary

Addresses the "server just vanishes" pattern from alandtse/tracy#2, where `Unable to connect` gives no way to tell a segfault apart from a hang and required manually killing an unresponsive process before restart:

- `faulthandler.enable()` at startup writes a thread-state traceback to `tracy_mcp.crash.log` on a genuine fatal crash (works on Windows via `SetUnhandledExceptionFilter`).
- The periodic sweep loop now also logs a heartbeat (uptime, instance/task counts, evictions) so a hung event loop is distinguishable from a dead process by the last timestamp on disk.
- `_is_our_server_running()` now backs its `os.kill(pid, 0)` check with an HTTP self-ping. A deadlocked-but-alive process passed the old PID-only check, silently blocking restart; a non-responsive server is now reported by PID and a fresh instance starts on a new port instead.

Also closes a separate gap: automatic eviction only ever covered disconnected live instances, so a file-loaded capture — potentially many GB — stayed resident forever until the `TRACY_MCP_MAX_INSTANCES` cap forced an LRU eviction to make room. Generalizes the sweep into `_evict_idle`: file-loaded instances now get their own idle-since-last-use TTL (`TRACY_MCP_FILE_IDLE_TTL_S`, default 1800s matching the disconnected-live TTL). Safe to evict on a timer since they're already durably on disk — `load_capture` brings them back. Connected live instances are untouched.

Updates `eval_guide.md`'s "Instance lifecycle" section, which previously claimed "two backstops" and omitted the new file-idle TTL.

## Test plan

- [x] `py_compile` clean
- [x] Unit-style test against `_evict_idle` covering three cases: stale file-loaded instance evicted (and `shutdown()` called), fresh file-loaded instance kept, connected live instance kept regardless of idle time — all pass
- [x] Live-tested against the real MCP server: `list_instances` correctly reports `background_done`, faulthandler/heartbeat wired up at startup