### PR TITLE
Defer CUDA GpuNewContext for on-demand connections

### DIFF
--- a/public/tracy/TracyCUDA.hpp
+++ b/public/tracy/TracyCUDA.hpp
@@ -1440,6 +1440,9 @@ namespace tracy
             #else
             tracyMemWrite(item->gpuNewContext.flags, tracy::GpuContextFlags(0));
             #endif
+            #ifdef TRACY_ON_DEMAND
+            GetProfiler().DeferItem(*item);
+            #endif
             Profiler::QueueSerialFinish();
 
             constexpr const char* tracyCtxName = "CUDA GPU/Device Activity";

--- a/tests/cuda/repro/on_demand/CMakeLists.txt
+++ b/tests/cuda/repro/on_demand/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.18)
+project(CUDAOnDemandReproTests LANGUAGES C CXX CUDA)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CUDA_STANDARD 17)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+    set(CMAKE_CUDA_ARCHITECTURES native)
+endif()
+
+set(TRACY_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../.."
+    CACHE PATH "Root of the Tracy repository")
+set(TRACY_PUBLIC "${TRACY_PATH}/public")
+
+find_package(CUDAToolkit REQUIRED)
+find_package(Threads REQUIRED)
+
+# On-demand mode is the point of this repro: the client sits idle until a
+# profiler connects, which is exactly what triggers the crash.
+set(REPRO_DEFINES TRACY_ENABLE TRACY_ON_DEMAND)
+
+# Tracy client (CXX-only, matching the Makefile's g++ step for TracyClient.cpp)
+add_library(TracyClient STATIC ${TRACY_PUBLIC}/TracyClient.cpp)
+target_include_directories(TracyClient PUBLIC ${TRACY_PUBLIC})
+target_compile_definitions(TracyClient PUBLIC ${REPRO_DEFINES})
+target_link_libraries(TracyClient PUBLIC Threads::Threads ${CMAKE_DL_LIBS})
+
+# repro: minimal CUDA program that creates a CUDA context and emits GPU zones
+add_executable(repro repro.cu)
+target_link_libraries(repro PRIVATE TracyClient CUDA::cupti CUDA::cuda_driver)
+
+# check_gpu_zones: loads a .tracy capture and verifies at least one GPU
+# context was registered, named, and has recorded GPU zones. Links the
+# Tracy server library, assembled the same way tracy-capture does it
+# (cmake/server.cmake + vendor.cmake). Off by default since it pulls in the
+# full server build and its vendored dependencies.
+option(BUILD_CHECK_TOOL "Build the check_gpu_zones verification helper" OFF)
+if(BUILD_CHECK_TOOL)
+    set(NO_STATISTICS ON)
+    include(${TRACY_PATH}/cmake/vendor.cmake)
+    include(${TRACY_PATH}/cmake/server.cmake)
+    add_executable(check_gpu_zones check_gpu_zones.cpp)
+    target_compile_features(check_gpu_zones PRIVATE cxx_std_20)
+    target_include_directories(check_gpu_zones PRIVATE ${TRACY_PATH})
+    target_link_libraries(check_gpu_zones PRIVATE TracyServer)
+endif()
+
+# ctest integration. To run the binaries via ctest:
+#   ctest --test-dir <cmake-build-dir> -R repro -C <build-config>
+enable_testing()
+add_test(NAME repro COMMAND repro)

--- a/tests/cuda/repro/on_demand/README.md
+++ b/tests/cuda/repro/on_demand/README.md
@@ -1,0 +1,65 @@
+# Tracy CUDA On-Demand Profiling Repro
+
+Demonstrates that unpatched Tracy crashes when a profiler connects to a
+CUDA application built with `TRACY_ON_DEMAND`.
+
+## Root cause
+
+`CUDACtx`'s constructor (`TracyCUDA.hpp`) writes a `GpuNewContext` queue
+item but does not call `DeferItem()`, unlike every other GPU backend
+(Vulkan, OpenGL, D3D11/12, Metal, WebGPU, Rocprof), which all defer it
+under `#ifdef TRACY_ON_DEMAND`.
+
+Under on-demand mode, a new connection clears the client's pending
+serial queue (`ClearQueues()`) before replaying deferred items. Since
+`GpuNewContext` is never deferred, it never survives that clear — no
+matter how early the connection happens, even immediately after the
+context is created. The `GpuContextName` message that `Name()` sends
+right after (already correctly deferred) is then replayed to a server
+that has no record of the context, triggering:
+
+    Assertion `ctx' failed in Worker::ProcessGpuContextName
+
+In release builds (assert compiled out) this is undefined behavior —
+a null-pointer dereference, typically a segfault.
+
+This is the same bug already fixed for the Rocprof backend in #1336;
+see also the closed issue #1171, which describes this exact crash.
+
+## Build and run
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+./build/repro &
+tracy-capture -o repro.tracy -s 5
+```
+
+The reproducer is also registered as a ctest target:
+
+```bash
+ctest --test-dir build -R repro
+```
+
+## Verifying the GPU zones
+
+`check_gpu_zones` loads a `.tracy` file and prints, for each GPU
+context, whether it is named and how many GPU zones it recorded. It
+links the Tracy server library, so it is built only on request:
+
+```bash
+cmake -B build -DBUILD_CHECK_TOOL=ON
+cmake --build build --target check_gpu_zones
+./build/check_gpu_zones repro.tracy
+# Expected (patched): "GPU context 0: line_scan_processing_cuda, 200 zones"
+```
+
+Exit codes: 0 = at least one named context with recorded zones, 2 =
+otherwise.
+
+## What to expect
+
+| Tracy version | Result |
+|---|---|
+| Unpatched | `tracy-capture` crashes: `Assertion 'ctx' failed` |
+| Patched | Capture succeeds, GPU context named and populated with zones |

