### PR TITLE
Fix VSyncDPC static_assert on Win32 builds

### DIFF
--- a/public/client/windows/TracyETW.cpp
+++ b/public/client/windows/TracyETW.cpp
@@ -127,7 +127,11 @@ struct VSyncDPC
     uint32_t    flipType;
     uint64_t    flipFenceId;
 };
-static_assert( sizeof( VSyncDPC ) == 64, "unexpected VSyncInfo struct size/alignment" );
+#if defined( _WIN64 )
+static_assert( sizeof( VSyncDPC ) == 64, "unexpected VSyncDPC struct size/alignment" );
+#else
+static_assert( sizeof( VSyncDPC ) == 48, "unexpected VSyncDPC struct size/alignment" );
+#endif
 
 // --------------------------
 


### PR DESCRIPTION
Fixes #1451

`VSyncDPC` contains pointer fields whose size differs between Win32 and x64. The ETW layout static assertion assumed the 64-bit size only, breaking Win32 builds.

Use architecture-specific expected sizes (48 bytes on Win32, 64 bytes on x64).
