### PR TITLE
D3D12: pass an empty written range when unmapping the readback buffer

### DIFF
--- a/public/tracy/TracyD3D12.hpp
+++ b/public/tracy/TracyD3D12.hpp
@@ -278,8 +278,8 @@ namespace tracy
 #if TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER
             if (m_readbackBuffer)
             {
-                D3D12_RANGE fullRange { 0, m_queryLimit * sizeof(UINT64) };
-                m_readbackBuffer->Unmap(0, &fullRange);
+                D3D12_RANGE emptyWrittenRange { 0, 0 };
+                m_readbackBuffer->Unmap(0, &emptyWrittenRange);
                 m_persistentTimestampBuffer = nullptr;
             }
 #endif
@@ -543,8 +543,8 @@ namespace tracy
         void UnmapTimestampBuffer(UINT64*)
         {
 #if !TRACY_D3D12_PERSISTENT_TIMESTAMP_BUFFER
-            D3D12_RANGE fullRange { 0, m_queryLimit * sizeof(UINT64) };
-            m_readbackBuffer->Unmap(0, &fullRange);
+            D3D12_RANGE emptyWrittenRange { 0, 0 };
+            m_readbackBuffer->Unmap(0, &emptyWrittenRange);
 #endif
         }
 


### PR DESCRIPTION
Otherwise on unmap you can get the validation layer error:

"ID3D12Resource3::ID3D12Resource::Unmap: pWrittenRange does not point to an empty D3D12_RANGE and the heap type is D3D12_HEAP_TYPE_READBACK. Readback resources can be written by the CPU but there's not much utility. The rationale is that readback heaps are stuck in COPY_DEST state such that the GPU can never use what the CPU is writing. The range [0, 524288) should be empty (Begin >= End)."

Check also https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12resource-unmap

"This indicates the region the CPU might have modified" -> tracy essentially declares the entire range as written, but it's not even a cpu->gpu write buffer -> bug.