--- a/tests/cuda/repro/on_demand/check_gpu_zones.cpp
+++ b/tests/cuda/repro/on_demand/check_gpu_zones.cpp
@@ -1,0 +1,58 @@
+// Loads a .tracy file and prints, for each GPU context, whether it is
+// named and how many GPU zones it recorded. Used to verify that a
+// late-connecting client correctly received the deferred GpuNewContext
+// (and, downstream, actual GPU zone data) rather than the connection
+// having crashed the server before any capture was possible.
+//
+// Usage: ./check_gpu_zones trace.tracy
+// Expected output: "GPU context 0: line_scan_processing_cuda, 100 zones"
+
+#include <cstdio>
+#include <cstdlib>
+#include "server/TracyFileRead.hpp"
+#include "server/TracyWorker.hpp"
+
+int main( int argc, char** argv )
+{
+    if( argc != 2 )
+    {
+        fprintf( stderr, "Usage: %s <trace.tracy>\n", argv[0] );
+        return 1;
+    }
+
+    try
+    {
+        auto f = std::unique_ptr<tracy::FileRead>( tracy::FileRead::Open( argv[1] ) );
+        if( !f )
+        {
+            fprintf( stderr, "Cannot open %s\n", argv[1] );
+            return 1;
+        }
+
+        tracy::Worker worker( *f, tracy::EventType::None, false );
+
+        const auto& gpuData = worker.GetGpuData();
+        if( gpuData.empty() )
+        {
+            printf( "No GPU contexts found.\n" );
+            return 2;
+        }
+
+        bool all_good = true;
+        for( size_t i = 0; i < gpuData.size(); i++ )
+        {
+            const auto& ctx = gpuData[i];
+            const bool has_name = ctx->name.Active() && worker.GetString( ctx->name )[0] != '\0';
+            const char* name = has_name ? worker.GetString( ctx->name ) : "(unnamed)";
+            printf( "GPU context %zu: %s, %lu zones\n", i, name, (unsigned long)ctx->count );
+            if( !has_name || ctx->count == 0 ) all_good = false;
+        }
+
+        return all_good ? 0 : 2;
+    }
+    catch( const std::exception& e )
+    {
+        fprintf( stderr, "Error: %s\n", e.what() );
+        return 1;
+    }
+}

