### PR TITLE
Added Profiler::GetPort() and TracyPort macro

### DIFF
--- a/manual/tracy.tex
+++ b/manual/tracy.tex
@@ -804,6 +804,8 @@ Suppose for some reason you want to use another port\footnote{For example, other
 
 If a custom port is not specified and the default listening port is already occupied, the profiler will automatically try to listen on a number of other ports.
 
+Since the port in use may differ from the default one, the client application may query the actual data connection port using the \texttt{TracyPort} macro. It returns the port number once the listening socket has been bound, or zero otherwise.
+
 \begin{bclogo}[
 noborder=true,
 couleur=black!5,

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1778,10 +1778,10 @@ void Profiler::Worker()
 
 #ifdef TRACY_DATA_PORT
     const bool dataPortSearch = false;
-    m_dataPort = m_userPort != 0 ? m_userPort : TRACY_DATA_PORT;
+    auto dataPort = m_userPort != 0 ? m_userPort : TRACY_DATA_PORT;
 #else
     const bool dataPortSearch = m_userPort == 0;
-    m_dataPort = m_userPort != 0 ? m_userPort : 8086;
+    auto dataPort = m_userPort != 0 ? m_userPort : 8086;
 #endif
 #ifdef TRACY_BROADCAST_PORT
     const auto broadcastPort = TRACY_BROADCAST_PORT;
@@ -1883,15 +1883,15 @@ void Profiler::Worker()
     bool isListening = false;
     if( !dataPortSearch )
     {
-        isListening = listen.Listen( m_dataPort, 4 );
+        isListening = listen.Listen( dataPort, 4 );
     }
     else
     {
         for( uint32_t i=0; i<20; i++ )
         {
-            if( listen.Listen( m_dataPort+i, 4 ) )
+            if( listen.Listen( dataPort+i, 4 ) )
             {
-                m_dataPort += i;
+                dataPort += i;
                 isListening = true;
                 break;
             }
@@ -1911,6 +1911,7 @@ void Profiler::Worker()
             std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
         }
     }
+    m_dataPort.store( dataPort, std::memory_order_release );
 
 #ifndef TRACY_NO_BROADCAST
     m_broadcast = (UdpBroadcast*)tracy_malloc( sizeof( UdpBroadcast ) );
@@ -1935,7 +1936,7 @@ void Profiler::Worker()
 #endif
 
     int broadcastLen = 0;
-    auto& broadcastMsg = GetBroadcastMessage( procname, pnsz, broadcastLen, m_dataPort );
+    auto& broadcastMsg = GetBroadcastMessage( procname, pnsz, broadcastLen, dataPort );
     uint64_t lastBroadcast = 0;
 
     // Connections loop.
@@ -1975,7 +1976,7 @@ void Profiler::Worker()
                     m_programNameLock.lock();
                     if( m_programName )
                     {
-                        broadcastMsg = GetBroadcastMessage( m_programName, strlen( m_programName ), broadcastLen, m_dataPort );
+                        broadcastMsg = GetBroadcastMessage( m_programName, strlen( m_programName ), broadcastLen, dataPort );
                         m_programName = nullptr;
                     }
                     m_programNameLock.unlock();

--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1524,6 +1524,7 @@ Profiler::Profiler()
     , m_broadcast( nullptr )
     , m_noExit( false )
     , m_userPort( 0 )
+    , m_dataPort( 0 )
     , m_zoneId( 1 )
     , m_sectionId( 1 )
     , m_samplingPeriod( 0 )
@@ -1777,10 +1778,10 @@ void Profiler::Worker()
 
 #ifdef TRACY_DATA_PORT
     const bool dataPortSearch = false;
-    auto dataPort = m_userPort != 0 ? m_userPort : TRACY_DATA_PORT;
+    m_dataPort = m_userPort != 0 ? m_userPort : TRACY_DATA_PORT;
 #else
     const bool dataPortSearch = m_userPort == 0;
-    auto dataPort = m_userPort != 0 ? m_userPort : 8086;
+    m_dataPort = m_userPort != 0 ? m_userPort : 8086;
 #endif
 #ifdef TRACY_BROADCAST_PORT
     const auto broadcastPort = TRACY_BROADCAST_PORT;
@@ -1882,15 +1883,15 @@ void Profiler::Worker()
     bool isListening = false;
     if( !dataPortSearch )
     {
-        isListening = listen.Listen( dataPort, 4 );
+        isListening = listen.Listen( m_dataPort, 4 );
     }
     else
     {
         for( uint32_t i=0; i<20; i++ )
         {
-            if( listen.Listen( dataPort+i, 4 ) )
+            if( listen.Listen( m_dataPort+i, 4 ) )
             {
-                dataPort += i;
+                m_dataPort += i;
                 isListening = true;
                 break;
             }
@@ -1934,7 +1935,7 @@ void Profiler::Worker()
 #endif
 
     int broadcastLen = 0;
-    auto& broadcastMsg = GetBroadcastMessage( procname, pnsz, broadcastLen, dataPort );
+    auto& broadcastMsg = GetBroadcastMessage( procname, pnsz, broadcastLen, m_dataPort );
     uint64_t lastBroadcast = 0;
 
     // Connections loop.
@@ -1974,7 +1975,7 @@ void Profiler::Worker()
                     m_programNameLock.lock();
                     if( m_programName )
                     {
-                        broadcastMsg = GetBroadcastMessage( m_programName, strlen( m_programName ), broadcastLen, dataPort );
+                        broadcastMsg = GetBroadcastMessage( m_programName, strlen( m_programName ), broadcastLen, m_dataPort );
                         m_programName = nullptr;
                     }
                     m_programNameLock.unlock();

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -909,6 +909,11 @@ public:
         return m_isConnected.load( std::memory_order_acquire );
     }
 
+    tracy_force_inline uint32_t GetPort() const
+    {
+        return m_dataPort;
+    }
+
     tracy_force_inline void SetProgramName( const char* name )
     {
         m_programNameLock.lock();
@@ -1170,6 +1175,7 @@ private:
     UdpBroadcast* m_broadcast;
     bool m_noExit;
     uint32_t m_userPort;
+    uint32_t m_dataPort;
     std::atomic<uint32_t> m_zoneId;
     std::atomic<uint32_t> m_sectionId;
     int64_t m_samplingPeriod;

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -909,9 +909,10 @@ public:
         return m_isConnected.load( std::memory_order_acquire );
     }
 
+    // Returns 0 until the listen socket is bound
     tracy_force_inline uint32_t GetPort() const
     {
-        return m_dataPort;
+        return m_dataPort.load( std::memory_order_acquire );
     }
 
     tracy_force_inline void SetProgramName( const char* name )
@@ -1175,7 +1176,7 @@ private:
     UdpBroadcast* m_broadcast;
     bool m_noExit;
     uint32_t m_userPort;
-    uint32_t m_dataPort;
+    std::atomic<uint32_t> m_dataPort;
     std::atomic<uint32_t> m_zoneId;
     std::atomic<uint32_t> m_sectionId;
     int64_t m_samplingPeriod;

--- a/public/tracy/Tracy.hpp
+++ b/public/tracy/Tracy.hpp
@@ -115,6 +115,7 @@
 #define TracyParameterRegister(x,y)
 #define TracyParameterSetup(x,y,z,w)
 #define TracyIsConnected false
+#define TracyPort 0
 #define TracyIsStarted false
 #define TracySetProgramName(x)
 
@@ -258,6 +259,7 @@
 #define TracyParameterRegister( cb, data ) tracy::Profiler::ParameterRegister( cb, data )
 #define TracyParameterSetup( idx, name, type, val ) tracy::Profiler::ParameterSetup( idx, name, type, val )
 #define TracyIsConnected tracy::GetProfiler().IsConnected()
+#define TracyPort tracy::GetProfiler().GetPort()
 #define TracySetProgramName( name ) tracy::GetProfiler().SetProgramName( name )
 
 #define TracySectionEnter( fmt, ... ) tracy::Profiler::SectionEnter( 0, fmt, ##__VA_ARGS__ )


### PR DESCRIPTION
I needed the port that Tracy is really using so my process could programmatically start the profiler viewer and auto connect by specifying the port via argument "-p".
Without that it's always connecting to the default port which could be any process on the same ip.

Maybe someone else could need that too.

TracyPort and Profiler::GetPort() both return 0 by default or before listen port is established.