### PR TITLE
document linux file descriptor limits

### DIFF
--- a/manual/tracy.md
+++ b/manual/tracy.md
@@ -2718,6 +2718,24 @@ Some profiling data can only be retrieved using the kernel facilities, which are
 
 [^59]: To make this easier, you can run MSVC with admin privileges, which will be inherited by your program when you start it from within the IDE.
 
+> [!TIP]
+> **Linux file descriptor limits**
+>
+> On Linux systems with many CPUs, Tracy may open a file descriptor for each CPU when collecting tracepoint data. If the process reaches its soft file descriptor limit, the profiled application may fail to open files and Tracy may report `Too many open files`. Check the current limit with `ulimit -n` and raise it in the shell that starts the profiled application:
+>
+> ```sh
+> ulimit -n 4096
+> ./your-program
+> ```
+>
+> When launching the application through `sudo`, set the limit in the same command, for example:
+>
+> ```sh
+> sudo sh -c 'ulimit -n 4096 && exec ./your-program'
+> ```
+>
+> The appropriate value depends on the number of CPUs and the events being collected.
+
 As this system-level tracing functionality is part of the automated collection process, no user intervention is necessary to enable it (assuming that the program was granted the rights needed). However, if, for some reason, you would want to prevent your application from trying to access kernel data, you may recompile your program with the `TRACY_NO_SYSTEM_TRACING` define. If you want to disable this functionality dynamically at runtime instead, you can set the `TRACY_NO_SYSTEM_TRACING` environment variable to "1".
 
 > [!TIP]

--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -3053,6 +3053,27 @@ Tracy will perform an automatic collection of system data without user intervent
 
 Some profiling data can only be retrieved using the kernel facilities, which are not available to users with normal privilege level. To collect such data, you will need to elevate your rights to the administrator level. You can do so either by running the profiled program from the \texttt{root} account on Unix or through the \emph{Run as administrator} option on Windows\footnote{To make this easier, you can run MSVC with admin privileges, which will be inherited by your program when you start it from within the IDE.}. On Android, you will need to have a rooted device (see section~\ref{androidlunacy} for additional information).
 
+\begin{bclogo}[
+noborder=true,
+couleur=black!5,
+logo=\bclampe
+]{Linux file descriptor limits}
+On Linux systems with many CPUs, Tracy may open a file descriptor for each CPU when collecting tracepoint data. If the process reaches its soft file descriptor limit, the profiled application may fail to open files and Tracy may report \texttt{Too many open files}. Check the current limit with \texttt{ulimit -n} and raise it in the shell that starts the profiled application:
+
+\begin{lstlisting}
+ulimit -n 4096
+./your-program
+\end{lstlisting}
+
+When launching the application through \texttt{sudo}, set the limit in the same command, for example:
+
+\begin{lstlisting}
+sudo sh -c 'ulimit -n 4096 && exec ./your-program'
+\end{lstlisting}
+
+The appropriate value depends on the number of CPUs and the events being collected.
+\end{bclogo}
+
 As this system-level tracing functionality is part of the automated collection process, no user intervention is necessary to enable it (assuming that the program was granted the rights needed). However, if, for some reason, you would want to prevent your application from trying to access kernel data, you may recompile your program with the \texttt{TRACY\_NO\_SYSTEM\_TRACING} define. If you want to disable this functionality dynamically at runtime instead, you can set the \texttt{TRACY\_NO\_SYSTEM\_TRACING} environment variable to \enquote{1}.
 
 \begin{bclogo}[


### PR DESCRIPTION
## what changed

added a linux file descriptor limits note to the manual. it explains why high-cpu systems can hit `Too many open files`, shows how to raise the limit before launching the profiled program, and covers the `sudo` case.

## why

tracy can open a file descriptor per cpu while collecting tracepoint data. the default soft limit can be too low on machines with many cpus, which can also stop the profiled application from opening files.

## checks

- git diff --check passes.
- updated both `manual/tracy.tex` and the checked-in `manual/tracy.md` rendering.
- the local machine does not have a latex or markdown renderer installed, so i did not render the manual locally.

fixes #512