### PR TITLE
Fix GitRef.hpp generation on Windows

### DIFF
--- a/cmake/GitRef.cmake
+++ b/cmake/GitRef.cmake
@@ -11,7 +11,7 @@ function(add_git_ref target)
         if(Git_FOUND)
             add_custom_target(git-ref
                 COMMAND ${CMAKE_COMMAND} -E echo "#pragma once" > GitRef.hpp.tmp
-                COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} log -1 "--format=namespace tracy { static inline const char* GitRef = %x22%h%x22; }" ${GIT_REV} >> GitRef.hpp.tmp || echo "namespace tracy { static inline const char* GitRef = \"unknown\"; }" >> GitRef.hpp.tmp
+                COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} log -1 "--format=namespace tracy { static inline const char* GitRef = %x22%h%x22; }" ${GIT_REV} >> GitRef.hpp.tmp || ${CMAKE_COMMAND} -E echo "namespace tracy { static inline const char* GitRef = \"unknown\"; }" >> GitRef.hpp.tmp
                 COMMAND ${CMAKE_COMMAND} -E copy_if_different GitRef.hpp.tmp GitRef.hpp
                 BYPRODUCTS GitRef.hpp GitRef.hpp.tmp
                 VERBATIM


### PR DESCRIPTION
When building from a tarball (no .git directory present) but git executable is present, the GitRef.hpp file is not well generated on Windows.

It has the following content:

```
#pragma once
"namespace tracy { static inline const char* GitRef = "unknown"; }"
```

When it should look like this:

```
#pragma once
namespace tracy { static inline const char* GitRef = "unknown"; }
```