### PR TITLE
Add function to calculate thread lock wait time in TracyTimelineItemThread

### DIFF
--- a/manual/tracy.md
+++ b/manual/tracy.md
@@ -3635,7 +3635,7 @@ Mutual exclusion zones are displayed in each thread that tries to acquire them. 
 
 [^77]: This region type is disabled by default and needs to be enabled in options (section [5.4](#options)).
 
-Hovering the  mouse pointer over a lock timeline will highlight the lock in all threads to help read the lock behavior. Hovering the  mouse pointer over a lock event will display important information, for example, a list of threads that are currently blocking or which are blocked by the lock. Clicking the left mouse button on a lock event or a lock label will open the lock information window, as described in section [5.19](#lockwindow). Clicking the middle mouse button on a lock event will zoom the view to the extent of the event.
+Hovering the  mouse pointer over a lock timeline will highlight the lock in all threads to help read the lock behavior. Hovering the  mouse pointer over a lock event will display important information, for example, a list of threads that are currently blocking or which are blocked by the lock. Hovering the  mouse pointer over a thread label shows that thread's aggregate lock wait time across all locks (see above). Clicking the left mouse button on a lock event or a lock label will open the lock information window, as described in section [5.19](#lockwindow). Clicking the middle mouse button on a lock event will zoom the view to the extent of the event.
 
 
 -----

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -4100,7 +4100,7 @@ Mutual exclusion zones are displayed in each thread that tries to acquire them. 
 \item \emph{Red region} -- The thread wants to acquire the lock but is blocked by other thread or threads in case of a shared lock.
 \end{itemize}
 
-Hovering the \faArrowPointer{}~mouse pointer over a lock timeline will highlight the lock in all threads to help read the lock behavior. Hovering the \faArrowPointer{}~mouse pointer over a lock event will display important information, for example, a list of threads that are currently blocking or which are blocked by the lock. Clicking the \LMB{}~left mouse button on a lock event or a lock label will open the lock information window, as described in section~\ref{lockwindow}. Clicking the \MMB{}~middle mouse button on a lock event will zoom the view to the extent of the event.
+Hovering the \faArrowPointer{}~mouse pointer over a lock timeline will highlight the lock in all threads to help read the lock behavior. Hovering the \faArrowPointer{}~mouse pointer over a lock event will display important information, for example, a list of threads that are currently blocking or which are blocked by the lock. Hovering the \faArrowPointer{}~mouse pointer over a thread label shows that thread's aggregate lock wait time across all locks (see above). Clicking the \LMB{}~left mouse button on a lock event or a lock label will open the lock information window, as described in section~\ref{lockwindow}. Clicking the \MMB{}~middle mouse button on a lock event will zoom the view to the extent of the event.
 
 \subparagraph{Plots}
 \label{plots}

--- a/profiler/src/profiler/TracyTimelineItemThread.cpp
+++ b/profiler/src/profiler/TracyTimelineItemThread.cpp
@@ -17,6 +17,45 @@ namespace tracy
 constexpr float MinVisSize = 3;
 constexpr float MinCtxSize = 4;
 
+// Sum Wait→Obtain (and WaitShared→ObtainShared) for one thread across all locks.
+static int64_t GetThreadLockWaitTime( const Worker& worker, uint64_t tid, size_t& lockCnt, uint64_t& waitCount )
+{
+    int64_t waitTotal = 0;
+    lockCnt = 0;
+    waitCount = 0;
+    for( const auto& lock : worker.GetLockMap() )
+    {
+        const auto& lockmap = *lock.second;
+        if( !lockmap.valid ) continue;
+        auto it = lockmap.threadMap.find( tid );
+        if( it == lockmap.threadMap.end() ) continue;
+        lockCnt++;
+        const uint8_t thread = it->second;
+        bool pending = false;
+        int64_t waitStart = 0;
+        for( const auto& evPtr : lockmap.timeline )
+        {
+            const auto* ev = evPtr.ptr.get();
+            if( !ev || ev->thread != thread ) continue;
+            if( ev->type == LockEvent::Type::Wait || ev->type == LockEvent::Type::WaitShared )
+            {
+                pending = true;
+                waitStart = ev->Time();
+            }
+            else if( ev->type == LockEvent::Type::Obtain || ev->type == LockEvent::Type::ObtainShared )
+            {
+                if( pending )
+                {
+                    waitTotal += ev->Time() - waitStart;
+                    waitCount++;
+                    pending = false;
+                }
+            }
+        }
+    }
+    return waitTotal;
+}
+
 
 TimelineItemThread::TimelineItemThread( View& view, Worker& worker, const ThreadData* thread )
     : TimelineItem( view, worker, thread, true )
@@ -171,14 +210,8 @@ void TimelineItemThread::HeaderTooltip( const char* label ) const
     ImGui::Separator();
 
     size_t lockCnt = 0;
-    for( const auto& lock : m_worker.GetLockMap() )
-    {
-        const auto& lockmap = *lock.second;
-        if( !lockmap.valid ) continue;
-        auto it = lockmap.threadMap.find( m_thread->id );
-        if( it == lockmap.threadMap.end() ) continue;
-        lockCnt++;
-    }
+    uint64_t lockWaitCount = 0;
+    const int64_t lockWaitTime = GetThreadLockWaitTime( m_worker, m_thread->id, lockCnt, lockWaitCount );
 
     if( last >= 0 )
     {
@@ -199,6 +232,18 @@ void TimelineItemThread::HeaderTooltip( const char* label ) const
             ImGui::SameLine();
             PrintStringPercent( buf, ctx->runningTime / double( lifetime ) * 100 );
             TextDisabledUnformatted( buf );
+        }
+        if( lockCnt != 0 || lockWaitTime > 0 )
+        {
+            TextFocused( "Lock wait time:", TimeToString( lockWaitTime ) );
+            ImGui::SameLine();
+            PrintStringPercent( buf, lockWaitTime / double( lifetime ) * 100 );
+            TextDisabledUnformatted( buf );
+            if( lockWaitCount != 0 )
+            {
+                ImGui::SameLine();
+                ImGui::TextDisabled( "(%s waits)", RealToString( lockWaitCount ) );
+            }
         }
     }
 


### PR DESCRIPTION
This update introduces a new function, GetThreadLockWaitTime, which computes the total wait time for locks held by a specific thread. The function aggregates wait times across all locks and updates the tooltip to display lock wait time and count, enhancing the profiling capabilities of the timeline item.