### PR TITLE
Fixed buffer overflow after using VkCtx cmdbuf ctor.

### DIFF
--- a/public/tracy/TracyVulkan.hpp
+++ b/public/tracy/TracyVulkan.hpp
@@ -174,7 +174,7 @@ public:
 
         WriteInitialItem( physdev, tcpu, tgpu );
 
-        m_res = (int64_t*)tracy_malloc( sizeof( int64_t ) * m_queryCount );
+        AllocateQueryResultBuffer();
     }
 
 #if defined VK_EXT_host_query_reset
@@ -223,9 +223,7 @@ public:
 
         WriteInitialItem( physdev, tcpu, tgpu );
 
-        // We need the buffer to be twice as large for availability values
-        size_t resSize = sizeof( int64_t ) * m_queryCount * 2;
-        m_res = (int64_t*)tracy_malloc( resSize );
+        AllocateQueryResultBuffer();
     }
 #endif
 
@@ -412,6 +410,12 @@ private:
             m_queryCount /= 2;
             poolInfo.queryCount = m_queryCount;
         }
+    }
+
+    tracy_force_inline void AllocateQueryResultBuffer()
+    {
+        // We need the buffer to be twice as large for availability values
+        m_res = (int64_t*)tracy_malloc( sizeof( int64_t ) * m_queryCount * 2 );
     }
 
     tracy_force_inline void FindAvailableTimeDomains( VkPhysicalDevice physicalDevice, PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT _vkGetPhysicalDeviceCalibrateableTimeDomainsEXT )


### PR DESCRIPTION
I got a crash in rpmalloc and found the root cause to be VkCtx::m_res being too small when its allocated in the cmdbuf ctor.
Later on, VkCtx::Collect() does read from m_res by pair of int64_t but the m_res is only able to contain a list of 1 int64_t...

Fix is straightforward and minimal, just created a function to avoid duplicating the code, so both ctor does exactly the same thing now and forever.

It could be the issue reported as #732 but they do not mention the renderer type, only the linux platform... so it's a wild guess.

Just in case, here is the callstack of the crash I had:
```
Exception thrown: read access violation with 'span->heap'

editor.exe!tracy::_rpmalloc_deallocate_small_or_medium(tracy::span_t * span, void * p)
editor.exe!tracy::_rpmalloc_deallocate(void * p)
editor.exe!tracy::rpfree(void * ptr)
editor.exe!tracy::Profiler::Dequeue::__l2::<lambda_2>::operator()(tracy::QueueItem * item, unsigned __int64 sz)
editor.exe!tracy::moodycamel::ConcurrentQueue<tracy::QueueItem,tracy::moodycamel::ConcurrentQueueDefaultTraits>::ExplicitProducer::dequeue_bulk<`tracy::Profiler::Dequeue'::`2'::<lambda_1>,`tracy::Profiler::Dequeue'::`2'::<lambda_2>>(tracy::Profiler::Dequeue::__l2::<lambda_1> notifyThread, tracy::Profiler::Dequeue::__l2::<lambda_2> processData)
editor.exe!tracy::moodycamel::ConcurrentQueue<tracy::QueueItem,tracy::moodycamel::ConcurrentQueueDefaultTraits>::try_dequeue_bulk_single<`tracy::Profiler::Dequeue'::`2'::<lambda_1>,`tracy::Profiler::Dequeue'::`2'::<lambda_2>>(tracy::moodycamel::ConsumerToken & token, tracy::Profiler::Dequeue::__l2::<lambda_1> notifyThread, tracy::Profiler::Dequeue::__l2::<lambda_2> processData)
editor.exe!tracy::Profiler::Dequeue(tracy::moodycamel::ConsumerToken & token)
editor.exe!tracy::Profiler::Worker()
editor.exe!tracy::Profiler::LaunchWorker(void * ptr)
editor.exe!tracy::Thread::Launch(void * ptr)
```

