### PR TITLE
Add formatted zone text/name macros to C API

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -2206,7 +2206,7 @@ void Profiler::Worker()
     // takes care of calling StopSystemTracing(). However, a client may decide to
     // manually RequestShutdown(), in which case ~Profile() may not execute before
     // this Worker() thread goes through its teardown stages and reaches this point.
-    // To ensure that system tracing does not keep pushing data to the worker queue 
+    // To ensure that system tracing does not keep pushing data to the worker queue
     // indefinitely (thus preventing this worker from terminating), we have to call
     // StopSystemTracing() here as well to be safe:
     StopSystemTracing();
@@ -4727,6 +4727,34 @@ TRACY_API void ___tracy_emit_zone_text( TracyCZoneCtx ctx, const char* txt, size
     }
 }
 
+TRACY_API void ___tracy_emit_zone_text_fmt( TracyCZoneCtx ctx, const char* fmt, ... )
+{
+    if( !ctx.active ) return;
+    va_list args;
+    va_start( args, fmt );
+    auto size = vsnprintf( nullptr, 0, fmt, args );
+    va_end( args );
+    if( size < 0 ) return;
+    assert( size < (std::numeric_limits<uint16_t>::max)() );
+
+    char* ptr = (char*)tracy::tracy_malloc( size_t( size ) + 1 );
+    va_start( args, fmt );
+    vsnprintf( ptr, size_t( size ) + 1, fmt, args );
+    va_end( args );
+
+#ifndef TRACY_NO_VERIFY
+    {
+        TracyQueuePrepareC( tracy::QueueType::ZoneValidation );
+        tracy::MemWrite( &item->zoneValidation.id, ctx.id );
+        TracyQueueCommitC( zoneValidationThread );
+    }
+#endif
+    TracyQueuePrepare( tracy::QueueType::ZoneText );
+    tracy::MemWrite( &item->zoneTextFat.text, (uint64_t)ptr );
+    tracy::MemWrite( &item->zoneTextFat.size, (uint16_t)size );
+    TracyQueueCommit( zoneTextFatThread );
+}
+
 TRACY_API void ___tracy_emit_zone_name( TracyCZoneCtx ctx, const char* txt, size_t size )
 {
     assert( size < std::numeric_limits<uint16_t>::max() );
@@ -4746,6 +4774,34 @@ TRACY_API void ___tracy_emit_zone_name( TracyCZoneCtx ctx, const char* txt, size
         tracy::MemWrite( &item->zoneTextFat.size, (uint16_t)size );
         TracyQueueCommitC( zoneTextFatThread );
     }
+}
+
+TRACY_API void ___tracy_emit_zone_name_fmt( TracyCZoneCtx ctx, const char* fmt, ... )
+{
+    if( !ctx.active ) return;
+    va_list args;
+    va_start( args, fmt );
+    auto size = vsnprintf( nullptr, 0, fmt, args );
+    va_end( args );
+    if( size < 0 ) return;
+    assert( size < (std::numeric_limits<uint16_t>::max)() );
+
+    char* ptr = (char*)tracy::tracy_malloc( size_t( size ) + 1 );
+    va_start( args, fmt );
+    vsnprintf( ptr, size_t( size ) + 1, fmt, args );
+    va_end( args );
+
+#ifndef TRACY_NO_VERIFY
+    {
+        TracyQueuePrepareC( tracy::QueueType::ZoneValidation );
+        tracy::MemWrite( &item->zoneValidation.id, ctx.id );
+        TracyQueueCommitC( zoneValidationThread );
+    }
+#endif
+    TracyQueuePrepare( tracy::QueueType::ZoneName );
+    tracy::MemWrite( &item->zoneTextFat.text, (uint64_t)ptr );
+    tracy::MemWrite( &item->zoneTextFat.size, (uint16_t)size );
+    TracyQueueCommit( zoneTextFatThread );
 }
 
 TRACY_API void ___tracy_emit_zone_color( TracyCZoneCtx ctx, uint32_t color ) {

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -4749,10 +4749,10 @@ TRACY_API void ___tracy_emit_zone_text_fmt( TracyCZoneCtx ctx, const char* fmt, 
         TracyQueueCommitC( zoneValidationThread );
     }
 #endif
-    TracyQueuePrepare( tracy::QueueType::ZoneText );
+    TracyQueuePrepareC( tracy::QueueType::ZoneText );
     tracy::MemWrite( &item->zoneTextFat.text, (uint64_t)ptr );
     tracy::MemWrite( &item->zoneTextFat.size, (uint16_t)size );
-    TracyQueueCommit( zoneTextFatThread );
+    TracyQueueCommitC( zoneTextFatThread );
 }
 
 TRACY_API void ___tracy_emit_zone_name( TracyCZoneCtx ctx, const char* txt, size_t size )
@@ -4798,10 +4798,10 @@ TRACY_API void ___tracy_emit_zone_name_fmt( TracyCZoneCtx ctx, const char* fmt, 
         TracyQueueCommitC( zoneValidationThread );
     }
 #endif
-    TracyQueuePrepare( tracy::QueueType::ZoneName );
+    TracyQueuePrepareC( tracy::QueueType::ZoneName );
     tracy::MemWrite( &item->zoneTextFat.text, (uint64_t)ptr );
     tracy::MemWrite( &item->zoneTextFat.size, (uint16_t)size );