--- a/tests/cuda/repro/on_demand/repro.cu
+++ b/tests/cuda/repro/on_demand/repro.cu
@@ -1,0 +1,99 @@
+// Tracy CUDA On-Demand Profiling Repro
+//
+// When Tracy is built with TRACY_ON_DEMAND, a profiler connecting at any
+// point after the CUDA context is created crashes the server:
+//
+//   Assertion `ctx' failed in Worker::ProcessGpuContextName
+//
+// Root cause: CUDACtx's constructor writes a GpuNewContext queue item but
+// never calls DeferItem(), so a new connection's ClearQueues() wipes it
+// before it can be replayed. GpuContextName is deferred correctly and gets
+// replayed anyway, referencing a context the server never registered.
+//
+// Build:
+//   cmake -B build -DCMAKE_BUILD_TYPE=Release
+//   cmake --build build
+//
+// Run:
+//   ./build/repro &
+//   tracy-capture -o repro.tracy -s 5
+//
+// Expected (unpatched): tracy-capture crashes with assertion failure
+// Expected (patched):   capture succeeds with GPU zones showing kernel/memcpy names
+
+#include <cstdio>
+#include <cstdlib>
+#include <unistd.h>
+#include <cuda_runtime.h>
+
+#include "tracy/Tracy.hpp"
+#include "tracy/TracyCUDA.hpp"
+
+__global__ void vector_add(float* a, float* b, float* c, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) c[i] = a[i] + b[i];
+}
+
+#define CHECK_CUDA(call)                                                      \
+    do {                                                                       \
+        cudaError_t err = (call);                                              \
+        if (err != cudaSuccess) {                                              \
+            fprintf(stderr, "CUDA error at %s:%d: %s\n", __FILE__, __LINE__,  \
+                    cudaGetErrorString(err));                                   \
+            exit(1);                                                           \
+        }                                                                      \
+    } while (0)
+
+int main() {
+    printf("CUDA on-demand repro - waiting for profiler to connect...\n");
+    fflush(stdout);
+
+    auto ctx = TracyCUDAContext();
+    static constexpr char name[] = "line_scan_processing_cuda";
+    TracyCUDAContextName(ctx, static_cast<const char*>(name), sizeof(name) - 1);
+    TracyCUDAStartProfiling(ctx);
+
+    const int N = 1 << 16;
+    const size_t bytes = N * sizeof(float);
+    const int threads = 256;
+    const int blocks  = (N + threads - 1) / threads;
+
+    float *d_a, *d_b, *d_c;
+    CHECK_CUDA(cudaMalloc(&d_a, bytes));
+    CHECK_CUDA(cudaMalloc(&d_b, bytes));
+    CHECK_CUDA(cudaMalloc(&d_c, bytes));
+
+    float* h_a = (float*)malloc(bytes);
+    float* h_b = (float*)malloc(bytes);
+    for (int i = 0; i < N; i++) { h_a[i] = 1.0f; h_b[i] = 2.0f; }
+    CHECK_CUDA(cudaMemcpy(d_a, h_a, bytes, cudaMemcpyHostToDevice));
+    CHECK_CUDA(cudaMemcpy(d_b, h_b, bytes, cudaMemcpyHostToDevice));
+
+    // Run many iterations so tracy-capture has time to connect.
+    // With 100ms sleep per iteration this runs for ~10 seconds.
+    for (int iter = 0; iter < 100; iter++) {
+        ZoneScopedN("iteration");
+        vector_add<<<blocks, threads>>>(d_a, d_b, d_c, N);
+        CHECK_CUDA(cudaDeviceSynchronize());
+        TracyCUDACollect(ctx);
+        usleep(100000);
+        FrameMark;
+    }
+
+    float* h_c = (float*)malloc(bytes);
+    CHECK_CUDA(cudaMemcpy(h_c, d_c, bytes, cudaMemcpyDeviceToHost));
+    bool ok = h_c[0] == h_a[0] + h_b[0];
+    printf("Result: %s\n", ok ? "PASS" : "FAIL");
+
+    CHECK_CUDA(cudaFree(d_a));
+    CHECK_CUDA(cudaFree(d_b));
+    CHECK_CUDA(cudaFree(d_c));
+    free(h_a);
+    free(h_b);
+    free(h_c);
+
+    TracyCUDAStopProfiling(ctx);
+    TracyCUDAContextDestroy(ctx);
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
This is very similar to #1336, but for CUDA.

## Problem

The CUDA GPU backend crashes when a profiler connects to an application built with `TRACY_ON_DEMAND`, even on the very first connection attempt:

    Assertion `ctx' failed in Worker::ProcessGpuContextName

In release builds (assert compiled out) this is undefined behavior — typically a segfault. See also #1171, which describes this exact crash.

## Root cause

`CUDACtx`'s constructor (`TracyCUDA.hpp`) writes a `GpuNewContext` queue item but never calls `DeferItem()`, unlike every other GPU backend (Vulkan, OpenGL, D3D11/12, Metal, WebGPU, and Rocprof as of #1336), which all defer it under `#ifdef TRACY_ON_DEMAND`.

Under on-demand mode, a new connection clears the client's pending serial queue (`ClearQueues()`) before replaying deferred items. Since `GpuNewContext` is never deferred, it never survives that clear — no matter how early the connection happens, even immediately after the context is created. The `GpuContextName` message that `Name()` sends right after (already correctly deferred, via `SubmitQueueItem()`) is then replayed to a server that has no record of the context, triggering the assertion above.

## Fix

Add a `DeferItem()` call for `GpuNewContext` under `#ifdef TRACY_ON_DEMAND`, matching the pattern `Name()` already uses a few lines below, and the pattern #1336 used for the identical bug in the Rocprof backend.

## Repro case

`tests/cuda/repro/on_demand/` contains a minimal CUDA program and a `check_gpu_zones` tool, mirroring the structure #1336 added for Rocprof. See the README in that directory for details.

## Test results

Tested on an NVIDIA RTX 2000 Ada Generation, CUDA 13.3, both release and debug builds, using both the vendored `repro.cu` and a standalone CUDA + TracyClient test program:

| Build | Unpatched | Patched |
|---|---|---|
| Release (`-O2`) | `tracy-capture` segfaults on first connection | Capture succeeds, GPU zones recorded |
| Debug (`-g -O0`) | `Assertion 'ctx' failed` in `Worker::ProcessGpuContextName` | No assertions |
| Reconnect (2nd, 3rd connection) | N/A (already crashed) | Capture succeeds each time |
| `check_gpu_zones` | N/A (crash, no trace file) | Context named, zones > 0 |

Three consecutive `tracy-capture` connect/disconnect cycles against the same long-running process all succeeded after the fix, confirming on-demand profiling now works for repeated attach/detach, not just a single session.
