### PR TITLE
fix(client): correct TracyPlotConfig color byte order (#1232)

### DIFF
--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -446,7 +446,8 @@ public:
         MemWrite( &item->plotConfig.type, (uint8_t)type );
         MemWrite( &item->plotConfig.step, (uint8_t)step );
         MemWrite( &item->plotConfig.fill, (uint8_t)fill );
-        MemWrite( &item->plotConfig.color, color );
+        const uint32_t plotColor = uint32_t( ( color & 0xFF ) << 16 ) | ( color & 0xFF00 ) | uint32_t( ( color & 0xFF0000 ) >> 16 );
+        MemWrite( &item->plotConfig.color, plotColor );
 
 #ifdef TRACY_ON_DEMAND
         GetProfiler().DeferItem( *item );


### PR DESCRIPTION
Fixes #1232

`TracyPlotConfig` now packs plot colors the same way as zone/message color events (swap R/B in the 0xRRGGBB value before writing to the queue), so the profiler displays the intended color.