-    TracyQueueCommit( zoneTextFatThread );
+    TracyQueueCommitC( zoneTextFatThread );
 }
 
 TRACY_API void ___tracy_emit_zone_color( TracyCZoneCtx ctx, uint32_t color ) {

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -20,7 +20,7 @@
 #include "../common/TracyQueue.hpp"
 #include "../common/TracyAlign.hpp"
 #include "../common/TracyAlloc.hpp"
-#include "../common/TracyFormat.hpp"
+#include "../common/TracyFormat.h"
 #include "../common/TracyMutex.hpp"
 #include "../common/TracyProtocol.hpp"
 
@@ -44,7 +44,7 @@
 #  define TRACY_HAS_CNTVCT
 #endif
 
-#if !defined TRACY_DISALLOW_HW_TIMER 
+#if !defined TRACY_DISALLOW_HW_TIMER
 #  if ( defined TRACY_HAS_RDTSC || defined TRACY_HAS_CNTVCT )
 #    define TRACY_HW_TIMER
 #  elif defined TARGET_OS_IOS && TARGET_OS_IOS == 1 // For now, !defined(TRACY_HW_TIMER) implies TRACY_TIMER_FALLBACK, so define TRACY_HW_TIMER to use mach_absolute_time() on iOS
@@ -248,7 +248,7 @@ public:
             uint64_t value;
             __asm__ __volatile__(
                //"isb \n"              // ommitting "Instruction Synchronization Barrier"
-                "mrs %0, CNTVCT_EL0" 
+                "mrs %0, CNTVCT_EL0"
                 : "=r" (value)          // Output: write 'register %0' to 'value'
                 :                       // No inputs
                 : "memory"              // Clobber list: memory (e.g., compiler barrier)
@@ -454,7 +454,7 @@ public:
 
         TracyLfqCommit;
     }
-    
+
     static tracy_force_inline void LogString( MessageSourceType source, MessageSeverity severity, uint32_t color, int32_t callstack_depth, size_t txtLength, const char* txt )
     {
         assert( txtLength < (std::numeric_limits<uint16_t>::max)() );

--- a/public/client/TracyScoped.hpp
+++ b/public/client/TracyScoped.hpp
@@ -9,7 +9,7 @@
 #include "../common/TracySystem.hpp"
 #include "../common/TracyAlign.hpp"
 #include "../common/TracyAlloc.hpp"
-#include "../common/TracyFormat.hpp"
+#include "../common/TracyFormat.h"
 #include "TracyProfiler.hpp"
 #include "TracyCallstack.hpp"
 

--- a/public/common/TracyFormat.h
+++ b/public/common/TracyFormat.h
@@ -1,5 +1,5 @@
-#ifndef __TRACYFORMAT_HPP__
-#define __TRACYFORMAT_HPP__
+#ifndef __TRACYFORMAT_H__
+#define __TRACYFORMAT_H__
 
 #if (defined(__GNUC__) || defined(__clang__))
 #  define TRACY_ATTRIBUTE_FORMAT_PRINTF(fmt_idx, arg_idx) \

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -58,7 +58,9 @@ typedef const void* TracyCSharedLockCtx;
 #define TracyCZoneNC(c,x,y,z)
 #define TracyCZoneEnd(c)
 #define TracyCZoneText(c,x,y)
+#define TracyCZoneTextF(c,x,...)
 #define TracyCZoneName(c,x,y)
+#define TracyCZoneNameF(c,x,...)
 #define TracyCZoneColor(c,x)
 #define TracyCZoneValue(c,x)
 

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include "../common/TracyApi.h"
+#include "../common/TracyFormat.hpp"
 
 #ifdef __cplusplus
 extern "C" {
@@ -240,7 +241,9 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t
 TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int32_t depth, int32_t active );
 TRACY_API void ___tracy_emit_zone_end( TracyCZoneCtx ctx );
 TRACY_API void ___tracy_emit_zone_text( TracyCZoneCtx ctx, const char* txt, size_t size );
+TRACY_API void ___tracy_emit_zone_text_fmt( TracyCZoneCtx ctx, const char* fmt, ... ) TRACY_ATTRIBUTE_FORMAT_PRINTF(2, 3);
 TRACY_API void ___tracy_emit_zone_name( TracyCZoneCtx ctx, const char* txt, size_t size );
+TRACY_API void ___tracy_emit_zone_name_fmt( TracyCZoneCtx ctx, const char* fmt, ... ) TRACY_ATTRIBUTE_FORMAT_PRINTF(2, 3);
 TRACY_API void ___tracy_emit_zone_color( TracyCZoneCtx ctx, uint32_t color );
 TRACY_API void ___tracy_emit_zone_value( TracyCZoneCtx ctx, uint64_t value );
 
@@ -280,7 +283,9 @@ TRACY_API int32_t ___tracy_connected(void);
 #define TracyCZoneEnd( ctx ) ___tracy_emit_zone_end( ctx );
 
 #define TracyCZoneText( ctx, txt, size ) ___tracy_emit_zone_text( ctx, txt, size );
+#define TracyCZoneTextF( ctx, fmt, ... ) ___tracy_emit_zone_text_fmt( ctx, fmt, ##__VA_ARGS__ );
 #define TracyCZoneName( ctx, txt, size ) ___tracy_emit_zone_name( ctx, txt, size );
+#define TracyCZoneNameF( ctx, fmt, ... ) ___tracy_emit_zone_name_fmt( ctx, fmt, ##__VA_ARGS__ );
 #define TracyCZoneColor( ctx, color ) ___tracy_emit_zone_color( ctx, color );
 #define TracyCZoneValue( ctx, value ) ___tracy_emit_zone_value( ctx, value );
 

--- a/public/tracy/TracyC.h
+++ b/public/tracy/TracyC.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 #include "../common/TracyApi.h"
-#include "../common/TracyFormat.hpp"
+#include "../common/TracyFormat.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Adds TracyCZoneTextF/TracyCZoneNameF macros to TracyC.h.

I've built it locally and it works in my testing, but have not fully verified there's no possible issues in this implementation relative to other C and C++ zone labeling functions.

Fixes #1445.